### PR TITLE
GRIM: Fix changing graphics modes overwriting save games

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -646,6 +646,7 @@ void GrimEngine::mainLoop() {
 
 			EngineMode mode = getMode();
 
+			_savegameFileName = "";
 			savegameSave();
 			clearPools();
 


### PR DESCRIPTION
If you save or load a game and then switch graphics modes, the last save game used will be over written by the temp save.
