### PR TITLE
GRIM: Reboost of the debug system, using debug channels.

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -924,12 +924,10 @@ void Actor::popCostume() {
 		_costumeStack.pop_back();
 
 		if (_costumeStack.empty()) {
-			if (gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-				printf("Popped (freed) the last costume for an actor.\n");
+			Debug::debug(Debug::Actors, "Popped (freed) the last costume for an actor.\n");
 		}
 	} else {
-		if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Attempted to pop (free) a costume when the stack is empty!");
+		Debug::warning(Debug::Actors, "Attempted to pop (free) a costume when the stack is empty!");
 	}
 }
 

--- a/engines/grim/animation.cpp
+++ b/engines/grim/animation.cpp
@@ -160,8 +160,7 @@ int Animation::update(int time) {
 				_time = animLength;
 				break;
 			default:
-				if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-					warning("Unknown repeat mode %d for keyframe %s", _repeatMode, _keyframe->getFilename().c_str());
+				Debug::warning(Debug::Keyframes, "Unknown repeat mode %d for keyframe %s", _repeatMode, _keyframe->getFilename().c_str());
 		}
 	}
 

--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -117,8 +117,7 @@ BitmapData::BitmapData(const Common::String &fname, const char *data, int len) {
 		loadTile(data, len);
 		return;
 	} else if (len < 8 || memcmp(data, "BM  F\0\0\0", 8) != 0) {
-		if (gDebugLevel == DEBUG_BITMAPS || gDebugLevel == DEBUG_ERROR || gDebugLevel == DEBUG_ALL)
-			error("Invalid magic loading bitmap");
+		Debug::error(Debug::Bitmaps, "Invalid magic loading bitmap");
 	}
 
 	int codec = READ_LE_UINT32(data + 8);
