### PR TITLE
EMI: Fix .\\saves\\efmi.cfg in ~/.residual

### DIFF
--- a/engines/grim/lua/liolib.cpp
+++ b/engines/grim/lua/liolib.cpp
@@ -232,8 +232,8 @@ static void io_writeto() {
 		}
 		setreturn(id, FOUTPUT);
 	} else {
-		const char *s = luaL_check_string(FIRSTARG);
-		if (Common::String(s).hasSuffix("\\bino.txt")) {
+		const char *s = Common::lastPathComponent(luaL_check_string(FIRSTARG), '\\').c_str();
+		if (Common::String(s).hasSuffix("bino.txt")) {
 			pushresult(0);
 			return;
 		}
@@ -253,7 +253,7 @@ static void io_writeto() {
 }
 
 static void io_appendto() {
-	const char *s = luaL_check_string(FIRSTARG);
+	const char *s = Common::lastPathComponent(luaL_check_string(FIRSTARG), '\\').c_str();;
 	Common::SeekableReadStream *inFile = NULL;
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	inFile = saveFileMan->openForLoading(s);


### PR DESCRIPTION
The first start of EMI generates a config file in ~/.residual with backslashes in its name due to a hard-coded location to the saves directory in the original game. This patch should fix that.

This new pull request also fixes problem with "\bino.txt" in Grim Fandango
