### PR TITLE
Support unusual colormap (orange.mat) (try2)

### DIFF
--- a/engines/grim/material.cpp
+++ b/engines/grim/material.cpp
@@ -38,8 +38,17 @@ Material::Material(const char *filename, const char *data, int len, CMap *cmap) 
 
 	_numImages = READ_LE_UINT32(data + 12);
 	_currImage = 0;
-	_width = READ_LE_UINT32(data + 76 + _numImages * 40);
-	_height = READ_LE_UINT32(data + 80 + _numImages * 40);
+	/* Discovered by diffing orange.mat with pink.mat and blue.mat .
+	 * Actual meaning unknown, so I prefer to use it as an enum-ish
+	 * at the moment, to detect unexpected values.
+	 */
+	uint32 offset = READ_LE_UINT32(data + 0x4c);
+	if (offset == 0x8)
+	    data += 16;
+	else if (offset != 0)
+	    error("Unknown offset: %d", offset);
+	_width = READ_LE_UINT32(data + 60 + _numImages * 40);
+	_height = READ_LE_UINT32(data + 64 + _numImages * 40);
 
 	if (_width == 0 || _height == 0) {
 		if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
@@ -47,7 +56,7 @@ Material::Material(const char *filename, const char *data, int len, CMap *cmap) 
 		return;
 	}
 
-	data += 100 + _numImages * 40;
+	data += 84 + _numImages * 40;
 
 	g_driver->createMaterial(this, data, cmap);
 }


### PR DESCRIPTION
orange.mat has a -16 offset for dimension & following properties. This seems to come from a 0x00 vs. 0x08 at offset 0x4c.
Fixes #73.
Warning: I only tested this on the clown's scene. This code will cry out loud if it finds something unexpected.

PS: I should find why my pull requests think they are pushing all commits since I forked the official repos...
vpelletier/residual@fddce619344dbf7852ddf59e03715b270dd0afb7 is the interesting commit.
