### PR TITLE
GRIM: Enhance the way that colors are given to lua.

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -51,7 +51,7 @@ namespace Grim {
 
 Actor::Actor(const Common::String &actorName) :
 		PoolObject<Actor, MKTAG('A', 'C', 'T', 'R')>(), _name(actorName), _setName(""),
-		_talkColor(PoolColor::getPool().getObject(2)), _pos(0, 0, 0),
+		_talkColor(255, 255, 255), _pos(0, 0, 0),
 		// Some actors don't set walk and turn rates, so we default the
 		// _turnRate so Doug at the cat races can turn and we set the
 		// _walkRate so Glottis at the demon beaver entrance can walk and
@@ -121,11 +121,9 @@ void Actor::saveState(SaveGame *savedState) const {
 	savedState->writeString(_name);
 	savedState->writeString(_setName);
 
-	if (_talkColor) {
-		savedState->writeLEUint32(_talkColor->getId());
-	} else {
-		savedState->writeLEUint32(0);
-	}
+	//SAVECHANGE: Remove the next line
+	savedState->writeByte(0);
+	savedState->writeColor(_talkColor);
 
 	savedState->writeVector3d(_pos);
 
@@ -242,7 +240,9 @@ bool Actor::restoreState(SaveGame *savedState) {
 	_name = savedState->readString();
 	_setName = savedState->readString();
 
-	_talkColor = PoolColor::getPool().getObject(savedState->readLEUint32());
+	//SAVECHANGE: Remove the next line
+	savedState->readByte();
+	_talkColor = savedState->readColor();
 
 	_pos                = savedState->readVector3d();
 	_pitch              = savedState->readFloat();

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -25,6 +25,7 @@
 
 #include "engines/grim/pool.h"
 #include "engines/grim/object.h"
+#include "engines/grim/color.h"
 #include "math/vector3d.h"
 #include "math/angle.h"
 
@@ -35,7 +36,6 @@ class Sector;
 class Costume;
 class LipSync;
 class Font;
-class PoolColor;
 class Set;
 
 struct Plane {
@@ -110,13 +110,13 @@ public:
 	 * @param color The color.
 	 * @see getTalkColor
 	 */
-	void setTalkColor(PoolColor *color) { _talkColor = color; }
+	void setTalkColor(const Color &color) { _talkColor = color; }
 	/**
 	 * Returns the color of the subtitles of the actor.
 	 *
 	 * @see setTalkColor
 	 */
-	PoolColor *getTalkColor() const { return _talkColor; }
+	Color getTalkColor() const { return _talkColor; }
 
 	/**
 	 * Sets the position of the actor on the 3D scene.
@@ -475,7 +475,7 @@ private:
 	Common::String _name;
 	Common::String _setName;    // The actual current set
 
-	PoolColor *_talkColor;
+	Color _talkColor;
 	Math::Vector3d _pos;
 	Math::Angle _pitch, _yaw, _roll;
 	float _walkRate, _turnRate;

--- a/engines/grim/color.cpp
+++ b/engines/grim/color.cpp
@@ -41,6 +41,18 @@ Color::Color(const Color& c) {
 	_vals[2] = c._vals[2];
 }
 
+Color::Color(uint32 c) {
+	_vals[0] = (c >> 16) & 0xFF;
+	_vals[1] = (c >> 8) & 0xFF;
+	_vals[2] = c & 0xFF;
+}
+
+uint32 Color::toEncodedValue() {
+	return	(_vals[0] << 16) |
+			(_vals[1] << 8 ) |
+			 _vals[2];
+}
+
 Color& Color::operator =(const Color &c) {
 	_vals[0] = c._vals[0];
 	_vals[1] = c._vals[1];
@@ -53,30 +65,6 @@ Color& Color::operator =(Color *c) {
 	_vals[1] = c->_vals[1];
 	_vals[2] = c->_vals[2];
 	return *this;
-}
-
-
-
-PoolColor::PoolColor() :
-	PoolObject<PoolColor, MKTAG('C', 'O', 'L', 'R')>(), Color() {
-
-}
-
-PoolColor::PoolColor(byte r, byte g, byte b) :
-	PoolObject<PoolColor, MKTAG('C', 'O', 'L', 'R')>(), Color(r, g, b) {
-
-}
-
-void PoolColor::restoreState(SaveGame *state) {
-	getRed() = state->readByte();
-	getGreen() = state->readByte();
-	getBlue() = state->readByte();
-}
-
-void PoolColor::saveState(SaveGame *state) const {
-	state->writeByte(getRed());
-	state->writeByte(getGreen());
-	state->writeByte(getBlue());
 }
 
 } // end of namespace Grim

--- a/engines/grim/color.h
+++ b/engines/grim/color.h
@@ -34,6 +34,7 @@ public:
 	Color();
 	Color(byte r, byte g, byte b);
 	Color(const Color& c);
+	Color(uint32 c);
 
 	byte &getRed() { return _vals[0]; }
 	byte getRed() const { return _vals[0]; }
@@ -42,18 +43,12 @@ public:
 	byte &getBlue() { return _vals[2]; }
 	byte getBlue() const { return _vals[2]; }
 
+	uint32 toEncodedValue();
+
 	Color& operator =(const Color &c);
 	Color& operator =(Color *c);
 };
 
-class PoolColor : public PoolObject<PoolColor, MKTAG('C', 'O', 'L', 'R')>, public Color {
-public:
-	PoolColor();
-	PoolColor(byte r, byte g, byte b);
-
-	void restoreState(SaveGame *state);
-	void saveState(SaveGame *state) const;
-};
 
 } // end of namespace Grim
 

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -929,10 +929,10 @@ void GfxOpenGL::drawTextObject(TextObject *text) {
 	glEnable(GL_TEXTURE_2D);
 	glDepthMask(GL_FALSE);
 
-	const Color *color = text->getFGColor();
+	const Color &color = text->getFGColor();
 	Font *font = text->getFont();
 
-	glColor3f(color->getRed() / 255.f, color->getGreen() / 255.f, color->getBlue() / 255.f);
+	glColor3f(color.getRed() / 255.f, color.getGreen() / 255.f, color.getBlue() / 255.f);
 	FontUserData *userData = (FontUserData *)font->getUserData();
 	if (!userData)
 		error("Could not get font userdata");
@@ -1362,7 +1362,7 @@ void GfxOpenGL::drawRectangle(PrimitiveObject *primitive) {
 	float x2 = (primitive->getP2().x+1) * _scaleW;
 	float y2 = (primitive->getP2().y+1) * _scaleH;
 
-	const Color &color = *primitive->getColor();
+	const Color color(primitive->getColor());
 
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
@@ -1401,7 +1401,7 @@ void GfxOpenGL::drawLine(PrimitiveObject *primitive) {
 	float x2 = primitive->getP2().x * _scaleW;
 	float y2 = primitive->getP2().y * _scaleH;
 
-	const Color &color = *primitive->getColor();
+	const Color &color = primitive->getColor();
 
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
@@ -1439,7 +1439,7 @@ void GfxOpenGL::drawPolygon(PrimitiveObject *primitive) {
 	float x4 = primitive->getP4().x * _scaleW;
 	float y4 = primitive->getP4().y * _scaleH;
 
-	const Color &color = *primitive->getColor();
+	const Color &color = primitive->getColor();
 
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -834,7 +834,7 @@ void GfxTinyGL::createTextObject(TextObject *text) {
 	int numLines = text->getNumLines();
 	const Common::String *lines = text->getLines();
 	const Font *font = text->getFont();
-	const Color *fgColor = text->getFGColor();
+	const Color &fgColor = text->getFGColor();
 	TextObjectData *userData = new TextObjectData[numLines];
 	text->setUserData(userData);
 	for (int j = 0; j < numLines; j++) {
@@ -871,9 +871,9 @@ void GfxTinyGL::createTextObject(TextObject *text) {
 		Graphics::PixelBuffer buf(_pixelFormat, width * height, DisposeAfterUse::NO);
 
 		uint8 *bitmapData = _textBitmap;
-		uint8 r = fgColor->getRed();
-		uint8 g = fgColor->getGreen();
-		uint8 b = fgColor->getBlue();
+		uint8 r = fgColor.getRed();
+		uint8 g = fgColor.getGreen();
+		uint8 b = fgColor.getBlue();
 		uint32 color = _zb->cmode.RGBToColor(r, g, b);
 
 		if (color == 0xf81f)
@@ -1112,7 +1112,7 @@ void GfxTinyGL::drawRectangle(PrimitiveObject *primitive) {
 	int x2 = primitive->getP2().x;
 	int y2 = primitive->getP2().y;
 
-	const Color &color = *primitive->getColor();
+	const Color &color = primitive->getColor();
 	uint32 c = _pixelFormat.RGBToColor(color.getRed(), color.getGreen(), color.getBlue());
 
 	if (primitive->isFilled()) {
@@ -1147,7 +1147,7 @@ void GfxTinyGL::drawLine(PrimitiveObject *primitive) {
 	int x2 = primitive->getP2().x;
 	int y2 = primitive->getP2().y;
 
-	const Color &color = *primitive->getColor();
+	const Color &color = primitive->getColor();
 
 	if (x2 == x1) {
 		for (int y = y1; y <= y2; y++) {
@@ -1177,7 +1177,7 @@ void GfxTinyGL::drawPolygon(PrimitiveObject *primitive) {
 	float m;
 	int b;
 
-	const Color &color = *primitive->getColor();
+	const Color &color = primitive->getColor();
 	uint32 c = _pixelFormat.RGBToColor(color.getRed(), color.getGreen(), color.getBlue());
 
 	m = (y2 - y1) / (x2 - x1);

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -139,8 +139,7 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 	_fps[0] = 0;
 	_iris = new Iris();
 
-	PoolColor *c = new PoolColor(0, 0, 0);
-	new PoolColor(255, 255, 255); // Default color for actors. Id == 2
+	Color c(0, 0, 0);
 
 	_printLineDefaults.setX(0);
 	_printLineDefaults.setY(100);
@@ -208,7 +207,6 @@ void GrimEngine::clearPools() {
 	Bitmap::getPool().deleteObjects();
 	Font::getPool().deleteObjects();
 	ObjectState::getPool().deleteObjects();
-	PoolColor::getPool().deleteObjects();
 
 	_currSet = NULL;
 }
@@ -764,9 +762,6 @@ void GrimEngine::savegameRestore() {
 	delete _currSet;
 	_currSet = NULL;
 
-	PoolColor::getPool().restoreObjects(_savedState);
-	Debug::debug(Debug::Engine, "Colors restored succesfully.");
-
 	Bitmap::getPool().restoreObjects(_savedState);
 	Debug::debug(Debug::Engine, "Bitmaps restored succesfully.");
 
@@ -831,9 +826,11 @@ void GrimEngine::restoreGRIM() {
 	_talkingActor = Actor::getPool().getObject(_savedState->readLEUint32());
 
 	//TextObject stuff
-	//SAVECHANGE: Remove the next line with the next save version
+	//SAVECHANGE: Remove the next two lines with the next save version
 	_savedState->readLESint32();
-	_sayLineDefaults.setFGColor(PoolColor::getPool().getObject(_savedState->readLEUint32()));
+	_savedState->readByte();
+
+	_sayLineDefaults.setFGColor(_savedState->readColor());
 	_sayLineDefaults.setFont(Font::getPool().getObject(_savedState->readLEUint32()));
 	_sayLineDefaults.setHeight(_savedState->readLESint32());
 	_sayLineDefaults.setJustify(_savedState->readLESint32());
@@ -898,9 +895,6 @@ void GrimEngine::savegameSave() {
 	g_movie->pause(true);
 
 	savegameCallback();
-
-	PoolColor::getPool().saveObjects(_savedState);
-	Debug::debug(Debug::Engine, "Colors saved succesfully.");
 
 	Bitmap::getPool().saveObjects(_savedState);
 	Debug::debug(Debug::Engine, "Bitmaps saved succesfully.");
@@ -969,9 +963,11 @@ void GrimEngine::saveGRIM() {
 	}
 
 	//TextObject stuff
-	//SAVECHANGE: Remove the next line with the next save version
+	//SAVECHANGE: Remove the next two lines with the next save version
 	_savedState->writeLESint32(0);
-	_savedState->writeLEUint32(_sayLineDefaults.getFGColor()->getId());
+	_savedState->writeByte(0);
+
+	_savedState->writeColor(_sayLineDefaults.getFGColor());
 	_savedState->writeLEUint32(_sayLineDefaults.getFont()->getId());
 	_savedState->writeLESint32(_sayLineDefaults.getHeight());
 	_savedState->writeLESint32(_sayLineDefaults.getJustify());

--- a/engines/grim/lua.cpp
+++ b/engines/grim/lua.cpp
@@ -370,8 +370,8 @@ Font *LuaBase::getfont(lua_Object obj) {
 	return Font::getPool().getObject(lua_getuserdata(obj));
 }
 
-PoolColor *LuaBase::getcolor(lua_Object obj) {
-	return PoolColor::getPool().getObject(lua_getuserdata(obj));
+Color LuaBase::getcolor(lua_Object obj) {
+	return Color(lua_getuserdata(obj));
 }
 
 PrimitiveObject *LuaBase::getprimitive(lua_Object obj) {

--- a/engines/grim/lua.h
+++ b/engines/grim/lua.h
@@ -26,13 +26,14 @@
 #include "common/str.h"
 #include "common/list.h"
 
+#include "engines/grim/color.h"
+
 namespace Grim {
 
 typedef uint32 lua_Object; // from lua/lua.h
 
 class Actor;
 class Bitmap;
-class PoolColor;
 class Costume;
 class Font;
 class ObjectState;
@@ -145,7 +146,7 @@ protected:
 	Bitmap *getbitmap(lua_Object obj);
 	TextObject *gettextobject(lua_Object obj);
 	Font *getfont(lua_Object obj);
-	PoolColor *getcolor(lua_Object obj);
+	Color getcolor(lua_Object obj);
 	PrimitiveObject *getprimitive(lua_Object obj);
 	ObjectState *getobjectstate(lua_Object obj);
 

--- a/engines/grim/lua/lstate.cpp
+++ b/engines/grim/lua/lstate.cpp
@@ -166,8 +166,8 @@ void callHook(lua_Function func, const char *filename, int32 line) {
 					Actor *a = Actor::getPool().getObject(lua_getuserdata(lua_getparam(i)));
 					fprintf(output, "<actor \"%s\">", a->getName().c_str());
 				} else if (lua_tag(lua_getparam(i)) == MKTAG('C','O','L','R')) {
-					Color *c = PoolColor::getPool().getObject(lua_getuserdata(lua_getparam(i)));
-					fprintf(output, "<color #%02x%02x%02x>", c->getRed(), c->getGreen(), c->getBlue());
+					Color c(lua_getuserdata(lua_getparam(i)));
+					fprintf(output, "<color #%02x%02x%02x>", c.getRed(), c.getGreen(), c.getBlue());
 				} else
 					fprintf(output, "<userdata %d>", lua_getuserdata(lua_getparam(i)));
 			} else if (lua_isfunction(lua_getparam(i))) {

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -196,16 +196,16 @@ void Lua_V1::MakeColor() {
 	else
 		b = clamp_color((int)lua_getnumber(bObj));
 
-	PoolColor *c = new PoolColor (r, g ,b);
-	lua_pushusertag(c->getId(), MKTAG('C','O','L','R'));
+	Color c(r, g, b);
+	lua_pushusertag(c.toEncodedValue(), MKTAG('C','O','L','R'));
 }
 
 void Lua_V1::GetColorComponents() {
 	lua_Object colorObj = lua_getparam(1);
-	Color *c = getcolor(colorObj);
-	lua_pushnumber(c->getRed());
-	lua_pushnumber(c->getGreen());
-	lua_pushnumber(c->getBlue());
+	Color c(getcolor(colorObj));
+	lua_pushnumber(c.getRed());
+	lua_pushnumber(c.getGreen());
+	lua_pushnumber(c.getBlue());
 }
 
 void Lua_V1::ReadRegistryValue() {

--- a/engines/grim/lua_v1_actor.cpp
+++ b/engines/grim/lua_v1_actor.cpp
@@ -81,8 +81,7 @@ void Lua_V1::SetActorTalkColor() {
 	if (!lua_isuserdata(colorObj) && lua_tag(colorObj) != MKTAG('C','O','L','R'))
 		return;
 	Actor *actor = getactor(actorObj);
-	PoolColor *color = getcolor(colorObj);
-	actor->setTalkColor(color);
+	actor->setTalkColor(getcolor(colorObj));
 }
 
 void Lua_V1::GetActorTalkColor() {
@@ -92,7 +91,7 @@ void Lua_V1::GetActorTalkColor() {
 		return;
 	}
 	Actor *actor = getactor(actorObj);
-	lua_pushusertag(actor->getTalkColor()->getId(), MKTAG('C','O','L','R'));
+	lua_pushusertag(actor->getTalkColor().toEncodedValue(), MKTAG('C','O','L','R'));
 }
 
 void Lua_V1::SetActorRestChore() {

--- a/engines/grim/lua_v1_graphics.cpp
+++ b/engines/grim/lua_v1_graphics.cpp
@@ -163,7 +163,7 @@ void Lua_V1::PurgePrimitiveQueue() {
 void Lua_V1::DrawPolygon() {
 	lua_Object pointObj;
 	Common::Point p1, p2, p3, p4;
-	PoolColor *color = NULL;
+	Color color;
 
 	lua_Object tableObj1 = lua_getparam(1);
 	if (!lua_istable(tableObj1)) {
@@ -229,7 +229,7 @@ void Lua_V1::DrawPolygon() {
 
 void Lua_V1::DrawLine() {
 	Common::Point p1, p2;
-	PoolColor *color = NULL;;
+	Color color;
 	lua_Object x1Obj = lua_getparam(1);
 	lua_Object y1Obj = lua_getparam(2);
 	lua_Object x2Obj = lua_getparam(3);
@@ -268,7 +268,7 @@ void Lua_V1::DrawLine() {
 
 void Lua_V1::ChangePrimitive() {
 	PrimitiveObject *psearch, *pmodify = NULL;
-	PoolColor *color = NULL;
+	Color color;
 
 	lua_Object param1 = lua_getparam(1);
 	if (!lua_isuserdata(param1) || lua_tag(param1) != MKTAG('P','R','I','M'))
@@ -375,7 +375,7 @@ void Lua_V1::ChangePrimitive() {
 
 void Lua_V1::DrawRectangle() {
 	Common::Point p1, p2;
-	PoolColor *color = NULL;
+	Color color;
 	lua_Object objX1 = lua_getparam(1);
 	lua_Object objY1 = lua_getparam(2);
 	lua_Object objX2 = lua_getparam(3);
@@ -414,7 +414,7 @@ void Lua_V1::DrawRectangle() {
 
 void Lua_V1::BlastRect() {
 	Common::Point p1, p2;
-	PoolColor *color = NULL;
+	Color color;
 	lua_Object objX1 = lua_getparam(1);
 	lua_Object objY1 = lua_getparam(2);
 	lua_Object objX2 = lua_getparam(3);

--- a/engines/grim/primitives.cpp
+++ b/engines/grim/primitives.cpp
@@ -35,7 +35,6 @@ PrimitiveObject::PrimitiveObject() :
 	_filled = false;
 	_type = 0;
 	_bitmap = NULL;
-	_color = NULL;
 }
 
 PrimitiveObject::~PrimitiveObject() {
@@ -46,7 +45,7 @@ PrimitiveObject::~PrimitiveObject() {
 void PrimitiveObject::saveState(SaveGame *savedState) const {
 	savedState->writeLESint32(_type);
 
-	savedState->writeLEUint32(_color->getId());
+	savedState->writeColor(_color);
 
 	savedState->writeLEUint32(_filled);
 
@@ -69,7 +68,7 @@ void PrimitiveObject::saveState(SaveGame *savedState) const {
 bool PrimitiveObject::restoreState(SaveGame *savedState) {
 	_type = savedState->readLESint32();
 
-	_color = PoolColor::getPool().getObject(savedState->readLEUint32());
+	_color = savedState->readLEUint32();
 
 	_filled = savedState->readLEUint32();
 
@@ -87,7 +86,7 @@ bool PrimitiveObject::restoreState(SaveGame *savedState) {
 	return true;
 }
 
-void PrimitiveObject::createRectangle(Common::Point p1, Common::Point p2, PoolColor *color, bool filled) {
+void PrimitiveObject::createRectangle(Common::Point p1, Common::Point p2, const Color &color, bool filled) {
 	_type = RECTANGLE;
 	_p1 = p1;
 	_p2 = p2;
@@ -103,14 +102,14 @@ void PrimitiveObject::createBitmap(Bitmap *bitmap, Common::Point p, bool /*trans
 	// transparent: what to do ?
 }
 
-void PrimitiveObject::createLine(Common::Point p1, Common::Point p2, PoolColor *color) {
+void PrimitiveObject::createLine(Common::Point p1, Common::Point p2, const Color &color) {
 	_type = LINE;
 	_p1 = p1;
 	_p2 = p2;
 	_color = color;
 }
 
-void PrimitiveObject::createPolygon(Common::Point p1, Common::Point p2, Common::Point p3, Common::Point p4, PoolColor *color) {
+void PrimitiveObject::createPolygon(Common::Point p1, Common::Point p2, Common::Point p3, Common::Point p4, const Color &color) {
 	_type = POLYGON;
 	_p1 = p1;
 	_p2 = p2;

--- a/engines/grim/primitives.h
+++ b/engines/grim/primitives.h
@@ -27,11 +27,11 @@
 
 #include "engines/grim/pool.h"
 #include "engines/grim/bitmap.h"
+#include "engines/grim/color.h"
 
 namespace Grim {
 
 class SaveGame;
-class PoolColor;
 
 class PrimitiveObject : public PoolObject<PrimitiveObject, MKTAG('P', 'R', 'I', 'M')> {
 public:
@@ -45,17 +45,17 @@ public:
 		POLYGON
 	} PrimType;
 
-	void createRectangle(Common::Point p1, Common::Point p2, PoolColor *color, bool filled);
+	void createRectangle(Common::Point p1, Common::Point p2, const Color &color, bool filled);
 	void createBitmap(Bitmap *bitmap, Common::Point p, bool transparent);
-	void createLine(Common::Point p1, Common::Point p2, PoolColor *color);
-	void createPolygon(Common::Point p1, Common::Point p2, Common::Point p3, Common::Point p4, PoolColor *color);
+	void createLine(Common::Point p1, Common::Point p2, const Color &color);
+	void createPolygon(Common::Point p1, Common::Point p2, Common::Point p3, Common::Point p4, const Color &color);
 	Common::Point getP1() { return _p1; }
 	Common::Point getP2() { return _p2; }
 	Common::Point getP3() { return _p3; }
 	Common::Point getP4() { return _p4; }
 	void setPos(int x, int y);
-	void setColor(PoolColor *color) { _color = color; }
-	PoolColor *getColor() { return _color; }
+	void setColor(const Color &color) { _color = color; }
+	Color getColor() { return _color; }
 	bool isFilled() { return _filled; }
 	void draw();
 	bool isBitmap() { return _type == BITMAP; }
@@ -65,7 +65,7 @@ public:
 
 private:
 	Common::Point _p1, _p2, _p3, _p4;
-	PoolColor *_color;
+	Color _color;
 	bool _filled;
 	int _type;
 	Bitmap::Ptr _bitmap;

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -68,7 +68,7 @@ void TextObject::reset() {
 }
 
 void TextObject::saveState(SaveGame *state) const {
-	state->writeLEUint32(_fgColor->getId());
+	state->writeColor(_fgColor);
 
 	state->writeLESint32(_x);
 	state->writeLESint32(_y);
@@ -90,7 +90,7 @@ void TextObject::saveState(SaveGame *state) const {
 }
 
 bool TextObject::restoreState(SaveGame *state) {
-	_fgColor = PoolColor::getPool().getObject(state->readLEUint32());
+	_fgColor = state->readLEUint32();
 
 	_x            = state->readLESint32();
 	_y            = state->readLESint32();

--- a/engines/grim/textobject.h
+++ b/engines/grim/textobject.h
@@ -24,12 +24,12 @@
 #define GRIM_TEXTOBJECT_H
 
 #include "engines/grim/pool.h"
+#include "engines/grim/color.h"
 
 namespace Grim {
 
 class SaveGame;
 class Font;
-class PoolColor;
 
 class TextObjectCommon {
 public:
@@ -42,8 +42,8 @@ public:
 	void setFont(Font *font) { _font = font; }
 	Font *getFont() { return _font; }
 
-	void setFGColor(PoolColor *fgColor) { _fgColor = fgColor; }
-	PoolColor *getFGColor() { return _fgColor; }
+	void setFGColor(const Color &fgColor) { _fgColor = fgColor; }
+	Color getFGColor() { return _fgColor; }
 
 	void setJustify(int justify) { _justify = justify; }
 	int getJustify() { return _justify; }
@@ -60,7 +60,7 @@ public:
 protected:
 	TextObjectCommon();
 
-	PoolColor *_fgColor;
+	Color _fgColor;
 	int _x, _y;
 	int _width, _height;
 	int _justify;


### PR DESCRIPTION
This makes it so lua is given a color in the form of a uint32. This is an advantage as there is no lookup needed to figure out which color needs to be output and no extra saving of color objects.

This is technically save compatible, but loading old saves causes all the text to be the wrong color, so it might be a good idea to hold off this commit until the next save version. 
