### PR TITLE
Only store the display when necessary.

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -990,7 +990,6 @@ void GrimEngine::updateDisplayScene() {
 		// including 3D objects such as Manny and the message tube
 		_currScene->drawBitmaps(ObjectState::OBJSTATE_OVERLAY);
 
-		g_driver->storeDisplay();
 		drawPrimitives();
 	} else if (_mode == ENGINE_MODE_DRAW) {
 		// Adding line below and comment out rest solve flickering, also in tripple buffering mode too

--- a/engines/grim/lua_v1_graphics.cpp
+++ b/engines/grim/lua_v1_graphics.cpp
@@ -456,6 +456,7 @@ void L1_KillPrimitive() {
 }
 
 void L1_DimScreen() {
+	g_driver->storeDisplay();
 	g_driver->dimScreen();
 }
 
@@ -474,6 +475,7 @@ void L1_ScreenShot() {
 	int mode = g_grim->getMode();
 	g_grim->setMode(ENGINE_MODE_NORMAL);
 	g_grim->updateDisplayScene();
+	g_driver->storeDisplay();
 	Bitmap *screenshot = g_driver->getScreenshot(width, height);
 	g_grim->setMode(mode);
 	if (screenshot) {


### PR DESCRIPTION
Instead of storing the display constantly, only store it when it needs to be used.
