### PR TITLE
EMI: Stub more lua functions and fix some text stuff.

### DIFF
--- a/engines/grim/lua_v1_text.cpp
+++ b/engines/grim/lua_v1_text.cpp
@@ -194,7 +194,12 @@ void setTextObjectParams(TextObjectCommon *textObject, lua_Object tableObj) {
 	keyObj = lua_gettable();
 	if (keyObj) {
 		if (lua_isnumber(keyObj)) {
-			textObject->setX((int)lua_getnumber(keyObj));
+			float num = lua_getnumber(keyObj);
+			if (g_grim->getGameType() == GType_MONKEY4) {
+				textObject->setX(num*640);
+			} else {
+				textObject->setX((int)num);
+			}
 		}
 	}
 
@@ -203,7 +208,12 @@ void setTextObjectParams(TextObjectCommon *textObject, lua_Object tableObj) {
 	keyObj = lua_gettable();
 	if (keyObj) {
 		if (lua_isnumber(keyObj)) {
-			textObject->setY((int)lua_getnumber(keyObj));
+			float num = lua_getnumber(keyObj);
+			if (g_grim->getGameType() == GType_MONKEY4) {
+				textObject->setY(num*480);
+			} else {
+				textObject->setY((int)num);
+			}
 		}
 	}
 
@@ -212,7 +222,7 @@ void setTextObjectParams(TextObjectCommon *textObject, lua_Object tableObj) {
 	keyObj = lua_gettable();
 	if (keyObj) {
 		if (g_grim->getGameType() == GType_MONKEY4 && lua_isstring(keyObj)) {
-			textObject->setFont(g_resourceloader->getFont(lua_getstring(keyObj)));
+			textObject->setFont(g_resourceloader->loadFont(lua_getstring(keyObj)));
 		} else if (lua_isuserdata(keyObj) && lua_tag(keyObj) == MKTAG('F','O','N','T')) {
 			textObject->setFont(getfont(keyObj));
 		}

--- a/engines/grim/lua_v2.cpp
+++ b/engines/grim/lua_v2.cpp
@@ -66,6 +66,10 @@ void L2_DimScreen() {
 	warning("L2_DimScreen: dim: %f", dim);
 }
 
+static void L2_UndimAll() {
+	warning("L2_UndimAll: stub");
+}
+
 void L2_MakeCurrentSetup() {
 	lua_Object setupObj = lua_getparam(1);
 	if (lua_isnumber(setupObj)) {
@@ -102,6 +106,18 @@ void L2_SetActorGlobalAlpha() {
 		// TODO
 	}
 	*/
+}
+
+static void L2_SetActorLocalAlpha() {
+	lua_Object actorObj = lua_getparam(1);
+	if (!lua_isuserdata(actorObj) || lua_tag(actorObj) != MKTAG('A','C','T','R'))
+		return;
+
+	Actor *actor = getactor(actorObj);
+	if (!actor)
+		return;
+
+	warning("L2_SetActorLocalAlpha: actor: %s", actor->getName().c_str());
 }
 
 void L2_ImGetMillisecondPosition() {
@@ -221,6 +237,17 @@ void L2_LockBackground() {
 	const char *filename = lua_getstring(filenameObj);
 	warning("L2_LockBackground, filename: %s", filename);
 	// FIXME: implement missing rest part of code
+}
+
+static void L2_UnLockBackground() {
+	lua_Object filenameObj = lua_getparam(1);
+
+	if (!lua_isstring(filenameObj)) {
+		lua_pushnil();
+		return;
+	}
+	const char *filename = lua_getstring(filenameObj);
+	warning("L2_UnLockBackground, filename: %s", filename);
 }
 
 void L2_LockChore() {
@@ -475,6 +502,44 @@ static void L2_StopActorChores() {
 	warning("L2_StopActorChores: implement opcode... bool param: %d, actor: %s", (int)p, actor->getName().c_str());
 }
 
+static void L2_IsChoreValid() {
+	lua_Object paramObj = lua_getparam(1);
+	if (!lua_isnumber(paramObj))
+		return;
+	int num = (int)lua_getnumber(paramObj);
+	warning("L2_IsChoreValid: stub, got %d, returns true", num);
+	pushbool(true);
+}
+
+static void L2_IsChorePlaying() {
+	lua_Object paramObj = lua_getparam(1);
+	if (!lua_isnumber(paramObj))
+		return;
+	int num = (int)lua_getnumber(paramObj);
+	warning("L2_IsChorePlaying: stub, got %d, returns true", num);
+	pushbool(true);
+}
+
+static void L2_StopChore() {
+	lua_Object choreObj = lua_getparam(1);
+	lua_Object timeObj = lua_getparam(2);
+	if (!lua_isnumber(choreObj) || !lua_isnumber(timeObj))
+		return;
+	int chore = (int)lua_getnumber(choreObj);
+	float time = lua_getnumber(timeObj);
+	warning("L2_StopChore: stub, chore: %d time: %f", chore, time);
+}
+
+static void L2_AdvanceChore() {
+	lua_Object choreObj = lua_getparam(1);
+	lua_Object timeObj = lua_getparam(2);
+	if (!lua_isnumber(choreObj) || !lua_isnumber(timeObj))
+		return;
+	int chore = (int)lua_getnumber(choreObj);
+	float time = lua_getnumber(timeObj);
+	warning("L2_AdvanceChore: stub, chore: %d time: %f", chore, time);
+}
+
 static void L2_SetActorLighting() {
 	lua_Object actorObj = lua_getparam(1);
 	lua_Object lightModeObj = lua_getparam(2);
@@ -505,6 +570,12 @@ static void L2_SetActorLighting() {
 		//FIXME actor->
 		warning("L2_SetActorLighting: case param 0(LIGHT_STATIC), actor: %s", actor->getName().c_str());
 	}
+}
+
+void L2_GetActorWorldPos() {
+	L1_GetActorPos();
+
+	warning("L2_GetActorWorldPos: Currently just calls L1_GetActorPos, probably wrong");
 }
 
 static void L2_SetActorCollisionMode() {
@@ -596,6 +667,11 @@ static void L2_AttachActor() {
 	warning("L2_AttachActor: implement opcode");
 }
 
+static void L2_DetachActor() {
+	// Missing lua parts
+	warning("L2_DetachActor: implement opcode");
+}
+
 static void L2_GetCPUSpeed() {
 	lua_pushnumber(500); // anything above 333 make best configuration
 }
@@ -607,6 +683,7 @@ static void L2_StartMovie() {
 }
 
 static void L2_IsMoviePlaying() {
+	g_grim->setMode(ENGINE_MODE_NORMAL);
 	warning("L2_IsMoviePlaying: always returns false");
 	lua_pushnil();
 }
@@ -654,6 +731,15 @@ static void L2_ImSetVoiceEffect() {
 	warning("L2_ImSetVoiceEffect: implement opcode");
 }
 
+static void L2_LoadSound() {
+	lua_Object strObj = lua_getparam(1);
+	if (!lua_isstring(strObj))
+		return;
+	const char *str = lua_getstring(strObj);
+
+	warning("L2_LoadSound: wants to load %s", str);
+}
+
 static void L2_EngineDisplay() {
 	// dummy
 }
@@ -664,6 +750,14 @@ static void L2_SetAmbientLight() {
 
 static void L2_Display() {
 	// dummy
+}
+
+static void L2_ToggleOverworld() {
+	warning("L2_ToggleOverworld: implement opcode");
+}
+
+static void L2_ScreenshotForSavegame() {
+	warning("L2_ScreenshotForSavegame: implement opcode");
 }
 
 // Stub function for builtin functions not yet implemented
@@ -684,12 +778,10 @@ STUB_FUNC2(L2_SetActorTurnChores)
 STUB_FUNC2(L2_SetActorRestChore)
 STUB_FUNC2(L2_SetActorMumblechore)
 STUB_FUNC2(L2_SetActorTalkChore)
-STUB_FUNC2(L2_GetActorPos)
 STUB_FUNC2(L2_WalkActorVector)
 STUB_FUNC2(L2_SetActorLookRate)
 STUB_FUNC2(L2_GetActorLookRate)
 STUB_FUNC2(L2_GetVisibleThings)
-STUB_FUNC2(L2_SetActorHead)
 STUB_FUNC2(L2_GetActorRot)
 STUB_FUNC2(L2_LockSet)
 STUB_FUNC2(L2_UnLockSet)
@@ -703,12 +795,7 @@ STUB_FUNC2(L2_ImGetSfxVol)
 STUB_FUNC2(L2_ImGetVoiceVol)
 STUB_FUNC2(L2_ImGetMusicVol)
 STUB_FUNC2(L2_ImSetSequence)
-STUB_FUNC2(L2_RenderModeUser)
-STUB_FUNC2(L2_SayLine)
-STUB_FUNC2(L2_GetTextObjectDimensions)
 STUB_FUNC2(L2_ChangeTextObject)
-STUB_FUNC2(L2_ExpireText)
-STUB_FUNC2(L2_GetColorComponents)
 STUB_FUNC2(L2_GetTextCharPosition)
 STUB_FUNC2(L2_SetOffscreenTextPos)
 STUB_FUNC2(L2_FadeInChore)
@@ -746,44 +833,34 @@ STUB_FUNC2(L2_SetActorRoll)
 STUB_FUNC2(L2_SetActorFrustrumCull)
 STUB_FUNC2(L2_DriveActorTo)
 STUB_FUNC2(L2_GetActorRect)
-STUB_FUNC2(L2_SetActorTimeScale)
 STUB_FUNC2(L2_GetTranslationMode)
 STUB_FUNC2(L2_SetTranslationMode)
 STUB_FUNC2(L2_KillPrimitive)
 STUB_FUNC2(L2_WalkActorToAvoiding)
-STUB_FUNC2(L2_GetActorChores)
+STUB_FUNC(L2_GetActorChores)
 STUB_FUNC2(L2_SetCameraPosition)
 STUB_FUNC2(L2_GetCameraFOV)
 STUB_FUNC2(L2_SetCameraFOV)
 STUB_FUNC2(L2_GetCameraRoll)
 STUB_FUNC2(L2_ActorPuckOrient)
 STUB_FUNC2(L2_GetMemoryUsage)
-STUB_FUNC2(L2_GetFontDimensions)
+STUB_FUNC(L2_GetFontDimensions)
 
 // Monkey specific opcodes
 STUB_FUNC2(L2_ThumbnailFromFile)
 STUB_FUNC2(L2_ClearSpecialtyTexture)
 STUB_FUNC2(L2_ClearOverworld)
-STUB_FUNC2(L2_ToggleOverworld)
 STUB_FUNC2(L2_EnableActorPuck)
-STUB_FUNC2(L2_SetActorLocalAlpha)
 STUB_FUNC2(L2_GetActorSortOrder)
-STUB_FUNC2(L2_DetachActor)
-STUB_FUNC2(L2_IsChoreValid)
-STUB_FUNC2(L2_IsChorePlaying)
 STUB_FUNC2(L2_IsChoreLooping)
 STUB_FUNC2(L2_PlayChore)
-STUB_FUNC2(L2_StopChore)
 STUB_FUNC2(L2_PauseChore)
-STUB_FUNC2(L2_AdvanceChore)
 STUB_FUNC2(L2_CompleteChore)
 STUB_FUNC2(L2_UnlockChore)
 STUB_FUNC2(L2_LockChoreSet)
 STUB_FUNC2(L2_UnlockChoreSet)
-STUB_FUNC2(L2_UnLockBackground)
 STUB_FUNC2(L2_EscapeMovie)
 STUB_FUNC2(L2_StopAllSounds)
-STUB_FUNC2(L2_LoadSound)
 STUB_FUNC2(L2_FreeSound)
 STUB_FUNC2(L2_PlayLoadedSound)
 STUB_FUNC2(L2_GetSoundVolume)
@@ -801,7 +878,6 @@ STUB_FUNC2(L2_YawCamera)
 STUB_FUNC2(L2_GetCameraPitch)
 STUB_FUNC2(L2_PitchCamera)
 STUB_FUNC2(L2_RollCamera)
-STUB_FUNC2(L2_UndimAll)
 STUB_FUNC2(L2_NewLayer)
 STUB_FUNC2(L2_FreeLayer)
 STUB_FUNC2(L2_SetLayerSortOrder)
@@ -832,7 +908,7 @@ struct luaL_reg monkeyMainOpcodes[] = {
 	{ "Load", L1_Load },
 	{ "Save", L1_Save },
 	{ "remove", L1_Remove },
-	{ "SetActorTimeScale", L2_SetActorTimeScale },
+	{ "SetActorTimeScale", L1_SetActorTimeScale },
 	{ "SetActorWalkChore", L1_SetActorWalkChore },
 	{ "SetActorTurnChores", L1_SetActorTurnChores },
 	{ "SetActorRestChore", L1_SetActorRestChore },
@@ -843,7 +919,7 @@ struct luaL_reg monkeyMainOpcodes[] = {
 	{ "SetActorTurnRate", L1_SetActorTurnRate },
 	{ "SetSelectedActor", L1_SetSelectedActor },
 	{ "LoadActor", L1_LoadActor },
-	{ "GetActorPos", L2_GetActorPos },
+	{ "GetActorPos", L1_GetActorPos },
 	{ "GetActorPuckVector", L2_GetActorPuckVector },
 	{ "GetActorYawToPoint", L1_GetActorYawToPoint },
 	{ "SetActorReflection", L1_SetActorReflection },
@@ -854,17 +930,17 @@ struct luaL_reg monkeyMainOpcodes[] = {
 	{ "WalkActorTo", L1_WalkActorTo },
 	{ "WalkActorToAvoiding", L2_WalkActorToAvoiding },
 	{ "ActorLookAt", L1_ActorLookAt },
-	{ "SetActorLookRate", L2_SetActorLookRate },
+	{ "SetActorLookRate", L1_SetActorLookRate },
 	{ "GetActorLookRate", L2_GetActorLookRate },
-	{ "GetVisibleThings", L2_GetVisibleThings },
-	{ "SetActorHead", L2_SetActorHead },
+	{ "GetVisibleThings", L1_GetVisibleThings },
+	{ "SetActorHead", L1_SetActorHead },
 	{ "SetActorVisibility", L1_SetActorVisibility },
 	{ "SetActorFollowBoxes", L1_SetActorFollowBoxes },
 	{ "ShutUpActor", L1_ShutUpActor },
 	{ "IsActorInSector", L1_IsActorInSector },
 	{ "GetActorSector", L1_GetActorSector },
 	{ "TurnActor", L1_TurnActor },
-	{ "GetActorRot", L2_GetActorRot },
+	{ "GetActorRot", L1_GetActorRot },
 	{ "SetActorRot", L1_SetActorRot },
 	{ "IsActorTurning", L1_IsActorTurning },
 	{ "PlayActorChore", L2_PlayActorChore },
@@ -897,7 +973,7 @@ struct luaL_reg monkeyMainOpcodes[] = {
 	{ "FileFindDispose", L1_FileFindDispose },
 	{ "InputDialog", L1_InputDialog },
 	{ "GetSectorOppositeEdge", L2_GetSectorOppositeEdge },
-	{ "MakeSectorActive", L2_MakeSectorActive },
+	{ "MakeSectorActive", L1_MakeSectorActive },
 	{ "GetCurrentScript", L1_GetCurrentScript },
 	{ "GetCameraPosition", L2_GetCameraPosition },
 	{ "SetCameraPosition", L2_SetCameraPosition },
@@ -926,7 +1002,7 @@ struct luaL_reg monkeyMainOpcodes[] = {
 	{ "LoadBundle", L2_LoadBundle },
 	{ "SetGamma", L1_SetGamma },
 	{ "SetActorWalkDominate", L1_SetActorWalkDominate },
-	{ "RenderModeUser", L2_RenderModeUser },
+	{ "RenderModeUser", L1_RenderModeUser },
 	{ "DimScreen", L2_DimScreen },
 	{ "Display", L2_Display },
 	{ "SetSpeechMode", L1_SetSpeechMode },
@@ -943,7 +1019,8 @@ struct luaL_reg monkeyMainOpcodes[] = {
 	{ "dofile", L1_new_dofile },
 
 	// Monkey specific opcodes:
-
+	{ "ScreenshotForSavegame", L2_ScreenshotForSavegame },
+	{ "GetActorWorldPos", L2_GetActorWorldPos },
 	{ "SetActiveCD", L2_SetActiveCD },
 	{ "GetActiveCD", L2_GetActiveCD },
 	{ "AreWeInternational", L2_AreWeInternational },
@@ -1043,16 +1120,16 @@ struct luaL_reg monkeyTextOpcodes[] = {
 	{ "IsMessageGoing", L1_IsMessageGoing },
 	{ "SetSayLineDefaults", L1_SetSayLineDefaults },
 	{ "SetActorTalkColor", L1_SetActorTalkColor },
-	{ "SayLine", L2_SayLine },
+	{ "SayLine", L1_SayLine },
 	{ "MakeTextObject", L1_MakeTextObject },
-	{ "GetTextObjectDimensions", L2_GetTextObjectDimensions },
+	{ "GetTextObjectDimensions", L1_GetTextObjectDimensions },
 	{ "GetFontDimensions", L2_GetFontDimensions },
 	{ "ChangeTextObject", L2_ChangeTextObject },
 	{ "KillTextObject", L1_KillTextObject },
-	{ "ExpireText", L2_ExpireText },
+	{ "ExpireText", L1_ExpireText },
 	{ "PurgeText", L2_PurgeText },
 	{ "MakeColor", L1_MakeColor },
-	{ "GetColorComponents", L2_GetColorComponents },
+	{ "GetColorComponents", L1_GetColorComponents },
 	{ "GetTextCharPosition", L2_GetTextCharPosition },
 	{ "LocalizeString", L1_LocalizeString },
 	{ "SetOffscreenTextPos", L2_SetOffscreenTextPos }

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -168,6 +168,12 @@ void TextObject::setupText() {
 		return;
 	}
 
+	if (g_grim->getGameType() == GType_MONKEY4) {
+		if (_x == 0)
+			_x = 320;
+		if (_y == 0)
+			_y = 240;
+	}
 
 	// format the output message to incorporate line wrapping
 	// (if necessary) for the text object


### PR DESCRIPTION
I changed getFont to loadFont because getFont was destroying the font before I could use it. Some changes will be needed eventually to fix up the EMI font stuff.

With this commit the EMI will start and change scenes a bit then just spout warnings. 

The menu opens, but is not usable.

EMI seems to specify text positions as a float between 0 and 1, I'm not sure if it is the same for all text, but it does work for the intro stuff.

When EMI sets text position to 0 it seems that it wants to be centered. 
