### PR TITLE
GRIM: Don't draw the entire Iris when a movie is played. Fixes #293

### DIFF
--- a/engines/grim/iris.cpp
+++ b/engines/grim/iris.cpp
@@ -23,6 +23,7 @@
 #include "engines/grim/iris.h"
 #include "engines/grim/gfx_base.h"
 #include "engines/grim/savegame.h"
+#include "engines/grim/grim.h"
 
 namespace Grim {
 
@@ -46,7 +47,7 @@ void Iris::play(Iris::Direction dir, int x, int y, int lenght) {
 
 void Iris::draw() {
 	if (!_playing) {
-		if (_direction == Close) {
+		if (_direction == Close && g_grim->getMode() != ENGINE_MODE_SMUSH) {
 			g_driver->dimRegion(0, 0, 640, 479, 0);
 		}
 		return;


### PR DESCRIPTION
The scripts call for an IrisDown of length 1 when meeting Meche on the Sub in Year 3, the IrisUp happens AFTER the movie, so this Iris would have been drawn above the movie. It should be safe to just avoid drawing any Iris while the engine is in SMUSH-mode, so that the movie will be visible (but any Irises of visible length will still get the fade, as only the completed Iris is skipped) 
