### PR TITLE
Destroy the old textobject graphics data when text is changed. Fixes #240

### DIFF
--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -55,6 +55,7 @@ TextObject::~TextObject() {
 }
 
 void TextObject::setText(const char *text) {
+	destroy();
 	if (strlen(text) < sizeof(_textID))
 		strcpy(_textID, text);
 	else {


### PR DESCRIPTION
Destroy the old textobject graphics data when text is changed. Fixes #240
