### PR TITLE
GRIM: Don't remove sprite from node's list of sprites when destructing. Fixes #117

### DIFF
--- a/engines/grim/costume.cpp
+++ b/engines/grim/costume.cpp
@@ -240,10 +240,6 @@ SpriteComponent::SpriteComponent(Costume::Component *p, int parentID, const char
 
 SpriteComponent::~SpriteComponent() {
 	if (_sprite) {
-		if (_parent) {
-			MeshComponent *mc = dynamic_cast<MeshComponent *>(_parent);
-			mc->getNode()->removeSprite(_sprite);
-		}
 		delete _sprite->_material;
 		delete _sprite;
 	}


### PR DESCRIPTION
Not necessary since the nodes will also be destructed when the components are destructed.