@@ -166,8 +165,7 @@ BitmapData::BitmapData(const Common::String &fname, const char *data, int len) {
 BitmapData::BitmapData(const char *data, int w, int h, int bpp, const char *fname) {
 	_fname = fname;
 	_refCount = 1;
-	if (gDebugLevel == DEBUG_BITMAPS || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-		printf("New bitmap loaded: %s\n", fname);
+	Debug::debug(Debug::Bitmaps, "New bitmap loaded: %s\n", fname);
 	_numImages = 1;
 	_x = 0;
 	_y = 0;

--- a/engines/grim/costume.cpp
+++ b/engines/grim/costume.cpp
@@ -228,8 +228,7 @@ void BitmapComponent::setKey(int val) {
 	// bitmaps were not loading with the scene. This was because they were requested
 	// as a different case then they were stored (tu_0_dorcu_door_open versus
 	// TU_0_DORCU_door_open), which was causing problems in the string comparison.
-	if (gDebugLevel == DEBUG_BITMAPS || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-		warning("Missing scene bitmap: %s", bitmap);
+	Debug::warning(Debug::Bitmaps | Debug::Costumes, "Missing scene bitmap: %s", bitmap);
 
 /* In case you feel like drawing the missing bitmap anyway...
 	// Assume that all objects the scene file forgot about are OBJSTATE_STATE class
@@ -294,8 +293,8 @@ void SpriteComponent::init() {
 			MeshComponent *mc = dynamic_cast<MeshComponent *>(_parent);
 			if (mc)
 				mc->getNode()->addSprite(_sprite);
-			else if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-				warning("Parent of sprite %s wasn't a mesh", _filename.c_str());
+			else
+				Debug::warning(Debug::Costumes, "Parent of sprite %s wasn't a mesh", _filename.c_str());
 		}
 	}
 }
@@ -364,8 +363,7 @@ void ModelComponent::init() {
 		if (!cm && g_grim->getCurrSet())
 			cm = g_grim->getCurrSet()->getCMap();
 		if (!cm) {
-			if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-				warning("No colormap specified for %s, using %s", _filename.c_str(), DEFAULT_COLORMAP);
+			Debug::warning(Debug::Costumes, "No colormap specified for %s, using %s", _filename.c_str(), DEFAULT_COLORMAP);
 
 			cm = g_resourceloader->getColormap(DEFAULT_COLORMAP);
 		}
@@ -380,8 +378,7 @@ void ModelComponent::init() {
 		} else {
 			_obj = g_resourceloader->loadModel(_filename, cm);
 			_hier = _obj->copyHierarchy();
-			if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-				warning("Parent of model %s wasn't a mesh", _filename.c_str());
+			Debug::warning(Debug::Costumes, "Parent of model %s wasn't a mesh", _filename.c_str());
 		}
 
 		// Use parent availablity to decide whether to default the
@@ -662,8 +659,7 @@ void KeyframeComponent::setKey(int val) {
 		fade(Animation::FadeOut, 125);
 		break;
 	default:
-		if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Unknown key %d for keyframe %s", val, _fname.c_str());
+		Debug::warning(Debug::Costumes, "Unknown key %d for component %s", val, _fname.c_str());
 	}
 }
 
@@ -685,8 +681,7 @@ void KeyframeComponent::init() {
 	if (mc) {
 		_anim = new Animation(_fname, mc->getAnimManager(), _priority1, _priority2);
 	} else {
-		if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Parent of %s was not a model", _fname.c_str());
+		Debug::warning(Debug::Costumes, "Parent of %s was not a model", _fname.c_str());
 		_anim = NULL;
 	}
 }
@@ -712,8 +707,7 @@ void MeshComponent::init() {
 		_node = mc->getHierarchy() + _num;
 		_model = mc->getModel();
 	} else {
-		if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Parent of mesh %d was not a model", _num);
+		Debug::warning(Debug::Costumes, "Parent of mesh %d was not a model", _num);
 		_node = NULL;
 		_model = NULL;
 	}
@@ -747,8 +741,7 @@ void MeshComponent::restoreState(SaveGame *state) {
 MaterialComponent::MaterialComponent(Costume::Component *p, int parentID, const char *filename, tag32 t) :
 		Costume::Component(p, parentID, t), _filename(filename) {
 
-	if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-		warning("Constructing MaterialComponent %s", filename);
+	Debug::debug(Debug::Costumes, "Constructing MaterialComponent %s", filename);
 }
 
 void MaterialComponent::init() {
@@ -851,8 +844,7 @@ void SoundComponent::setKey(int val) {
 		g_imuse->setHookId(_soundName.c_str(), 0x80);
 		break;
 	default:
-		if (gDebugLevel == DEBUG_MODEL || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Unknown key %d for sound %s", val, _soundName.c_str());
+		Debug::warning(Debug::Costumes, "Unknown key %d for sound %s", val, _soundName.c_str());
 	}
 }
 
@@ -959,8 +951,7 @@ void Costume::loadGRIM(TextSplitter &ts, Costume *prevCost) {
 		_chores[id]._length = length;
 		_chores[id]._numTracks = tracks;
 		memcpy(_chores[id]._name, name, 32);
-		if (gDebugLevel == DEBUG_ALL || gDebugLevel == DEBUG_CHORES)
-			printf("Loaded chore: %s\n", name);
+		Debug::debug(Debug::Chores, "Loaded chore: %s\n", name);
 	}
 
 	ts.expectString("section keys");
@@ -1394,8 +1385,7 @@ Model *Costume::getModel() {
 
 void Costume::playChoreLooping(int num) {
 	if (num < 0 || num >= _numChores) {
-		if (gDebugLevel == DEBUG_CHORES || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Requested chore number %d is outside the range of chores (0-%d)", num, _numChores);
+		Debug::warning(Debug::Chores, "Requested chore number %d is outside the range of chores (0-%d)", num, _numChores);
 		return;
 	}
 	_chores[num].playLooping();
@@ -1416,8 +1406,7 @@ void Costume::playChore(const char *name) {
 
 void Costume::playChore(int num) {
 	if (num < 0 || num >= _numChores) {
-		if (gDebugLevel == DEBUG_CHORES || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Requested chore number %d is outside the range of chores (0-%d)", num, _numChores);
+		Debug::warning(Debug::Chores, "Requested chore number %d is outside the range of chores (0-%d)", num, _numChores);
 		return;
 	}
 	_chores[num].play();
@@ -1427,8 +1416,7 @@ void Costume::playChore(int num) {
 
 void Costume::stopChore(int num) {
 	if (num < 0 || num >= _numChores) {
-		if (gDebugLevel == DEBUG_CHORES || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Requested chore number %d is outside the range of chores (0-%d)", num, _numChores);
+		Debug::warning(Debug::Chores, "Requested chore number %d is outside the range of chores (0-%d)", num, _numChores);
 		return;
 	}
 	_chores[num].stop();
@@ -1455,8 +1443,7 @@ void Costume::stopChores() {
 void Costume::fadeChoreIn(int chore, int msecs) {
 	if (chore >= _numChores) {
 		if (chore < 0 || chore >= _numChores) {
-			if (gDebugLevel == DEBUG_CHORES || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-				warning("Requested chore number %d is outside the range of chores (0-%d)", chore, _numChores);
+			Debug::warning(Debug::Chores, "Requested chore number %d is outside the range of chores (0-%d)", chore, _numChores);
 			return;
 		}
 	}
@@ -1468,8 +1455,7 @@ void Costume::fadeChoreIn(int chore, int msecs) {
 void Costume::fadeChoreOut(int chore, int msecs) {
 	if (chore >= _numChores) {
 		if (chore < 0 || chore >= _numChores) {
-			if (gDebugLevel == DEBUG_CHORES || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-				warning("Requested chore number %d is outside the range of chores (0-%d)", chore, _numChores);
+			Debug::warning(Debug::Chores, "Requested chore number %d is outside the range of chores (0-%d)", chore, _numChores);
 			return;
 		}
 	}

--- a/engines/grim/debug.cpp
+++ b/engines/grim/debug.cpp
@@ -1,0 +1,98 @@
+/* Residual - A 3D game interpreter
+ *
+ * Residual is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ *
+ */
+
+#include "common/debug-channels.h"
+
+#include "engines/grim/debug.h"
+
+namespace Grim {
+
+void Debug::registerDebugChannels() {
+	DebugMan.addDebugChannel(Info, "info", "");
+	DebugMan.addDebugChannel(Warning, "warning", "");
+	DebugMan.addDebugChannel(Error, "error", "");
+	DebugMan.addDebugChannel(Engine, "engine", "");
+	DebugMan.addDebugChannel(Lua, "lua", "");
+	DebugMan.addDebugChannel(Bitmaps, "bitmaps", "");
+	DebugMan.addDebugChannel(Models, "models", "");
+	DebugMan.addDebugChannel(Actors, "actors", "");
+	DebugMan.addDebugChannel(Costumes, "costumes", "");
+	DebugMan.addDebugChannel(Chores, "chores", "");
+	DebugMan.addDebugChannel(Fonts, "fonts", "");
+	DebugMan.addDebugChannel(Keyframes, "keyframes", "");
+	DebugMan.addDebugChannel(Movie, "movie", "");
+	DebugMan.addDebugChannel(Imuse, "imuse", "");
+	DebugMan.addDebugChannel(Scripts, "scripts", "");
+	DebugMan.addDebugChannel(Sets, "sets", "");
+	DebugMan.addDebugChannel(TextObjects, "textobjects", "");
+	DebugMan.addDebugChannel(All, "all", "");
+}
+
+bool Debug::isChannelEnabled(DebugChannel chan) {
+	return DebugMan.isDebugChannelEnabled(chan);
+}
+
+void Debug::debug(DebugChannel channel, const char *s, ...) {
+	if (isChannelEnabled(channel | Debug::Info)) {
+		va_list args;
+		va_start(args, s);
+		Common::String buf = Common::String::vformat(s, args);
+		va_end(args);
+
+		::debug(buf.c_str());
+	}
+}
+
+void Debug::warning(DebugChannel channel, const char *s, ...) {
+	if (isChannelEnabled(channel | Debug::Warning)) {
+		va_list args;
+		va_start(args, s);
+		Common::String buf = Common::String::vformat(s, args);
+		va_end(args);
+
+		::warning(buf.c_str());
+	}
+}
+
+void Debug::error(DebugChannel channel, const char *s, ...) {
+	if (isChannelEnabled(channel | Debug::Error)) {
+		va_list args;
+		va_start(args, s);
+		Common::String buf = Common::String::vformat(s, args);
+		va_end(args);
+
+		::error(buf.c_str());
+	}
+}
+
+void Debug::error(const char *s, ...) {
+	if (isChannelEnabled(Debug::Error)) {
+		va_list args;
+		va_start(args, s);
+		Common::String buf = Common::String::vformat(s, args);
+		va_end(args);
+
+		::error(buf.c_str());
+	}
+}
+
+}

--- a/engines/grim/debug.h
+++ b/engines/grim/debug.h
@@ -28,21 +28,68 @@
 
 namespace Grim {
 
-enum enDebugLevels {
-	DEBUG_NONE = 0,
-	DEBUG_NORMAL = 1,
-	DEBUG_WARN = 2,
-	DEBUG_ERROR = 4,
-	DEBUG_LUA = 8,
-	DEBUG_BITMAPS = 16,
-	DEBUG_MODEL = 32,
-	DEBUG_STUB = 64,
-	DEBUG_MOVIE = 128,
-	DEBUG_IMUSE = 256,
-	DEBUG_CHORES = 512,
-	DEBUG_ALL = DEBUG_NORMAL | DEBUG_WARN | DEBUG_ERROR | DEBUG_LUA | DEBUG_BITMAPS |
-				DEBUG_MODEL | DEBUG_STUB | DEBUG_MOVIE | DEBUG_IMUSE | DEBUG_CHORES
+class Debug {
+public:
+	enum DebugChannel {
+		Info = 1,
+		Warning = Info * 2,
+		Error = Warning * 2,
+		Engine = Error * 2,
+		Lua = Engine * 2,
+		Bitmaps = Lua * 2,
+		Models = Bitmaps * 2,
+		Actors = Models * 2,
+		Costumes = Actors * 2,
+		Chores = Costumes * 2,
+		Fonts = Chores * 2,
+		Keyframes = Fonts * 2,
+		Materials = Keyframes * 2,
+		Movie = Materials * 2,
+		Imuse = Movie * 2,
+		Scripts = Imuse * 2,
+		Sets = Scripts * 2,
+		TextObjects = Sets * 2,
+		All = Info | Warning | Error | Engine | Lua | Bitmaps | Models |
+		      Actors | Costumes | Chores | Fonts | Keyframes | Materials | Movie | Imuse |
+		      Scripts | Sets | TextObjects
+	};
+
+	static void registerDebugChannels();
+	static bool isChannelEnabled(DebugChannel chan);
+
+	/**
+	 * Prints a message to the console (stdout), only if the specified debug channel
+	 * or the channel Info are active.
+	 *
+	 * @param channel The debug channel to use.
+	 */
+	static void debug(DebugChannel channel, const char *s, ...);
+	/**
+	 * Prints a message to the console (sterr), only if the specified debug channel
+	 * or the channel Warning are active.
+	 *
+	 * @param channel The debug channel to use.
+	 */
+	static void warning(DebugChannel channel, const char *s, ...);
+	/**
+	 * Prints a message to the console (stderr) and exit the program immediately,
+	 * only if the specified debug channel or the channel Error are active.
+	 *
+	 * @param channel The debug channel to use.
+	 */
+	static void error(DebugChannel channel, const char *s, ...);
+	/**
+	 * Prints a message to the console (stderr) and exit the program immediately,
+	 * only if the debug channel Error is active.
+	 *
+	 * @param channel The debug channel to use.
+	 */
+	static void error(const char *s, ...);
 };
+
+inline Debug::DebugChannel operator|(Debug::DebugChannel a, Debug::DebugChannel b) {
+	return (Debug::DebugChannel)((int)a | (int) b);
+}
 
 }
 

--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -127,8 +127,7 @@ uint16 Font::getCharIndex(unsigned char c) const {
 		if (_charIndex[i] == c2)
 			return i;
 	}
-	if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-		warning("The requsted character (code 0x%x) does not correspond to anything in the font data!", c2);
+	Debug::warning(Debug::Fonts, "The requsted character (code 0x%x) does not correspond to anything in the font data!", c2);
 	// If we couldn't find the character then default to
 	// the first character in the font so that something
 	// gets loaded to prevent the game from crashing

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -172,6 +172,8 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 	// Add 'movies' subdirectory for the demo
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 	SearchMan.addSubDirectoryMatching(gameDataDir, "movies");
+
+	Debug::registerDebugChannels();
 }
 
 GrimEngine::~GrimEngine() {
@@ -311,8 +313,8 @@ int GrimEngine::bundle_dofile(const char *filename) {
 		delete b;
 		// Don't print warnings on Scripts\foo.lua,
 		// d:\grimFandango\Scripts\foo.lua
-		if (!strstr(filename, "Scripts\\") && (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL))
-			warning("Cannot find script %s", filename);
+		if (!strstr(filename, "Scripts\\"))
+			Debug::warning(Debug::Engine, "Cannot find script %s", filename);
 
 		return 2;
 	}
@@ -327,8 +329,7 @@ int GrimEngine::single_dofile(const char *filename) {
 
 	if (!f->open(filename)) {
 		delete f;
-		if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Cannot find script %s", filename);
+		Debug::warning(Debug::Engine, "Cannot find script %s", filename);
 
 		return 2;
 	}
@@ -900,7 +901,7 @@ void GrimEngine::loadGame(const Common::String &file) {
 }
 
 void GrimEngine::savegameRestore() {
-	debug("GrimEngine::savegameRestore() started.\n");
+	debug("GrimEngine::savegameRestore() started.");
 	_savegameLoadRequest = false;
 	Common::String filename;
 	if (_savegameFileName.size() == 0) {
@@ -923,20 +924,46 @@ void GrimEngine::savegameRestore() {
 	_currSet = NULL;
 
 	PoolColor::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "Colors restored succesfully.");
+
 	Bitmap::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "Bitmaps restored succesfully.");
+
 	Font::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "Fonts restored succesfully.");
+
 	ObjectState::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "ObjectStates restored succesfully.");
+
 	Set::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "Sets restored succesfully.");
+
 	TextObject::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "TextObjects restored succesfully.");
+
 	PrimitiveObject::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "PrimitiveObjects restored succesfully.");
+
 	Actor::getPool()->restoreObjects(_savedState);
+	Debug::debug(Debug::Engine, "Actors restored succesfully.");
+
 	restoreGRIM();
+	Debug::debug(Debug::Engine, "Engine restored succesfully.");
 
 	g_driver->restoreState(_savedState);
+	Debug::debug(Debug::Engine, "Renderer restored succesfully.");
+
 	g_imuse->restoreState(_savedState);
+	Debug::debug(Debug::Engine, "iMuse restored succesfully.");
+
 	g_movie->restoreState(_savedState);
+	Debug::debug(Debug::Engine, "Movie restored succesfully.");
+
 	_iris->restoreState(_savedState);
+	Debug::debug(Debug::Engine, "Iris restored succesfully.");
+
 	lua_Restore(_savedState);
+	Debug::debug(Debug::Engine, "Lua restored succesfully.");
 
 	delete _savedState;
 
@@ -959,7 +986,7 @@ void GrimEngine::savegameRestore() {
 
 	g_imuse->pause(false);
 	g_movie->pause(false);
-	debug("GrimEngine::savegameRestore() finished.\n");
+	debug("GrimEngine::savegameRestore() finished.");
 
 	_shortFrame = true;
 	clearEventQueue();
@@ -999,7 +1026,7 @@ void GrimEngine::storeSaveGameImage(SaveGame *state) {
 	int width = 250, height = 188;
 	Bitmap *screenshot;
 
-	debug("GrimEngine::StoreSaveGameImage() started.\n");
+	debug("GrimEngine::StoreSaveGameImage() started.");
 
 	EngineMode mode = g_grim->getMode();
 	g_grim->setMode(_previousMode);
@@ -1020,11 +1047,11 @@ void GrimEngine::storeSaveGameImage(SaveGame *state) {
 	}
 	state->endSection();
 	delete screenshot;
-	debug("GrimEngine::StoreSaveGameImage() finished.\n");
+	debug("GrimEngine::StoreSaveGameImage() finished.");
 }
 
 void GrimEngine::savegameSave() {
-	debug("GrimEngine::savegameSave() started.\n");
+	debug("GrimEngine::savegameSave() started.");
 	_savegameSaveRequest = false;
 	char filename[200];
 	if (_savegameFileName.size() == 0) {
@@ -1047,26 +1074,51 @@ void GrimEngine::savegameSave() {
 	savegameCallback();
 
 	PoolColor::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "Colors saved succesfully.");
+
 	Bitmap::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "Bitmaps saved succesfully.");
+
 	Font::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "Fonts saved succesfully.");
+
 	ObjectState::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "ObjectStates saved succesfully.");
+
 	Set::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "Sets saved succesfully.");
+
 	TextObject::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "TextObjects saved succesfully.");
+
 	PrimitiveObject::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "PrimitiveObjects saved succesfully.");
