### PR TITLE
EMI: Made it so the EMI demo was not flagged as the GRIM demo.

### DIFF
--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -224,7 +224,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			ADGF_DEMO,
 			GUIO_NONE
 		},
-		GF_DEMO,
+		EMI_DEMO,
 		GType_MONKEY4
 	},
 

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -52,14 +52,13 @@ enum GrimGameType {
 };
 
 enum GrimGameFeatures {
-	GF_DEMO =   1 << 0
+	GF_DEMO  =   1 << 0,
+	EMI_DEMO =   1 << 1
 };
 
 struct GrimGameDescription;
 
 typedef Common::HashMap<Common::String, const char *> StringPtrHashMap;
-
-#define GF_DEMO		1
 
 struct ControlDescriptor {
 	const char *name;


### PR DESCRIPTION
Removed a define that I'm not sure why it was there. Was there any purpose to that define, or was it left over after some other change?
