### PR TITLE
GRIM: fix compilation if OpenGL is unused

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -649,11 +649,15 @@ void GrimEngine::mainLoop() {
 			clearPools();
 
 			delete g_driver;
+#ifdef USE_OPENGL
 			if (tolower(g_registry->get("soft_renderer", "false")[0]) == 't') {
 				g_driver = CreateGfxTinyGL();
 			} else {
 				g_driver = CreateGfxOpenGL();
 			}
+#else
+			g_driver = CreateGfxTinyGL();
+#endif
 
 			g_driver->setupScreen(640, 480, false);
 			savegameRestore();


### PR DESCRIPTION
I get a compilation error if both OpenGL and myst3 engine are disabled. This pull request fix that.
