### PR TITLE
Use the correct type of delete.

### DIFF
--- a/engines/grim/textsplit.cpp
+++ b/engines/grim/textsplit.cpp
@@ -89,7 +89,7 @@ TextSplitter::TextSplitter(const char *data, int len) {
 }
 
 TextSplitter::~TextSplitter() {
-	delete _stringData;
+	delete[] _stringData;
 	delete[] _lines;
 }
 


### PR DESCRIPTION
I accidentally used the wrong type of delete in my last commit to textsplit. 
