### PR TITLE
Initialize LUA ref objects when growing the pool

### DIFF
--- a/engines/grim/lua/lgc.cpp
+++ b/engines/grim/lua/lgc.cpp
@@ -38,8 +38,11 @@ int32 luaC_ref(TObject *o, int32 lock) {
 		{
 			int32 oldSize = refSize;
 			refSize = luaM_growvector(&refArray, refSize, struct ref, refEM, MAX_WORD);
-			for (ref = oldSize; ref < refSize; ref++)
+			for (ref = oldSize; ref < refSize; ref++) {
 				refArray[ref].status = FREE;
+				refArray[ref].o.ttype = LUA_T_NIL;
+				refArray[ref].o.value.ts = NULL;
+			}
 			ref = oldSize;
 		}
 found:
@@ -50,8 +53,11 @@ found:
 }
 
 void lua_unref(int32 ref) {
-	if (ref >= 0 && ref < refSize)
+	if (ref >= 0 && ref < refSize) {
 		refArray[ref].status = FREE;
+		refArray[ref].o.ttype = LUA_T_NIL;
+		refArray[ref].o.value.ts = NULL;
+	}
 }
 
 TObject* luaC_getref(int32 ref) {


### PR DESCRIPTION
This fixes saving/loading for me.
The problem was that when unitialized objects were saved, their type
and value could be anything. On loading, LUA_T_USERDATA value
pointers are searched for in a global array, and said random
unitialized values are, of course, not in that array, so loading such
a save triggered an assert().

Interestingly, it only failed with a 64bit build for me, the 32bit
build works fine regardless.
