### PR TITLE
GRIM/GFX: Make OpenGL scalable and resolution-independent.

### DIFF
--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -226,6 +226,9 @@ public:
 	void renderZBitmaps(bool render);
 
 protected:
+	static const int _gameHeight = 480;
+	static const int _gameWidth = 640;
+	float _scaleW, _scaleH;
 	int _screenWidth, _screenHeight, _screenSize;
 	bool _isFullscreen;
 	Shadow *_currentShadowArray;


### PR DESCRIPTION
Mostly a pull request intended for review of the idea.

This pull-request adds scaling-support to the gfx_opengl-backend for GRIM, currently there are no plans of giving user-access to this, but it atleast shows the engine to be resolution-agnostic.

Known issues:
Copal's computer will have pin-stripes instead of a filled background for selection (probably something with glLineWidth that I didn't get down correctly).

For testing, simply set screenW and screenH to appropriate values in setupScreen in gfx_opengl.cpp.
