### PR TITLE
Trivial fix in glx_opengl

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -373,7 +373,7 @@ void GfxOpenGL::drawShadowPlanes() {
 	glStencilFunc(GL_ALWAYS, 1, (GLuint)~0);
 	glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
 	glDisable(GL_LIGHTING);
-	glDisable(GL_TEXTURE);
+	glDisable(GL_TEXTURE_2D);
 	_currentShadowArray->planeList.begin();
 	for (SectorListType::iterator i = _currentShadowArray->planeList.begin(); i != _currentShadowArray->planeList.end(); ++i) {
 		Sector *shadowSector = i->sector;


### PR DESCRIPTION
Found by apitrace (https://github.com/apitrace/apitrace) as I was giving it a try. I just discovered it by random browsing on phoronix, it looks a very nice tool. It hurts framerate a lot in residual - I didn't try with other apps yet.

Disclaimer: I still have virtually no opengl experience, so this fix might be stupid :) .
