### PR TITLE
GRIM: fix compilation errors due to pull request #340

### DIFF
--- a/engines/grim/movie/movie.cpp
+++ b/engines/grim/movie/movie.cpp
@@ -20,8 +20,6 @@
  *
  */
 
-#include "common/system.h"
-
 #include "engines/grim/movie/movie.h"
 
 #if !defined(USE_MPEG2) || !defined(USE_SMUSH) || !defined(USE_BINK)

--- a/engines/grim/movie/movie.h
+++ b/engines/grim/movie/movie.h
@@ -26,6 +26,7 @@
 #include <zlib.h>
 
 #include "common/file.h"
+#include "common/system.h"
 
 #include "audio/mixer.h"
 #include "audio/audiostream.h"


### PR DESCRIPTION
Got this errors with pull request #340:

In file included from /usr/include/zconf.h:378:0,
                 from /usr/include/zlib.h:34,
                 from ./engines/grim/movie/movie.h:26,
                 from engines/grim/movie/movie.cpp:25:
/usr/include/unistd.h:494:12: erreur: expected initializer before ‘SYMBOL’
/usr/include/unistd.h:508:14: erreur: expected initializer before ‘SYMBOL’
/usr/include/unistd.h:522:14: erreur: expected initializer before ‘SYMBOL’
In file included from /usr/include/zconf.h:378:0,
                 from /usr/include/zlib.h:34,
                 from ./engines/grim/movie/movie.h:26,
                 from engines/grim/movie/movie.cpp:25:
/usr/include/unistd.h:845:12: erreur: expected initializer before ‘SYMBOL’