+
 	Actor::getPool()->saveObjects(_savedState);
+	Debug::debug(Debug::Engine, "Actors saved succesfully.");
+
 	saveGRIM();
+	Debug::debug(Debug::Engine, "Engine saved succesfully.");
 
 	g_driver->saveState(_savedState);
+	Debug::debug(Debug::Engine, "Renderer saved succesfully.");
+
 	g_imuse->saveState(_savedState);
+	Debug::debug(Debug::Engine, "iMuse saved succesfully.");
+
 	g_movie->saveState(_savedState);
+	Debug::debug(Debug::Engine, "Movie saved succesfully.");
+
 	_iris->saveState(_savedState);
+	Debug::debug(Debug::Engine, "Iris saved succesfully.");
+
 	lua_Save(_savedState);
 
 	delete _savedState;
 
 	g_imuse->pause(false);
 	g_movie->pause(false);
-	debug("GrimEngine::savegameSave() finished.\n");
+	debug("GrimEngine::savegameSave() finished.");
 
 	_shortFrame = true;
 	clearEventQueue();
@@ -1148,8 +1200,7 @@ void GrimEngine::setSetLock(const char *name, bool lockStatus) {
 	Set *scene = findSet(name);
 
 	if (!scene) {
-		if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Set object '%s' not found in list", name);
+		Debug::warning(Debug::Engine, "Set object '%s' not found in list", name);
 		return;
 	}
 	// Change the locking status

--- a/engines/grim/imuse/imuse.cpp
+++ b/engines/grim/imuse/imuse.cpp
@@ -91,7 +91,6 @@ void Imuse::resetState() {
 
 void Imuse::restoreState(SaveGame *savedState) {
 	Common::StackLock lock(_mutex);
-	debug("Imuse::restoreState() started.");
 
 	savedState->beginSection('IMUS');
 	_curMusicState = savedState->readLESint32();
@@ -153,13 +152,10 @@ void Imuse::restoreState(SaveGame *savedState) {
 	}
 	savedState->endSection();
 	g_system->getMixer()->pauseAll(false);
-
-	debug("Imuse::restoreState() finished.");
 }
 
 void Imuse::saveState(SaveGame *savedState) {
 	Common::StackLock lock(_mutex);
-	debug("Imuse::saveState() started.");
 
 	savedState->beginSection('IMUS');
 	savedState->writeLESint32(_curMusicState);
@@ -191,7 +187,6 @@ void Imuse::saveState(SaveGame *savedState) {
 		savedState->writeLESint32(track->mixerFlags);
 	}
 	savedState->endSection();
-	debug("Imuse::saveState() finished.");
 }
 
 int32 Imuse::makeMixerFlags(int32 flags) {
@@ -334,8 +329,7 @@ void Imuse::switchToNextRegion(Track *track) {
 	assert(track);
 
 	if (track->trackId >= MAX_IMUSE_TRACKS) {
-		if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-			debug("Imuse::switchToNextRegion(): fadeTrack end: soundName:%s", track->soundName);
+		Debug::debug(Debug::Imuse, "Imuse::switchToNextRegion(): fadeTrack end: soundName:%s", track->soundName);
 		flushTrack(track);
 		return;
 	}
@@ -343,8 +337,7 @@ void Imuse::switchToNextRegion(Track *track) {
 	int numRegions = _sound->getNumRegions(track->soundDesc);
 
 	if (++track->curRegion == numRegions) {
-		if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-			debug("Imuse::switchToNextRegion(): end of tracks: soundName:%s", track->soundName);
+		Debug::debug(Debug::Imuse, "Imuse::switchToNextRegion(): end of tracks: soundName:%s", track->soundName);
 		flushTrack(track);
 		return;
 	}
@@ -357,8 +350,7 @@ void Imuse::switchToNextRegion(Track *track) {
 	if (jumpId == -1 && track->curHookId != 128)
 		jumpId = _sound->getJumpIdByRegionAndHookId(soundDesc, track->curRegion, 0);
 	if (jumpId != -1) {
-		if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-			debug("Imuse::switchToNextRegion(): JUMP: soundName:%s", track->soundName);
+		Debug::debug(Debug::Imuse, "Imuse::switchToNextRegion(): JUMP: soundName:%s", track->soundName);
 		int region = _sound->getRegionIdByJumpId(soundDesc, jumpId);
 		assert(region != -1);
 		int sampleHookId = _sound->getJumpHookId(soundDesc, jumpId);
@@ -380,8 +372,7 @@ void Imuse::switchToNextRegion(Track *track) {
 				track->curHookId = 0;
 	}
 
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::switchToNextRegion(): REGION %d: soundName:%s", (int)track->curRegion, track->soundName);
+	Debug::debug(Debug::Imuse, "Imuse::switchToNextRegion(): REGION %d: soundName:%s", (int)track->curRegion, track->soundName);
 	track->dataOffset = _sound->getRegionOffset(soundDesc, track->curRegion);
 	track->regionOffset = 0;
 }

--- a/engines/grim/imuse/imuse_music.cpp
+++ b/engines/grim/imuse/imuse_music.cpp
@@ -41,8 +41,7 @@ void Imuse::setMusicState(int stateId) {
 	}
 	assert(num != -1);
 
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::setMusicState(): SoundId %d, filename: %s", _stateMusicTable[l].soundId, _stateMusicTable[l].filename);
+	Debug::debug(Debug::Imuse, "Imuse::setMusicState(): SoundId %d, filename: %s", _stateMusicTable[l].soundId, _stateMusicTable[l].filename);
 
 	if (_curMusicState == num)
 		return;
@@ -72,8 +71,7 @@ int Imuse::setMusicSequence(int seqId) {
 
 	assert(num != -1);
 
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::setMusicSequence(): SoundId %d, filename: %s", _seqMusicTable[l].soundId, _seqMusicTable[l].filename);
+	Debug::debug(Debug::Imuse, "Imuse::setMusicSequence(): SoundId %d, filename: %s", _seqMusicTable[l].soundId, _seqMusicTable[l].filename);
 
 	if (_curMusicSeq == num)
 		return _seqMusicTable[_curMusicSeq].soundId;

--- a/engines/grim/imuse/imuse_script.cpp
+++ b/engines/grim/imuse/imuse_script.cpp
@@ -76,26 +76,22 @@ void Imuse::refreshScripts() {
 }
 
 bool Imuse::startVoice(const char *soundName, int volume, int pan) {
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::startVoice(): SoundName %s, vol:%d, pan:%d", soundName, volume, pan);
+	Debug::debug(Debug::Imuse, "Imuse::startVoice(): SoundName %s, vol:%d, pan:%d", soundName, volume, pan);
 	return startSound(soundName, IMUSE_VOLGRP_VOICE, 0, volume, pan, 127, NULL);
 }
 
 void Imuse::startMusic(const char *soundName, int hookId, int volume, int pan) {
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::startMusic(): SoundName %s, hookId:%d, vol:%d, pan:%d", soundName, hookId, volume, pan);
+	Debug::debug(Debug::Imuse, "Imuse::startMusic(): SoundName %s, hookId:%d, vol:%d, pan:%d", soundName, hookId, volume, pan);
 	startSound(soundName, IMUSE_VOLGRP_MUSIC, hookId, volume, pan, 126, NULL);
 }
 
 void Imuse::startMusicWithOtherPos(const char *soundName, int hookId, int volume, int pan, Track *otherTrack) {
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::startMusicWithOtherPos(): SoundName %s, hookId:%d, vol:%d, pan:%d", soundName, hookId, volume, pan);
+	Debug::debug(Debug::Imuse, "Imuse::startMusicWithOtherPos(): SoundName %s, hookId:%d, vol:%d, pan:%d", soundName, hookId, volume, pan);
 	startSound(soundName, IMUSE_VOLGRP_MUSIC, hookId, volume, pan, 126, otherTrack);
 }
 
 void Imuse::startSfx(const char *soundName, int priority) {
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::startSfx(): SoundName %s, priority:%d", soundName, priority);
+	Debug::debug(Debug::Imuse, "Imuse::startSfx(): SoundName %s, priority:%d", soundName, priority);
 	startSound(soundName, IMUSE_VOLGRP_SFX, 0, 127, 0, priority, NULL);
 }
 
@@ -106,8 +102,7 @@ int32 Imuse::getPosIn60HzTicks(const char *soundName) {
 	getTrack = findTrack(soundName);
 	// Warn the user if the track was not found
 	if (getTrack == NULL) {
-		if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Sound '%s' could not be found to get ticks", soundName);
+		Debug::warning(Debug::Imuse, "Sound '%s' could not be found to get ticks", soundName);
 		return false;
 	}
 
@@ -141,8 +136,7 @@ bool Imuse::getSoundStatus(const char *soundName) {
 	if (track == NULL || !g_system->getMixer()->isSoundHandleActive(track->handle)) {
 		// This debug warning should be "light" since this function gets called
 		// on occassion to see if a sound has stopped yet
-		if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-			debug("Sound '%s' could not be found to get status, assume inactive.", soundName);
+		Debug::debug(Debug::Imuse, "Sound '%s' could not be found to get status, assume inactive.", soundName);
 		return false;
 	}
 	return true;
@@ -150,15 +144,13 @@ bool Imuse::getSoundStatus(const char *soundName) {
 
 void Imuse::stopSound(const char *soundName) {
 	Common::StackLock lock(_mutex);
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::stopSound(): SoundName %s", soundName);
+	Debug::debug(Debug::Imuse, "Imuse::stopSound(): SoundName %s", soundName);
 	Track *removeTrack = NULL;
 
 	removeTrack = findTrack(soundName);
 	// Warn the user if the track was not found
 	if (removeTrack == NULL) {
-		if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-			warning("Sound track '%s' could not be found to stop", soundName);
+		Debug::warning(Debug::Imuse, "Sound track '%s' could not be found to stop", soundName);
 		return;
 	}
 	flushTrack(removeTrack);
@@ -166,8 +158,7 @@ void Imuse::stopSound(const char *soundName) {
 
 void Imuse::stopAllSounds() {
 	Common::StackLock lock(_mutex);
-	if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_ALL)
-		debug("Imuse::stopAllSounds()");
+	Debug::debug(Debug::Imuse, "Imuse::stopAllSounds()");
 
 	for (int l = 0; l < MAX_IMUSE_TRACKS + MAX_IMUSE_FADETRACKS; l++) {
 		Track *track = _track[l];

--- a/engines/grim/imuse/imuse_track.cpp
+++ b/engines/grim/imuse/imuse_track.cpp
@@ -20,8 +20,6 @@
  *
  */
 
-#define FORBIDDEN_SYMBOL_EXCEPTION_printf
-
 #include "common/textconsole.h"
 
 #include "engines/grim/debug.h"
@@ -83,8 +81,7 @@ bool Imuse::startSound(const char *soundName, int volGroupId, int hookId, int vo
 	for (i = 0; i < MAX_IMUSE_TRACKS + MAX_IMUSE_FADETRACKS; i++) {
 		// Filenames are case insensitive, see findTrack
 		if (!scumm_stricmp(_track[i]->soundName, soundName)) {
-			if (gDebugLevel == DEBUG_IMUSE || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-				printf("Imuse::startSound(): Track '%s' already playing.\n", soundName);
+			Debug::debug(Debug::Imuse, "Imuse::startSound(): Track '%s' already playing.", soundName);
 			return true;
 		}
 	}

--- a/engines/grim/keyframe.cpp
+++ b/engines/grim/keyframe.cpp
@@ -47,13 +47,7 @@ KeyframeAnim::KeyframeAnim(const Common::String &fname, const char *data, int le
 void KeyframeAnim::loadBinary(const char *data, int len) {
 	// First four bytes are the FYEK Keyframe identifier code
 	// Next 36 bytes are the filename
-	if (gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL) {
-		char filebuf[37];
-
-		memcpy(filebuf, data + 4, 36);
-		filebuf[36] = 0;
-		printf("Loading Keyframe '%s'.", filebuf);
-	}
+	Debug::debug(Debug::Keyframes, "Loading Keyframe '%s'.", _fname.c_str());
 	// Next four bytes are the flags
 	_flags = READ_LE_UINT32(data + 40);
 	// Next four bytes are a duplicate of _numJoints (?)
@@ -98,9 +92,7 @@ void KeyframeAnim::loadBinary(const char *data, int len) {
 		// else is still wrong but it should now load correctly in
 		// all cases
 		if (nodeNum >= _numJoints) {
-			if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL) {
-				warning("A node number was greater than the maximum number of nodes (%d/%d)", nodeNum, _numJoints);
-			}
+			Debug::warning(Debug::Keyframes, "A node number was greater than the maximum number of nodes (%d/%d)", nodeNum, _numJoints);
 			return;
 		}
 		if (_nodes[nodeNum]) {

--- a/engines/grim/lua/lstate.cpp
+++ b/engines/grim/lua/lstate.cpp
@@ -206,7 +206,7 @@ void lua_open() {
 	luaT_init();
 	luaB_predefine();
 	luaL_addlibtolist(stdErrorRimFunc, (sizeof(stdErrorRimFunc) / sizeof(stdErrorRimFunc[0])));
-	if (gDebugLevel == DEBUG_LUA || gDebugLevel == DEBUG_ALL)
+	if (Debug::isChannelEnabled(Debug::Lua))
 		lua_callhook = callHook;
 }
 

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -150,41 +150,41 @@ void L1_new_dofile() {
 // Debugging message functions
 
 void L1_PrintDebug() {
-	if (gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL) {
+	if (Debug::isChannelEnabled(Debug::Scripts | Debug::Info)) {
 		Common::String msg("Debug: ");
 		lua_Object strObj = lua_getparam(1);
 		if (lua_isnil(strObj))
 			msg += "(nil)";
 		if (!lua_isstring(strObj))
 			return;
-		msg += Common::String(lua_getstring(strObj)) + "\n";
-		printf("%s", msg.c_str());
+		msg += Common::String(lua_getstring(strObj));
+		debug(msg.c_str());
 	}
 }
 
 void L1_PrintError() {
-	if (gDebugLevel == DEBUG_ERROR || gDebugLevel == DEBUG_ALL) {
+	if (Debug::isChannelEnabled(Debug::Scripts | Debug::Info)) {
 		Common::String msg("Error: ");
 		lua_Object strObj = lua_getparam(1);
 		if (lua_isnil(strObj))
 			msg += "(nil)";
 		if (!lua_isstring(strObj))
 			return;
-		msg += Common::String(lua_getstring(strObj)) + "\n";
-		printf("%s", msg.c_str());
+		msg += Common::String(lua_getstring(strObj));
+		debug(msg.c_str());
 	}
 }
 
 void L1_PrintWarning() {
-	if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL) {
+	if (Debug::isChannelEnabled(Debug::Scripts | Debug::Info)) {
 		Common::String msg("Warning: ");
 		lua_Object strObj = lua_getparam(1);
 		if (lua_isnil(strObj))
 			msg += "(nil)";
 		if (!lua_isstring(strObj))
 			return;
-		msg += Common::String(lua_getstring(strObj)) + "\n";
-		printf("%s", msg.c_str());
+		msg += Common::String(lua_getstring(strObj));
+		debug(msg.c_str());
 	}
 }
 
@@ -685,8 +685,7 @@ void L1_MakeCurrentSet() {
 	}
 
 	const char *name = lua_getstring(nameObj);
-	if (gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-		printf("Entered new scene '%s'.\n", name);
+	Debug::debug(Debug::Engine, "Entered new scene '%s'.", name);
 	g_grim->setSet(name);
 }
 
@@ -1169,13 +1168,11 @@ void L1_LightMgrStartup() {
 }
 
 void L1_JustLoaded() {
-	if (gDebugLevel == DEBUG_ERROR || gDebugLevel == DEBUG_ALL)
-		error("OPCODE USAGE VERIFICATION: JustLoaded");
+	Debug::error("OPCODE USAGE VERIFICATION: JustLoaded");
 }
 
 void L1_SetEmergencyFont() {
-	if (gDebugLevel == DEBUG_ERROR || gDebugLevel == DEBUG_ALL)
-		error("OPCODE USAGE VERIFICATION: SetEmergencyFont");
+	Debug::error("OPCODE USAGE VERIFICATION: SetEmergencyFont");
 }
 
 void L1_typeOverride() {

--- a/engines/grim/lua_v1_sound.cpp
+++ b/engines/grim/lua_v1_sound.cpp
@@ -90,8 +90,7 @@ void L1_ImSetVoiceEffect() {
 	const char *effectName;
 
 	effectName = luaL_check_string(1);
-	if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-		warning("ImSetVoiceEffect(%s) Voice effects are not yet supported", effectName);
+	Debug::warning(Debug::Imuse, "ImSetVoiceEffect(%s) Voice effects are not yet supported", effectName);
 }
 
 void L1_ImSetMusicVol() {

--- a/engines/grim/material.cpp
+++ b/engines/grim/material.cpp
@@ -67,8 +67,7 @@ void MaterialData::initGrim(const Common::String &filename, const char *data, in
 		t->_height = READ_LE_UINT32(data + 4);
 		t->_hasAlpha = READ_LE_UINT32(data + 8);
 		if (t->_width == 0 || t->_height == 0) {
-			if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-				warning("skip load texture: bad texture size (%dx%d) for texture %d of material %s",
+			Debug::warning(Debug::Materials, "skip load texture: bad texture size (%dx%d) for texture %d of material %s",
 						t->_width, t->_height, i, _fname.c_str());
 			break;
 		}

--- a/engines/grim/model.cpp
+++ b/engines/grim/model.cpp
@@ -241,8 +241,8 @@ void Model::loadText(TextSplitter *ts, CMap *cmap) {
 		_rootHierNode[num]._sprite = NULL;
 	}
 
-	if (!ts->isEof() && (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL))
-		warning("Unexpected junk at end of model text");
+	if (!ts->isEof())
+		Debug::warning(Debug::Models, "Unexpected junk at end of model text");
 }
 
 void Model::draw() const {

--- a/engines/grim/module.mk
+++ b/engines/grim/module.mk
@@ -46,6 +46,7 @@ MODULE_OBJS := \
 	costume.o \
 	color.o \
 	colormap.o \
+	debug.o \
 	detection.o \
 	font.o \
 	gfx_base.o \

--- a/engines/grim/movie/codecs/smush_decoder.cpp
+++ b/engines/grim/movie/codecs/smush_decoder.cpp
@@ -159,13 +159,11 @@ void SmushDecoder::handleFrame() {
 			//  MakeAnim animation type 'Bl16' parameters: 6000;8000;100;0;0;0;0;0;2;0;
 			//  Lola engine room (loops a limited number of times?):
 			//  MakeAnim animation type 'Bl16' parameters: 6000;8000;90;1;0;0;0;0;2;0;
-			if (gDebugLevel == DEBUG_MOVIE || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-				debug("Announcement data: %s\n", anno);
+			Debug::debug(Debug::Movie, "Announcement data: %s\n", anno);
 			// It looks like the announcement data is actually for setting some of the
 			// header parameters, not for any looping purpose
 		} else {
-			if (gDebugLevel == DEBUG_MOVIE || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-				debug("Announcement header not understood: %s\n", anno);
+			Debug::debug(Debug::Movie, "Announcement header not understood: %s\n", anno);
 		}
 		delete[] anno;
 		tag = _file->readUint32BE();
@@ -187,8 +185,8 @@ void SmushDecoder::handleFrame() {
 			else
 				handleWave(frame + pos + 8 + 4, decompressed_size);
 			pos += READ_BE_UINT32(frame + pos + 4) + 8;
-		} else if (gDebugLevel == DEBUG_MOVIE || gDebugLevel == DEBUG_ERROR || gDebugLevel == DEBUG_ALL) {
-			error("SmushDecoder::handleFrame() unknown tag");
+		} else {
+			Debug::error(Debug::Movie, "SmushDecoder::handleFrame() unknown tag");
 		}
 	} while (pos < size);
 	delete[] frame;
@@ -445,7 +443,7 @@ bool SmushDecoder::setupAnim() {
 
 	flags = READ_LE_UINT16(s_header + 18);
 	// Output information for checking out the flags
-	if (gDebugLevel == DEBUG_MOVIE || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL) {
+	if (Debug::isChannelEnabled(Debug::Movie | Debug::Info)) {
 		warning("SMUSH Flags:");
 		for (int i = 0; i < 16; i++)
 			warning(" %d", (flags & (1 << i)) != 0);

--- a/engines/grim/movie/movie.cpp
+++ b/engines/grim/movie/movie.cpp
@@ -136,8 +136,7 @@ bool MoviePlayer::play(Common::String filename, bool looping, int x, int y) {
 	if (!loadFile(_fname))
 		return false;
 
-	if (gDebugLevel == DEBUG_MOVIE)
-		warning("Playing video '%s'.\n", filename.c_str());
+	Debug::debug(Debug::Movie, "Playing video '%s'.\n", filename.c_str());
 
 	init();
 

--- a/engines/grim/sector.cpp
+++ b/engines/grim/sector.cpp
@@ -128,8 +128,8 @@ void Sector::load(TextSplitter &ts) {
 		_type = SpecialType;
 	else if (strstr(buf, "chernobyl"))
 		_type = HotType;
-	else if (gDebugLevel == DEBUG_ERROR || gDebugLevel == DEBUG_ALL)
-		error("Unknown sector type '%s' in room setup", buf);
+	else
+		Debug::error(Debug::Sets, "Unknown sector type '%s' in room setup", buf);
 
 	ts.scanString(" default visibility %256s", 1, buf);
 	if (strcmp(buf, "visible") == 0)

--- a/engines/grim/set.cpp
+++ b/engines/grim/set.cpp
@@ -362,11 +362,11 @@ void Set::Setup::load(TextSplitter &ts) {
 	ts.scanString(" background %256s", 1, buf);
 	_bkgndBm = g_resourceloader->loadBitmap(buf);
 	if (!_bkgndBm) {
-		if (gDebugLevel == DEBUG_BITMAPS || gDebugLevel == DEBUG_ERROR || gDebugLevel == DEBUG_ALL)
-			warning("Unable to load scene bitmap: %s\n", buf);
+		Debug::warning(Debug::Bitmaps | Debug::Sets,
+					   "Unable to load scene bitmap: %s\n", buf);
 	} else {
-		if (gDebugLevel == DEBUG_BITMAPS || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-			warning("Loaded scene bitmap: %s\n", buf);
+		Debug::debug(Debug::Bitmaps | Debug::Sets,
+					 "Loaded scene bitmap: %s\n", buf);
 	}
 
 	// ZBuffer is optional
@@ -376,8 +376,8 @@ void Set::Setup::load(TextSplitter &ts) {
 		// Don't even try to load if it's the "none" bitmap
 		if (strcmp(buf, "<none>.lbm") != 0) {
 			_bkgndZBm = g_resourceloader->loadBitmap(buf);
-			if (gDebugLevel == DEBUG_BITMAPS || gDebugLevel == DEBUG_NORMAL || gDebugLevel == DEBUG_ALL)
-				printf("Loading scene z-buffer bitmap: %s\n", buf);
+			Debug::debug(Debug::Bitmaps | Debug::Sets,
+						 "Loading scene z-buffer bitmap: %s\n", buf);
 		}
 	}
 
@@ -579,8 +579,7 @@ ObjectState *Set::findState(const char *filename) {
 		if (file == filename)
 			return *i;
 		if (file.compareToIgnoreCase(filename) == 0) {
-			if (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL)
-				warning("State object request '%s' matches object '%s' but is the wrong case", filename, file.c_str());
+			Debug::warning(Debug::Sets, "State object request '%s' matches object '%s' but is the wrong case", filename, file.c_str());
 			return *i;
 		}
 	}

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -327,7 +327,7 @@ void TextObject::draw() {
 		_created = true;
 	}
 
-	if ((_justify > 3 || _justify < 0) && (gDebugLevel == DEBUG_WARN || gDebugLevel == DEBUG_ALL))
+	if (_justify > 3 || _justify < 0)
 		warning("TextObject::draw: Unknown justification code (%d)", _justify);
 
 	g_driver->drawTextObject(this);


### PR DESCRIPTION
This is a reboost of the debug system, using debug channels (passing them with the option --debugflags=whatever at command line) and some convenience functions.
There is only one thing i'm unsure with: the name of the function Debug::error(const char *s, ...) doesn't make clear that it prints only if the channel Error is active.

Thoughts?
