### PR TITLE
Speed up saving and loading of actors.

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -253,9 +253,7 @@ void Actor::saveState(SaveGame *savedState) const {
 		}
 
 		savedState->writeLESint32(shadow.shadowMaskSize);
-		for (int j = 0; j < shadow.shadowMaskSize; ++j) {
-			savedState->writeByte(shadow.shadowMask[j]);
-		}
+		savedState->write(shadow.shadowMask, shadow.shadowMaskSize);
 		savedState->writeLESint32(shadow.active);
 		savedState->writeLESint32(shadow.dontNegate);
 	}
@@ -410,9 +408,7 @@ bool Actor::restoreState(SaveGame *savedState) {
 		delete[] shadow.shadowMask;
 		if (shadow.shadowMaskSize > 0) {
 			shadow.shadowMask = new byte[shadow.shadowMaskSize];
-			for (int j = 0; j < shadow.shadowMaskSize; ++j) {
-				shadow.shadowMask[j] = savedState->readByte();
-			}
+			savedState->read(shadow.shadowMask, shadow.shadowMaskSize);
 		} else {
 			shadow.shadowMask = NULL;
 		}


### PR DESCRIPTION
This makes it write the entire array at one time instead of one byte at a time.

This code does not break the savegame format.
