### PR TITLE
GRIM: Fix a leak when loading savegames

### DIFF
--- a/engines/grim/savegame.cpp
+++ b/engines/grim/savegame.cpp
@@ -85,11 +85,11 @@ SaveGame::~SaveGame() {
 		_outSaveFile->finalize();
 		if (_outSaveFile->err())
 			warning("SaveGame::~SaveGame() Can't write file. (Disk full?)");
-		free(_sectionBuffer);
 		delete _outSaveFile;
 	} else {
 		delete _inSaveFile;
 	}
+	free(_sectionBuffer);
 }
 
 int SaveGame::saveVersion() const {
@@ -113,7 +113,11 @@ uint32 SaveGame::beginSection(uint32 sectionTag) {
 			_sectionSize = _inSaveFile->readUint32BE();
 			_inSaveFile->seek(_sectionSize, SEEK_CUR);
 		}
-		_sectionBuffer = (byte *)malloc(_sectionSize);
+		if (!_sectionBuffer || _sectionAlloc < _sectionSize) {
+			_sectionAlloc = _sectionSize;
+			_sectionBuffer = (byte *)realloc(_sectionBuffer, _sectionAlloc);
+		}
+
 		_inSaveFile->seek(-(int32)_sectionSize, SEEK_CUR);
 		_inSaveFile->read(_sectionBuffer, _sectionSize);
 


### PR DESCRIPTION
An additional improvement is that when a savegame is loaded, it does not malloc the memory for each section, but instead just realloc's the memory when the next section is larger than what was loaded before.
