### PR TITLE
BUILD: fix iphone build

### DIFF
--- a/ports.mk
+++ b/ports.mk
@@ -74,7 +74,7 @@ endif
 	$(STRIP) residualvm
 	ldid -S residualvm
 	chmod 755 residualvm
-	cp residual $(bundle_name)/ResidualVM
+	cp residualvm $(bundle_name)/ResidualVM
 	cp $(srcdir)/dists/iphone/icon.png $(bundle_name)/
 	cp $(srcdir)/dists/iphone/icon-72.png $(bundle_name)/
 	cp $(srcdir)/dists/iphone/Default.png $(bundle_name)/


### PR DESCRIPTION
there is still a lonely "residual" in the ports.mk file. This pull request corrects it
