### PR TITLE
EMI: Implement sleep_for in the engine

### DIFF
--- a/engines/grim/lua/lbuiltin.cpp
+++ b/engines/grim/lua/lbuiltin.cpp
@@ -512,6 +512,7 @@ static struct luaL_reg int_funcs[] = {
 	{ "pause_scripts", pause_scripts },
 	{ "unpause_scripts", unpause_scripts },
 	{ "find_script", find_script },
+	{ "sleep_for", sleep_for },
 	{ "break_here", break_here }
 };
 

--- a/engines/grim/lua/lbuiltin.h
+++ b/engines/grim/lua/lbuiltin.h
@@ -15,6 +15,7 @@ void find_script();
 void identify_script();
 void next_script();
 void break_here();
+void sleep_for();
 void pause_scripts();
 void unpause_scripts();
 

--- a/engines/grim/lua/ldo.cpp
+++ b/engines/grim/lua/ldo.cpp
@@ -281,7 +281,7 @@ int32 luaD_call(StkId base, int32 nResults) {
 				base = lua_state->task->some_base;
 			}
 
-			if (function == break_here) {
+			if (function == break_here || function == sleep_for) {
 				if (!lua_state->state_counter1)  {
 					lua_state->some_task = tmpTask;
 					return 1;

--- a/engines/grim/lua/lstate.cpp
+++ b/engines/grim/lua/lstate.cpp
@@ -92,6 +92,7 @@ void lua_stateinit(LState *state) {
 	state->task = NULL;
 	state->some_task = NULL;
 	state->taskFunc.ttype = LUA_T_NIL;
+	state->sleepFor = 0;
 
 	state->stack.stack = luaM_newvector(STACK_UNIT, TObject);
 	state->stack.top = state->stack.stack;

--- a/engines/grim/lua/lstate.h
+++ b/engines/grim/lua/lstate.h
@@ -90,6 +90,7 @@ struct LState {
 	TObject	taskFunc;
 	struct C_Lua_Stack Cblocks[MAX_C_BLOCKS];
 	int numCblocks; // number of nested Cblocks
+	int sleepFor;
 };
 
 extern LState *lua_state, *lua_rootState;

--- a/engines/grim/lua/ltask.cpp
+++ b/engines/grim/lua/ltask.cpp
@@ -243,6 +243,15 @@ void current_script() {
 
 void break_here() {}
 
+void sleep_for() {
+	lua_Object msObj = lua_getparam(1);
+
+	if (lua_isnumber(msObj)) {
+		int ms = (int)lua_getnumber(msObj);
+		lua_state->sleepFor = ms;
+	}
+}
+
 void lua_runtasks() {
 	if (!lua_state || !lua_state->next) {
 		return;
@@ -251,7 +260,11 @@ void lua_runtasks() {
 	// Mark all the states to be updated
 	LState *state = lua_state->next;
 	do {
-		state->updated = false;
+		if (state->sleepFor > 0) {
+			state->sleepFor -= g_grim->getFrameTime();
+		} else {
+			state->updated = false;
+		}
 		state = state->next;
 	} while	(state);
 

--- a/engines/grim/lua/ltask.h
+++ b/engines/grim/lua/ltask.h
@@ -32,6 +32,7 @@ void pause_scripts();
 void unpause_scripts();
 void find_script();
 void break_here();
+void sleep_for();
 
 void runtasks(LState *const rootState);
 

--- a/engines/grim/lua_v2.cpp
+++ b/engines/grim/lua_v2.cpp
@@ -73,16 +73,6 @@ void Lua_V2::UndimRegion() {
 	}
 }
 
-void Lua_V2::SleepFor() {
-	lua_Object msObj = lua_getparam(1);
-
-	if (lua_isnumber(msObj)) {
-		int ms = (int)lua_getnumber(msObj);
-		// FIXME func(ms);
-		warning("Lua_V2::SleepFor: ms: %d", ms);
-	}
-}
-
 void Lua_V2::DimScreen() {
 	lua_Object dimObj = lua_getparam(1);
 	float dim = 0.6999f;
@@ -1046,8 +1036,7 @@ struct luaL_reg monkeyMainOpcodes[] = {
 	{ "SectEditSortAdd", LUA_OPCODE(Lua_V2, SectEditSortAdd) },
 	{ "SectEditForgetIt", LUA_OPCODE(Lua_V2, SectEditForgetIt) },
 	{ "FRUTEY_Begin", LUA_OPCODE(Lua_V2, FRUTEY_Begin) },
-	{ "FRUTEY_End", LUA_OPCODE(Lua_V2, FRUTEY_End) },
-	{ "sleep_for", LUA_OPCODE(Lua_V2, SleepFor) }
+	{ "FRUTEY_End", LUA_OPCODE(Lua_V2, FRUTEY_End) }
 };
 
 void Lua_V2::registerOpcodes() {


### PR DESCRIPTION
I don't know if this is the best way to do it, but it is the best way I could come up with. 

In Grim sleep_for is defined in _system.lua but it is not in EMI. What sleep_for does is just sleep the current coroutine for a given amount of milliseconds. The way grim does it is by calling break_here in a busy loop. This essentially does the same thing as that.

If anyone knows of a better way to do this that would be awesome.
