### PR TITLE
GRIM: Fix some issues with text objects. Fixes #440, #441

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -852,6 +852,13 @@ void Actor::sayLine(const char *msgId, bool background) {
 	}
 }
 
+void Actor::lineCleanup() {
+	if (_sayLineText) {
+		delete TextObject::getPool().getObject(_sayLineText);
+		_sayLineText = 0;
+	}
+}
+
 bool Actor::isTalking() {
 	// If there's no sound file then we're obviously not talking
 	GrimEngine::SpeechMode m = g_grim->getSpeechMode();

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -371,7 +371,7 @@ public:
 	void sayLine(const char *msgId, bool background);
 	// When we clean all text objects we don't want the actors to clean their
 	// objects again since they're already freed
-	void lineCleanup() { _sayLineText = 0; }
+	void lineCleanup();
 	/**
 	 * Makes the actor discard any subtitle and voice.
 	 *

--- a/engines/grim/lua_v1_text.cpp
+++ b/engines/grim/lua_v1_text.cpp
@@ -136,11 +136,6 @@ void Lua_V1::GetTextObjectDimensions() {
 }
 
 void Lua_V1::ExpireText() {
-	// Expire all the text objects
-	foreach (TextObject *t, TextObject::getPool()) {
-		t->setDisabled(true);
-	}
-
 	// Cleanup actor references to deleted text objects
 	foreach (Actor *a, Actor::getPool()) {
 		a->lineCleanup();

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -51,7 +51,9 @@ TextObject::TextObject() :
 
 TextObject::~TextObject() {
 	delete[] _lines;
-	g_driver->destroyTextObject(this);
+	if (_created) {
+		g_driver->destroyTextObject(this);
+	}
 }
 
 void TextObject::setText(const Common::String &text) {


### PR DESCRIPTION
Expire text should only be removing the text that actors are saying and not the other text objects.

Also make sure that a text object has been setup and don't incorrectly destroy it if it has not been.
