### PR TITLE
More accurate frames per second.

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1012,11 +1012,12 @@ void GrimEngine::doFlip() {
 
 	if (_showFps && _doFlip && _mode != ENGINE_MODE_DRAW) {
 		_frameCounter++;
-		_timeAccum += _frameTime;
-		if (_timeAccum > 500) {
-			sprintf(_fps, "%7.2f", (double)(_frameCounter * 1000) / (double)_timeAccum );
+		unsigned int currentTime = g_system->getMillis();
+		unsigned int delta = currentTime - _lastFrameTime;
+		if (delta > 500) {
+			sprintf(_fps, "%7.2f", (double)(_frameCounter * 1000) / (double)delta );
 			_frameCounter = 0;
-			_timeAccum = 0;
+			_lastFrameTime = currentTime;
 		}
 	}
 }
@@ -1026,7 +1027,7 @@ void GrimEngine::mainLoop() {
 	_frameTime = 0;
 	_frameStart = g_system->getMillis();
 	_frameCounter = 0;
-	_timeAccum = 0;
+	_lastFrameTime = 0;
 	_frameTimeCollection = 0;
 	_prevSmushFrame = 0;
 	_refreshShadowMask = false;

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -261,7 +261,7 @@ private:
 	unsigned int _frameTimeCollection;
 	int _prevSmushFrame;
 	unsigned int _frameCounter;
-	unsigned int _timeAccum;
+	unsigned int _lastFrameTime;
 	unsigned _speedLimitMs;
 	bool _showFps;
 	bool _softRenderer;


### PR DESCRIPTION
The problem with the old way is that the frame timer would restart on every input making the number meaningless when moving the mouse over the window.
