### PR TITLE
GRIM: Fix inventory display resetting to start of animation after each it

### DIFF
--- a/engines/grim/animation.cpp
+++ b/engines/grim/animation.cpp
@@ -107,8 +107,11 @@ int Animation::update(int time) {
 	else if (!_paused)
 		newTime = _time + time;
 
-	int marker = _keyframe->getMarker(_time / 1000.f, newTime / 1000.f);
-	_time = newTime;
+	int marker = 0;
+	if (!_paused) {
+		marker = _keyframe->getMarker(_time / 1000.f, newTime / 1000.f);
+		_time = newTime;
+	}
 
 	int animLength = (int)(_keyframe->getLength() * 1000);
 


### PR DESCRIPTION
The current item display is buggy, because PauseAtEnd animations cause newTime to be used when uninitialized.
