### PR TITLE
Fix SDL-CONFIG-path during make bundle on mac

### DIFF
--- a/configure
+++ b/configure
@@ -3122,6 +3122,7 @@ WINDRESFLAGS := $WINDRESFLAGS
 WIN32PATH=$_win32path
 AOS4PATH=$_aos4path
 STATICLIBPATH=$_staticlibpath
+SDLCONFIG=$_sdlconfig
 
 BACKEND := $_backend
 MODULES += $MODULES

--- a/ports.mk
+++ b/ports.mk
@@ -78,7 +78,7 @@ endif
 # Location of static libs for the iPhone
 ifneq ($(BACKEND), iphone)
 # Static libaries, used for the residual-static and iphone targets
-OSX_STATIC_LIBS := `$(STATICLIBPATH)/bin/sdl-config --static-libs`
+OSX_STATIC_LIBS := `$(SDLCONFIG) --static-libs`
 endif
 
 ifdef USE_VORBIS


### PR DESCRIPTION
Previously this hardcoded back to /sw, making it impossible to make bundle with Macports.
