### PR TITLE
GRIM: Recalculate the path node position in the case where the sector is 

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -581,6 +581,24 @@ void Actor::walkTo(const Graphics::Vector3d &p) {
 					if (bridges.empty())
 						continue; // The sectors are not adjacent.
 
+					Graphics::Vector3d closestPoint = s->getClosestPoint(_destPos);
+					Graphics::Vector3d best;
+					float bestDist = 1e6f;
+					Graphics::Line3d l(node->pos, closestPoint);
+					while (!bridges.empty()) {
+						Graphics::Line3d bridge = bridges.back();
+						Graphics::Vector3d pos;
+						if (!bridge.intersectLine2d(l, &pos)) {
+							pos = bridge.middle();
+						}
+						float dist = (pos - closestPoint).magnitude();
+						if (dist < bestDist) {
+							bestDist = dist;
+							best = pos;
+						}
+						bridges.pop_back();
+					}
+
 					PathNode *n = NULL;
 					for (Common::List<PathNode *>::iterator j = openList.begin(); j != openList.end(); ++j) {
 						if ((*j)->sect == s) {
@@ -589,30 +607,14 @@ void Actor::walkTo(const Graphics::Vector3d &p) {
 						}
 					}
 					if (n) {
-						float newCost = node->cost + (n->pos - node->pos).magnitude();
+						float newCost = node->cost + (best - node->pos).magnitude();
 						if (newCost < n->cost) {
 							n->cost = newCost;
 							n->parent = node;
+							n->pos = best;
+							n->dist = (n->pos - _destPos).magnitude();
 						}
 					} else {
-						Graphics::Vector3d closestPoint = s->getClosestPoint(_destPos);
-						Graphics::Vector3d best;
-						float bestDist = 1e6f;
-						Graphics::Line3d l(node->pos, closestPoint);
-						while (!bridges.empty()) {
-							Graphics::Line3d bridge = bridges.back();
-							Graphics::Vector3d pos;
-							if (!bridge.intersectLine2d(l, &pos)) {
-								pos = bridge.middle();
-							}
-							float dist = (pos - closestPoint).magnitude();
-							if (dist < bestDist) {
-								bestDist = dist;
-								best = pos;
-							}
-							bridges.pop_back();
-						}
-
 						n = new PathNode;
 						n->parent = node;
 						n->sect = s;


### PR DESCRIPTION
GRIM: Recalculate the path node position in the case where the sector is already in the open list. Fixes #116
