### PR TITLE
GRIM: Wrap file streams in a compressed read stream whenever needed

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -23,8 +23,6 @@
 #define FORBIDDEN_SYMBOL_EXCEPTION_printf
 
 #include "common/endian.h"
-#include "common/zlib.h"
-#include "common/memstream.h"
 
 #include "engines/grim/debug.h"
 #include "engines/grim/grim.h"
@@ -118,10 +116,7 @@ BitmapData::BitmapData(const Common::String &fname, Common::SeekableReadStream *
 		case(MKTAG('B','M',' ',' ')):				//Grim bitmap
 			loadGrimBm(fname, data);
 			break;
-		case(MKTAG('\x1f','\x8b','\x08','\0')):		// MI4 bitmap
-			loadTile(fname, data);
-			break;
-		case(529205248): // FIXME, this is the value MKTAG should create
+		case(MKTAG('T','I','L','0')):				// MI4 bitmap
 			loadTile(fname, data);
 			break;
 		default:
@@ -223,7 +218,7 @@ BitmapData::BitmapData(const char *data, int w, int h, int bpp, const char *fnam
 }
 
 BitmapData::BitmapData() :
-	_numImages(0), _width(0), _height(0), _x(0), _y(0), _format(0), _numTex(0), 
+	_numImages(0), _width(0), _height(0), _x(0), _y(0), _format(0), _numTex(0),
 	_bpp(0), _colorFormat(0), _texIds(0), _hasTransparency(false), _data(NULL), _refCount(1) {
 }
 
@@ -249,14 +244,13 @@ BitmapData::~BitmapData() {
 	}
 }
 
-bool BitmapData::loadTile(const Common::String &fname, Common::SeekableReadStream *data) {
+bool BitmapData::loadTile(const Common::String &fname, Common::SeekableReadStream *o) {
 #ifdef ENABLE_MONKEY4
 	_x = 0;
 	_y = 0;
 	_format = 1;
-	data->seek(0, SEEK_SET);
+	o->seek(0, SEEK_SET);
 	//warning("Loading TILE: %s",fname.c_str());
-	Common::SeekableReadStream *o = Common::wrapCompressedReadStream(data);
 
 	uint32 id, bmoffset;
 	id = o->readUint32LE();

--- a/engines/grim/movie/codecs/smush_decoder.cpp
+++ b/engines/grim/movie/codecs/smush_decoder.cpp
@@ -26,7 +26,6 @@
 #include "common/rational.h"
 #include "common/system.h"
 #include "common/timer.h"
-#include "common/zlib.h"
 
 #include "audio/audiostream.h"
 #include "audio/mixer.h"
@@ -458,13 +457,13 @@ bool SmushDecoder::setupAnim() {
 bool SmushDecoder::loadStream(Common::SeekableReadStream *stream) {
 	close();
 
+	_file = stream;
+
 	// Load the video
 	if (_demo) {
-		_file = stream;
 		if (!setupAnimDemo())
 			return false;
 	} else {
-		_file = wrapCompressedReadStream(stream);
 		if (!setupAnim())
 			return false;
 

--- a/engines/grim/resource.cpp
+++ b/engines/grim/resource.cpp
@@ -38,6 +38,7 @@
 #include "engines/grim/debug.h"
 #include "engines/grim/patchr.h"
 #include "common/algorithm.h"
+#include "common/zlib.h"
 #include "gui/message.h"
 
 namespace Grim {
@@ -229,12 +230,13 @@ Common::SeekableReadStream *ResourceLoader::openNewStreamFile(Common::String fna
 			byte *buf = new byte[size];
 			s->read(buf, size);
 			putIntoCache(fname, buf, size);
-			return new Common::MemoryReadStream(buf, size);
-		} else
-			return s;
+			s = new Common::MemoryReadStream(buf, size);
+		}
+	} else {
+		s = loadFile(fname);
 	}
-
-	return loadFile(fname);
+	// This will only have an effect if the stream is actually compressed.
+	return Common::wrapCompressedReadStream(s);
 }
 
 void ResourceLoader::putIntoCache(const Common::String &fname, byte *res, uint32 len) {


### PR DESCRIPTION
This makes is so separate components do not need to worry about compression. This also helps with EMI texture loading as the demo has uncompressed textures and the full windows version has them compressed. 
