### PR TITLE
Improved TextSplit.

### DIFF
--- a/engines/grim/textsplit.h
+++ b/engines/grim/textsplit.h
@@ -32,6 +32,7 @@ namespace Grim {
 class TextSplitter {
 public:
 	TextSplitter(const char *data, int len);
+	~TextSplitter();
 
 	char *nextLine() {
 		processLine();
@@ -55,26 +56,12 @@ public:
 	// scanf); if not all fields are read (according to the field_count
 	// argument), bail out with an error.  Advance to the next line.
 	void scanString(const char *fmt, int field_count, ...);
-	class TextLines {
-	public:
-		TextLines() {};
-		~TextLines() { delete[] _lineData; }
-		void setData(char *data, int length);
-		char *getData() { return _lineData; }
-
-	protected:
-		char *_lineData;
-		int _lineLength;
-
-		friend class TextSplitter;
-	};
-
-	~TextSplitter() { delete[] _lines; }
 
 private:
+	char *_stringData;
 	char *_currLine;
 	int _numLines, _lineIndex;
-	TextLines *_lines;
+	char **_lines;
 
 	void processLine();
 };


### PR DESCRIPTION
Improved TextSplit to only allocate one set of memory and make each line have a pointer to part of that memory.

Instead of allocating memory for each line, this just uses pointers to the start of each line and replaces new lines with string terminations. 

The main benefits are less memory usage, albeit only a very small decrease, and faster loading. 

For me it is noticeable when using a profiler while loading residual, but otherwise it is about the same speed.
