### PR TITLE
SDL: Fix copying the screen to the overlay

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -43,6 +43,7 @@ public:
 
 	virtual void launcherInitSize(uint w, uint h) = 0;
 	virtual byte *setupScreen(int screenW, int screenH, bool fullscreen, bool accel3d) = 0;
+	virtual int getScreenChangeID() const = 0;
 	virtual int16 getHeight() = 0;
 	virtual int16 getWidth() = 0;
 	virtual void updateScreen() = 0;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -55,6 +55,7 @@ public:
 
 	virtual void launcherInitSize(uint w, uint h);
 	byte *setupScreen(int screenW, int screenH, bool fullscreen, bool accel3d);
+	virtual int getScreenChangeID() const { return _screenChangeCount; }
 	virtual int16 getHeight();
 	virtual int16 getWidth();
 
@@ -105,6 +106,8 @@ protected:
 
 	/** Force full redraw on next updateScreen */
 	bool _forceFull;
+
+	int _screenChangeCount;
 };
 
 #endif

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -72,6 +72,10 @@ byte *ModularBackend::setupScreen(int screenW, int screenH, bool fullscreen, boo
 	return _graphicsManager->setupScreen(screenW, screenH, fullscreen, accel3d);
 }
 
+int ModularBackend::getScreenChangeID() const {
+	return _graphicsManager->getScreenChangeID();
+}
+
 int16 ModularBackend::getHeight() {
 	return _graphicsManager->getHeight();
 }

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -64,6 +64,7 @@ public:
 	virtual GraphicsManager *getGraphicsManager();
 	virtual void launcherInitSize(uint w, uint h);
 	virtual byte *setupScreen(int screenW, int screenH, bool fullscreen, bool accel3d);
+	virtual int getScreenChangeID() const;
 
 	virtual int16 getHeight();
 	virtual int16 getWidth();


### PR DESCRIPTION
- glReadPixels did not use the correct overlay height
- The copied image was flipped vertically
- Screen change ID was not updated, which prevented the theme engine
  from detecting screen resolution changes

(This prevented the debug console from working in the Myst 3 engine)
