### PR TITLE
GRIM: Improve the way that patchr searches for patches and clean up some code.

### DIFF
--- a/engines/grim/patchr.cpp
+++ b/engines/grim/patchr.cpp
@@ -80,7 +80,7 @@ uint32 Patchr::calcIncSize(Common::Array<Op>::const_iterator start) {
 	return incSize;
 }
 
-bool Patchr::patchFile(Common::SeekableReadStream *&file, Common::String &name) {
+bool Patchr::patchFile(Common::SeekableReadStream *&file, const Common::String &name) {
 	Common::Array<Op>::const_iterator line;
 	Common::String md5;
 	uint32 maxSize, fileSize;

--- a/engines/grim/patchr.h
+++ b/engines/grim/patchr.h
@@ -36,7 +36,7 @@ public:
 	Patchr(): _data(NULL), _err(false), _kMd5size(5000), _kMaxFileSize(0x100000) {}
 	~Patchr() { if (_data) delete[] _data; }
 	void loadPatch(Common::SeekableReadStream *patchStream);
-	bool patchFile(Common::SeekableReadStream *&file, Common::String &name);
+	bool patchFile(Common::SeekableReadStream *&file, const Common::String &name);
 private:
 	uint32 _kMaxFileSize;
 	uint32 _kMd5size;

--- a/engines/grim/resource.h
+++ b/engines/grim/resource.h
@@ -87,14 +87,12 @@ public:
 	};
 
 private:
-	Common::SeekableReadStream *loadFile(Common::String &filename);  //TODO: make it const again at next scummvm sync
+	Common::SeekableReadStream *loadFile(const Common::String &filename);  //TODO: make it const again at next scummvm sync
 	Common::SeekableReadStream *getFileFromCache(const Common::String &filename);
 	ResourceLoader::ResourceCache *getEntryFromCache(const Common::String &filename);
 	void putIntoCache(const Common::String &fname, byte *res, uint32 len);
-	void loadPatches();
 
 	Common::SearchSet _files;
-	Common::List<Common::String> _patches;
 
 	Common::Array<ResourceCache> _cache;
 	bool _cacheDirty;


### PR DESCRIPTION
Instead of searching at the beginning for any files that end in .patchr, just try to load a .patchr file whenever a file is loaded. My profiling shows that this patch greatly improves startup time and does not make loadfile take any longer.
