### PR TITLE
Reduced the number of memory allocations done in savegame.

### DIFF
--- a/engines/grim/savegame.h
+++ b/engines/grim/savegame.h
@@ -79,7 +79,7 @@ protected:
 	uint32 _sectionPtr;
 	byte *_sectionBuffer;
 
-	static const int _allocAmmount = 1024;
+	static const int _allocAmmount = 1048576;
 };
 
 } // end of namespace Grim


### PR DESCRIPTION
Instead of each section of the savegame allocating its own memory, memory is allocated as it is needed and shared between all the sections. 

This speeds up saving the game.
