### PR TITLE
GRIM: Add support for live switching of gfx engines

### DIFF
--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -39,7 +39,7 @@ Font::Font(const Common::String &filename, Common::SeekableReadStream *data) :
 }
 
 Font::Font() :
-		PoolObject<Font, MKTAG('F', 'O', 'N', 'T')>() {
+		PoolObject<Font, MKTAG('F', 'O', 'N', 'T')>(), _userData(0) {
 	_charIndex = NULL;
 }
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -173,14 +173,7 @@ GrimEngine::~GrimEngine() {
 	delete[] _controlsEnabled;
 	delete[] _controlsState;
 
-	Set::getPool().deleteObjects();
-	Actor::getPool().deleteObjects();
-	PrimitiveObject::getPool().deleteObjects();
-	TextObject::getPool().deleteObjects();
-	Bitmap::getPool().deleteObjects();
-	Font::getPool().deleteObjects();
-	ObjectState::getPool().deleteObjects();
-	PoolColor::getPool().deleteObjects();
+	clearPools();
 
 	delete LuaBase::instance();
 	if (g_registry) {
@@ -199,6 +192,19 @@ GrimEngine::~GrimEngine() {
 	delete g_driver;
 	g_driver = NULL;
 	delete _iris;
+}
+
+void GrimEngine::clearPools() {
+	Set::getPool().deleteObjects();
+	Actor::getPool().deleteObjects();
+	PrimitiveObject::getPool().deleteObjects();
+	TextObject::getPool().deleteObjects();
+	Bitmap::getPool().deleteObjects();
+	Font::getPool().deleteObjects();
+	ObjectState::getPool().deleteObjects();
+	PoolColor::getPool().deleteObjects();
+
+	_currSet = NULL;
 }
 
 Common::Error GrimEngine::run() {
@@ -424,7 +430,7 @@ void GrimEngine::playIrisAnimation(Iris::Direction dir, int x, int y, int time) 
 }
 
 void GrimEngine::luaUpdate() {
-	if (_savegameLoadRequest || _savegameSaveRequest)
+	if (_savegameLoadRequest || _savegameSaveRequest || _changeHardwareState)
 		return;
 
 	// Update timing information
@@ -598,6 +604,7 @@ void GrimEngine::mainLoop() {
 	_refreshShadowMask = false;
 	_shortFrame = false;
 	bool resetShortFrame = false;
+	_changeHardwareState = false;
 
 	for (;;) {
 		uint32 startTime = g_system->getMillis();
@@ -613,6 +620,33 @@ void GrimEngine::mainLoop() {
 		}
 		if (_savegameSaveRequest) {
 			savegameSave();
+		}
+
+		if (_changeHardwareState) {
+			_changeHardwareState = false;
+
+			EngineMode mode = getMode();
+
+			savegameSave();
+			clearPools();
+
+			delete g_driver;
+			if (tolower(g_registry->get("soft_renderer", "false")[0]) == 't') {
+				g_driver = CreateGfxTinyGL();
+			} else {
+				g_driver = CreateGfxOpenGL();
+			}
+
+			g_driver->setupScreen(640, 480, false);
+			savegameRestore();
+
+			if (mode == DrawMode) {
+				setMode(GrimEngine::NormalMode);
+				updateDisplayScene();
+				g_driver->storeDisplay();
+				g_driver->dimScreen();
+			}
+			setMode(mode);
 		}
 
 		g_imuse->flushTracks();
@@ -671,6 +705,10 @@ void GrimEngine::mainLoop() {
 			g_system->delayMillis(delayTime);
 		}
 	}
+}
+
+void GrimEngine::changeHardwareState() {
+	_changeHardwareState = true;
 }
 
 void GrimEngine::saveGame(const Common::String &file) {

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -81,6 +81,8 @@ public:
 	GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, Common::Platform platform, Common::Language language);
 	virtual ~GrimEngine();
 
+	void clearPools();
+
 	int getGameFlags() { return _gameFlags; }
 	GrimGameType getGameType() { return _gameType; }
 	Common::Language getGameLanguage() { return _gameLanguage; }
@@ -148,6 +150,8 @@ public:
 	void saveGame(const Common::String &file);
 	void loadGame(const Common::String &file);
 
+	void changeHardwareState();
+
 	Common::StringArray _listFiles;
 	Common::StringArray::const_iterator _listFilesIter;
 
@@ -197,6 +201,8 @@ private:
 
 	bool *_controlsEnabled;
 	bool *_controlsState;
+
+	bool _changeHardwareState;
 
 	Actor *_selectedActor;
 	Actor *_talkingActor;

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -294,6 +294,7 @@ void Lua_V1::SetHardwareState() {
 		g_registry->set("soft_renderer", "false");
 	else
 		g_registry->set("soft_renderer", "true");
+	g_grim->changeHardwareState();
 }
 
 void Lua_V1::SetVideoDevices() {

--- a/engines/grim/movie/movie.cpp
+++ b/engines/grim/movie/movie.cpp
@@ -85,7 +85,9 @@ bool MoviePlayer::prepareFrame() {
 		return false;
 
 	if (_videoFinished) {
-		g_grim->setMode(GrimEngine::NormalMode);
+		if (g_grim->getMode() == GrimEngine::SmushMode) {
+			g_grim->setMode(GrimEngine::NormalMode);
+		}
 		_videoPause = true;
 		return false;
 	}


### PR DESCRIPTION
Not all that efficient as it saves the game and then loads it right away, but it still could be useful for testing.
