### PR TITLE
MYST3: Add detection and database-data for PS2-PAL-version

### DIFF
--- a/engines/myst3/database.cpp
+++ b/engines/myst3/database.cpp
@@ -41,7 +41,8 @@ Database::Database() :
 		"Myst3 Exile JP",
 		"Myst III Exile for Mac OS X",
 		"Myst III Exile for Mac OS 8-9",
-		"SLUS_204.34"
+		"SLUS_204.34",
+		"SLES_507.26"
 	};
 
 	// Game versions database
@@ -65,7 +66,8 @@ Database::Database() :
 			{ "1.2 Japanese",   Common::kPlatformMacintosh, kFlagNone,                    "506758f57d9a903549fa6bd34a189fae", 0,        0x11230,  0x1116C,  0x112F8 },
 			{ "1.27 English",   Common::kPlatformMacintosh, kFlagNone,                    "675e469044ef406c92be36be5ebe92a3", 0,        0x11934,  0x11864,  0x11A10 },
 			{ "1.27 English",   Common::kPlatformMacintosh, kFlagNone,                    "5951edd640c0455555280515974c4008", 0,        0x11378,  0x112A8,  0x11454 },
-			{ "English",        Common::kPlatformPS2,       kFlagNone,                    "c6d6dadac5ae3b882ed276bde7e92031", 0xFFF00,  0x14EB10, 0x14EA10, 0x14ECA0 }
+			{ "English",        Common::kPlatformPS2,       kFlagNone,                    "c6d6dadac5ae3b882ed276bde7e92031", 0xFFF00,  0x14EB10, 0x14EA10, 0x14ECA0 },
+			{ "English",        Common::kPlatformPS2,       kFlagNone,                    "dc03e8cb6a638df2184a6004fd74760e", 0xFFF00,  0x14ED10, 0x14EC10, 0x14EEA0 }
 	};
 
 	// First, see what executable files we have

--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -72,6 +72,20 @@ static const Myst3GameDescription gameDescriptions[] = {
 		},
 		0
 	},
+	
+	{
+		// Myst 3 PS2 (PAL)
+		{
+			"myst3",
+			0,
+			AD_ENTRY1s("RSRC.m3r", "f0e0c502f77157e6b5272686c661ea75", 91371793),
+			Common::UNK_LANG,
+			Common::kPlatformPS2,
+			ADGF_NO_FLAGS,
+			GUIO_NONE
+		},
+		0
+	},
 
 	{ AD_TABLE_END_MARKER, 0 }
 };

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -91,6 +91,7 @@ Myst3Engine::Myst3Engine(OSystem *syst, int gameFlags) :
 	SearchMan.addSubDirectoryMatching(gameDataDir, "MYST3BIN/M3DATA");
 	SearchMan.addSubDirectoryMatching(gameDataDir, "MYST3BIN/M3DATA/TEXT");
 	SearchMan.addSubDirectoryMatching(gameDataDir, "MYST3BIN/M3DATA/TEXT/NTSC");
+	SearchMan.addSubDirectoryMatching(gameDataDir, "MYST3BIN/M3DATA/TEXT/PAL");
 }
 
 Myst3Engine::~Myst3Engine() {


### PR DESCRIPTION
With help from Clone2727, I added in the entries for my PS2-PAL version of Myst III, the disk is a tad scratched so no guarantees, but atleast it seems to be correct.
