### PR TITLE
SDL: Fixed antialiasing fallback for less tolerant OpenGL drivers. Fix #407

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -104,6 +104,12 @@ protected:
 	GLuint *_overlayTexIds;
 #endif
 
+#ifdef USE_OPENGL
+	// Antialiasing
+	int _antialiasing;
+	void setAntialiasing(bool enable);
+#endif
+
 	/** Force full redraw on next updateScreen */
 	bool _forceFull;
 


### PR DESCRIPTION
It's still not a perfect solution, but at least it provides some kind of fallback on Linux as mentioned in bug #407 (and possibly on some other drivers) if the selected antialiasing mode is not supported. It also tries to apply AA if it falls back to 16-bit mode.

If the selected 32-bit with AA is not supported, it tries 32-bit without AA, then 16-bit with AA, then 16-bit without AA as a last resort.
