### PR TITLE
GRIM: Remove grim.h-dependency in iMuse

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -455,6 +455,7 @@ GrimEngine::~GrimEngine() {
 Common::Error GrimEngine::run() {
 	g_resourceloader = new ResourceLoader();
 	g_localizer = new Localizer();
+	bool demo = g_grim->getGameFlags() & ADGF_DEMO;
 	if (getGameType() == GType_GRIM)
 		g_movie = CreateSmushPlayer();
 	else if (getGameType() == GType_MONKEY4) {
@@ -463,7 +464,7 @@ Common::Error GrimEngine::run() {
 		else
 			g_movie = CreateBinkPlayer();
 	}
-	g_imuse = new Imuse(20);
+	g_imuse = new Imuse(20, demo);
 
 	bool fullscreen = (tolower(g_registry->get("fullscreen", "false")[0]) == 't');
 

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -212,9 +212,6 @@ extern GrimEngine *g_grim;
 
 extern int g_imuseState;
 
-void vimaInit(uint16 *destTable);
-void decompressVima(const byte *src, int16 *dest, int destLen, uint16 *destTable);
-
 // Fake KEYCODE_* values for joystick and mouse events
 
 enum {

--- a/engines/grim/imuse/imuse.cpp
+++ b/engines/grim/imuse/imuse.cpp
@@ -26,11 +26,13 @@
 
 #include "common/timer.h"
 
-#include "engines/grim/grim.h"
 #include "engines/grim/savegame.h"
 #include "engines/grim/debug.h"
 
 #include "engines/grim/imuse/imuse.h"
+
+#include "engines/grim/movie/codecs/vima.h"
+
 
 #include "audio/audiostream.h"
 #include "audio/mixer.h"
@@ -51,9 +53,9 @@ void Imuse::timerHandler(void *refCon) {
 	imuse->callback();
 }
 
-Imuse::Imuse(int fps) {
+Imuse::Imuse(int fps, bool demo) : _demo(demo) {
 	_pause = false;
-	_sound = new ImuseSndMgr();
+	_sound = new ImuseSndMgr(_demo);
 	assert(_sound);
 	_callbackFps = fps;
 	resetState();
@@ -64,7 +66,7 @@ Imuse::Imuse(int fps) {
 		_track[l]->trackId = l;
 	}
 	vimaInit(imuseDestTable);
-	if (g_grim->getGameFlags() & ADGF_DEMO) {
+	if (_demo) {
 		_stateMusicTable = grimDemoStateMusicTable;
 		_seqMusicTable = grimDemoSeqMusicTable;
 	} else {

--- a/engines/grim/imuse/imuse.h
+++ b/engines/grim/imuse/imuse.h
@@ -46,6 +46,7 @@ private:
 	ImuseSndMgr *_sound;
 
 	bool _pause;
+	bool _demo;
 
 	int32 _attributes[185];
 	int32 _curMusicState;
@@ -71,7 +72,7 @@ private:
 	void flushTrack(Track *track);
 
 public:
-	Imuse(int fps);
+	Imuse(int fps, bool demo);
 	~Imuse();
 
 	bool startSound(const char *soundName, int volGroupId, int hookId, int volume, int pan, int priority, Track *otherTrack);

--- a/engines/grim/imuse/imuse_mcmp_mgr.cpp
+++ b/engines/grim/imuse/imuse_mcmp_mgr.cpp
@@ -22,9 +22,9 @@
 
 #include "common/file.h"
 
-#include "engines/grim/grim.h"
 #include "engines/grim/resource.h"
 
+#include "engines/grim/movie/codecs/vima.h"
 #include "engines/grim/imuse/imuse_mcmp_mgr.h"
 
 namespace Grim {

--- a/engines/grim/imuse/imuse_sndmgr.cpp
+++ b/engines/grim/imuse/imuse_sndmgr.cpp
@@ -22,7 +22,6 @@
 
 #include "common/endian.h"
 
-#include "engines/grim/grim.h"
 #include "engines/grim/resource.h"
 #include "engines/grim/lab.h"
 #include "engines/grim/colormap.h"
@@ -32,7 +31,7 @@
 
 namespace Grim {
 
-ImuseSndMgr::ImuseSndMgr() {
+ImuseSndMgr::ImuseSndMgr(bool demo) : _demo(demo) {
 	for (int l = 0; l < MAX_IMUSE_SOUNDS; l++) {
 		memset(&_sounds[l], 0, sizeof(SoundDesc));
 	}
@@ -173,7 +172,7 @@ ImuseSndMgr::SoundDesc *ImuseSndMgr::openSound(const char *soundName, int volGro
 	strcpy(sound->name, soundName);
 	sound->volGroupId = volGroupId;
 
-	if (!(g_grim->getGameFlags() & ADGF_DEMO) && scumm_stricmp(extension, "imu") == 0) {
+	if (!_demo && scumm_stricmp(extension, "imu") == 0) {
 		sound->blockRes = g_resourceloader->getFileBlock(soundName);
 		if (sound->blockRes) {
 			ptr = (byte *)sound->blockRes->getData();
@@ -185,7 +184,7 @@ ImuseSndMgr::SoundDesc *ImuseSndMgr::openSound(const char *soundName, int volGro
 			return NULL;
 		}
 	} else if (scumm_stricmp(extension, "wav") == 0 || scumm_stricmp(extension, "imc") == 0 ||
-			(g_grim->getGameFlags() & ADGF_DEMO && scumm_stricmp(extension, "imu") == 0)) {
+			(_demo && scumm_stricmp(extension, "imu") == 0)) {
 		sound->mcmpMgr = new McmpMgr();
 		if (!sound->mcmpMgr->openSound(soundName, &ptr, headerSize)) {
 			closeSound(sound);

--- a/engines/grim/imuse/imuse_sndmgr.h
+++ b/engines/grim/imuse/imuse_sndmgr.h
@@ -81,7 +81,7 @@ public:
 	};
 
 private:
-
+	bool _demo;
 	SoundDesc _sounds[MAX_IMUSE_SOUNDS];
 
 	bool checkForProperHandle(SoundDesc *soundDesc);
@@ -91,7 +91,7 @@ private:
 
 public:
 
-	ImuseSndMgr();
+	ImuseSndMgr(bool demo);
 	~ImuseSndMgr();
 
 	SoundDesc *openSound(const char *soundName, int volGroupId);

--- a/engines/grim/movie/codecs/vima.h
+++ b/engines/grim/movie/codecs/vima.h
@@ -1,0 +1,33 @@
+/* Residual - A 3D game interpreter
+ *
+ * Residual is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ *
+ */
+
+#ifndef GRIM_VIMA_H
+#define GRIM_VIMA_H
+
+namespace Grim {
+
+void vimaInit(uint16 *destTable);
+void decompressVima(const byte *src, int16 *dest, int destLen, uint16 *destTable);
+
+} // end of namespace Grim
+
+#endif

--- a/engines/grim/movie/smush.cpp
+++ b/engines/grim/movie/smush.cpp
@@ -45,6 +45,8 @@
 #include "engines/grim/resource.h"
 #include "engines/grim/savegame.h"
 
+#include "engines/grim/movie/codecs/vima.h"
+
 #ifdef USE_SMUSH
 
 namespace Grim {


### PR DESCRIPTION
I think the subfolders shouldn't really need to include stuff from engines/grim unless it's really necessary, so here's a suggestion for removing the dependency on grim.h in imuse, by letting imuse keep track of whether we are in the demo or the full game.

I know this pull request isn't properly formatted, I just want to know if the idea is good or not. If it's ok I'll redo it without the extra newlines, and commit that.

Thoughts?
