### PR TITLE
GRIM: Add return to launcher support

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -75,6 +75,8 @@ SurfaceSdlGraphicsManager::~SurfaceSdlGraphicsManager() {
 	// Unregister the event observer
 	if (g_system->getEventManager()->getEventDispatcher() != NULL)
 		g_system->getEventManager()->getEventDispatcher()->unregisterObserver(this);
+
+	closeOverlay();
 }
 
 void SurfaceSdlGraphicsManager::initEventObserver() {

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -38,6 +38,7 @@
 #endif
 
 #include "common/archive.h"
+#include "common/debug-channels.h"
 #include "common/events.h"
 #include "common/file.h"
 #include "common/fs.h"
@@ -193,6 +194,8 @@ GrimEngine::~GrimEngine() {
 	delete g_driver;
 	g_driver = NULL;
 	delete _iris;
+
+	DebugMan.clearAllDebugChannels();
 }
 
 void GrimEngine::clearPools() {
@@ -583,6 +586,9 @@ void GrimEngine::mainLoop() {
 			resetShortFrame = !resetShortFrame;
 		}
 
+		if (shouldQuit())
+			return;
+
 		if (_savegameLoadRequest) {
 			savegameRestore();
 		}
@@ -647,9 +653,6 @@ void GrimEngine::mainLoop() {
 			if (type == Common::EVENT_KEYDOWN || type == Common::EVENT_KEYUP) {
 				handleControls(type, event.kbd.keycode, event.kbd.flags, event.kbd.ascii);
 			}
-			// Check for "Hard" quit"
-			if (type == Common::EVENT_QUIT)
-				return;
 			if (type == Common::EVENT_SCREEN_CHANGED)
 				_refreshDrawNeeded = true;
 
@@ -1052,6 +1055,10 @@ void GrimEngine::clearEventQueue() {
 	for (int i = 0; i < KEYCODE_EXTRA_LAST; ++i) {
 		_controlsState[i] = false;
 	}
+}
+
+bool GrimEngine::hasFeature(EngineFeature f) const {
+	return f == kSupportsRTL;
 }
 
 } // end of namespace Grim

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -152,6 +152,9 @@ public:
 
 	void changeHardwareState();
 
+	// Engine APIs
+	bool hasFeature(EngineFeature f) const;
+
 	Common::StringArray _listFiles;
 	Common::StringArray::const_iterator _listFilesIter;
 

--- a/engines/grim/lua/lauxlib.cpp
+++ b/engines/grim/lua/lauxlib.cpp
@@ -82,6 +82,7 @@ void lua_removelibslists() {
 		luaM_free(list);
 		list = nextList;
 	}
+	list_of_libs = NULL;
 }
 
 void luaL_openlib(luaL_reg *l, int32 n) {


### PR DESCRIPTION
Add the ability to return to ResidualVM's launcher from the global game menu in the Grim engine.

For this feature to work properly, the engine needs to free all the memory it allocated, and reinitialize all of its global variables and singleton classes. At first glance this seems to be taken care of already, but maybe the grim engine maintainers can confirm.
