### PR TITLE
GRIM: Disable lighting for models that have lightingMode set to 0.

### DIFF
--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -74,6 +74,7 @@ public:
 	virtual void drawModelFace(const Model::Face *face, float *vertices, float *vertNormals, float *textureVerts) = 0;
 	virtual void drawSprite(const Sprite *sprite) = 0;
 
+	virtual void enableLights() = 0;
 	virtual void disableLights() = 0;
 	virtual void setupLight(Scene::Light *light, int lightId) = 0;
 

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -526,6 +526,10 @@ void GfxOpenGL::drawHierachyNode(const Model::HierNode *node) {
 		node->_sibling->draw();
 }
 
+void GfxOpenGL::enableLights() {
+	glEnable(GL_LIGHTING);
+}
+
 void GfxOpenGL::disableLights() {
 	glDisable(GL_LIGHTING);
 }

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -75,6 +75,7 @@ public:
 	void drawModelFace(const Model::Face *face, float *vertices, float *vertNormals, float *textureVerts);
 	void drawSprite(const Sprite *sprite);
 
+	void enableLights();
 	void disableLights();
 	void setupLight(Scene::Light *light, int lightId);
 

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -563,6 +563,10 @@ void GfxTinyGL::drawHierachyNode(const Model::HierNode *node) {
 		node->_sibling->draw();
 }
 
+void GfxTinyGL::enableLights() {
+	tglEnable(TGL_LIGHTING);
+}
+
 void GfxTinyGL::disableLights() {
 	tglDisable(TGL_LIGHTING);
 }

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -66,6 +66,7 @@ public:
 	void drawModelFace(const Model::Face *face, float *vertices, float *vertNormals, float *textureVerts);
 	void drawSprite(const Sprite *sprite);
 
+	void enableLights();
 	void disableLights();
 	void setupLight(Scene::Light *light, int lightId);
 

--- a/engines/grim/model.cpp
+++ b/engines/grim/model.cpp
@@ -611,8 +611,14 @@ void Model::Mesh::draw() const {
 		g_winY2 = MAX(g_winY2, winY2);
 	}
 
+	if (_lightingMode == 0)
+		g_driver->disableLights();
+
 	for (int i = 0; i < _numFaces; i++)
 		_faces[i].draw(_vertices, _vertNormals, _textureVerts);
+
+	if (_lightingMode == 0)
+		g_driver->enableLights();
 }
 
 void Model::Face::draw(float *vertices, float *vertNormals, float *textureVerts) const {


### PR DESCRIPTION
This fixes lighting of the roulette wheels in the casino and the demon beavers at the dam.
