### PR TITLE
GRIM: Various cleanups to code

### DIFF
--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -435,7 +435,7 @@ public:
 	void setLookAtVectorZero() {
 		_lookAtVector.set(0.f, 0.f, 0.f);
 	}
-	void setLookAtVector(Math::Vector3d vector) {
+	void setLookAtVector(const Math::Vector3d &vector) {
 		_lookAtVector = vector;
 	}
 	Math::Vector3d getLookAtVector() {

--- a/engines/grim/costume.cpp
+++ b/engines/grim/costume.cpp
@@ -471,7 +471,7 @@ float Costume::getLookAtRate() const {
 	return _lookAtRate;
 }
 
-void Costume::setPosRotate(Math::Vector3d pos, const Math::Angle &pitch,
+void Costume::setPosRotate(const Math::Vector3d &pos, const Math::Angle &pitch,
 						   const Math::Angle &yaw, const Math::Angle &roll) {
 	_matrix.setPosition(pos);
 	_matrix.buildFromPitchYawRoll(pitch, yaw, roll);

--- a/engines/grim/costume.h
+++ b/engines/grim/costume.h
@@ -80,7 +80,7 @@ public:
 	void setupTextures();
 	virtual void draw();
 	void getBoundingBox(int *x1, int *y1, int *x2, int *y2);
-	void setPosRotate(Math::Vector3d pos, const Math::Angle &pitch,
+	void setPosRotate(const Math::Vector3d &pos, const Math::Angle &pitch,
 					  const Math::Angle &yaw, const Math::Angle &roll);
 	Math::Matrix4 getMatrix() const;
 

--- a/engines/grim/costume/bitmap_component.cpp
+++ b/engines/grim/costume/bitmap_component.cpp
@@ -35,8 +35,7 @@ BitmapComponent::BitmapComponent(Component *p, int parentID, const char *filenam
 }
 
 void BitmapComponent::setKey(int val) {
-	const char *bitmap = _filename.c_str();
-	ObjectState *state = g_grim->getCurrSet()->findState(bitmap);
+	ObjectState *state = g_grim->getCurrSet()->findState(_filename);
 
 	if (state) {
 		state->setActiveImage(val);
@@ -47,7 +46,7 @@ void BitmapComponent::setKey(int val) {
 	// bitmaps were not loading with the scene. This was because they were requested
 	// as a different case then they were stored (tu_0_dorcu_door_open versus
 	// TU_0_DORCU_door_open), which was causing problems in the string comparison.
-	Debug::warning(Debug::Bitmaps | Debug::Costumes, "Missing scene bitmap: %s", bitmap);
+	Debug::warning(Debug::Bitmaps | Debug::Costumes, "Missing scene bitmap: %s", _filename.c_str());
 
 /* In case you feel like drawing the missing bitmap anyway...
 	// Assume that all objects the scene file forgot about are OBJSTATE_STATE class

--- a/engines/grim/costume/component.cpp
+++ b/engines/grim/costume/component.cpp
@@ -26,15 +26,11 @@
 
 namespace Grim {
 
-Component::Component(Component *p, int parentID, tag32 t)  {
-	_visible = true;
-	_previousCmap = NULL;
-	_cmap = NULL;
-	_cost = NULL;
-	_parent = NULL;
-	_parentID = parentID;
+Component::Component(Component *p, int parentID, tag32 t) :
+	_visible(true), _tag(t), _parentID(parentID),
+	_previousCmap(NULL), _cmap(NULL), _cost(NULL) {
+
 	setParent(p);
-	_tag = t;
 }
 
 Component::~Component() {

--- a/engines/grim/costume/component.h
+++ b/engines/grim/costume/component.h
@@ -43,7 +43,7 @@ public:
 	virtual void setColormap(CMap *c);
 	bool isVisible();
 	Component *getParent() { return _parent; }
-	virtual void setMatrix(Math::Matrix4) { };
+	virtual void setMatrix(const Math::Matrix4 &) { };
 	virtual void init() { }
 	virtual void setKey(int) { }
 	virtual void setMapName(char *) { }

--- a/engines/grim/costume/keyframe_component.cpp
+++ b/engines/grim/costume/keyframe_component.cpp
@@ -28,8 +28,7 @@
 namespace Grim {
 
 KeyframeComponent::KeyframeComponent(Component *p, int parentID, const char *filename, tag32 t) :
-		Component(p, parentID, t), _priority1(1), _priority2(5) {
-	_fname = filename;
+		Component(p, parentID, t), _priority1(1), _priority2(5), _fname(filename) {
 	const char *comma = strchr(filename, ',');
 	if (comma) {
 		_fname = Common::String(filename, comma);

--- a/engines/grim/costume/mesh_component.h
+++ b/engines/grim/costume/mesh_component.h
@@ -42,7 +42,7 @@ public:
 	void saveState(SaveGame *state);
 	void restoreState(SaveGame *state);
 
-	void setMatrix(Math::Matrix4 matrix) { _matrix = matrix; };
+	void setMatrix(const Math::Matrix4 &matrix) { _matrix = matrix; };
 
 	ModelNode *getNode() { return _node; }
 	Model *getModel() { return _model; }

--- a/engines/grim/costume/model_component.h
+++ b/engines/grim/costume/model_component.h
@@ -40,7 +40,7 @@ public:
 	void animate();
 	void reset();
 	void resetColormap();
-	void setMatrix(Math::Matrix4 matrix) { _matrix = matrix; };
+	void setMatrix(const Math::Matrix4 &matrix) { _matrix = matrix; };
 	void restoreState(SaveGame *state);
 	void translateObject(bool reset);
 	static void translateObject(ModelNode *node, bool reset);

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -91,7 +91,7 @@ public:
 	virtual uint getScreenHeight() { return _screenHeight; }
 
 	virtual void setupCamera(float fov, float nclip, float fclip, float roll) = 0;
-	virtual void positionCamera(Math::Vector3d pos, Math::Vector3d interest) = 0;
+	virtual void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest) = 0;
 
 	virtual void clearScreen() = 0;
 
@@ -101,7 +101,7 @@ public:
 	virtual void flipBuffer() = 0;
 
 	virtual void getBoundingBoxPos(const Mesh *mesh, int *x1, int *y1, int *x2, int *y2) = 0;
-	virtual void startActorDraw(Math::Vector3d pos, float scale, const Math::Angle &yaw,
+	virtual void startActorDraw(const Math::Vector3d &pos, float scale, const Math::Angle &yaw,
 								const Math::Angle &pitch, const Math::Angle &roll) = 0;
 	virtual void finishActorDraw() = 0;
 	virtual void setShadow(Shadow *shadow) = 0;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -185,7 +185,7 @@ void GfxOpenGL::setupCamera(float fov, float nclip, float fclip, float roll) {
 	glRotatef(roll, 0, 0, -1);
 }
 
-void GfxOpenGL::positionCamera(Math::Vector3d pos, Math::Vector3d interest) {
+void GfxOpenGL::positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest) {
 	Math::Vector3d up_vec(0, 0, 1);
 
 	// EMI only: transform XYZ to YXZ
@@ -218,7 +218,7 @@ bool GfxOpenGL::isHardwareAccelerated() {
 	return true;
 }
 
-static void glShadowProjection(Math::Vector3d light, Math::Vector3d plane, Math::Vector3d normal, bool dontNegate) {
+static void glShadowProjection(const Math::Vector3d &light, const Math::Vector3d &plane, const Math::Vector3d &normal, bool dontNegate) {
 	// Based on GPL shadow projection example by
 	// (c) 2002-2003 Phaetos <phaetos@gaffga.de>
 	float d, c;
@@ -338,7 +338,7 @@ void GfxOpenGL::getBoundingBoxPos(const Mesh *model, int *x1, int *y1, int *x2, 
 	*y2 = (int)bottom;
 }
 
-void GfxOpenGL::startActorDraw(Math::Vector3d pos, float scale, const Math::Angle &yaw,
+void GfxOpenGL::startActorDraw(const Math::Vector3d &pos, float scale, const Math::Angle &yaw,
 		const Math::Angle &pitch, const Math::Angle &roll) {
 	glEnable(GL_TEXTURE_2D);
 	glMatrixMode(GL_MODELVIEW);

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -52,7 +52,7 @@ public:
 	const char *getVideoDeviceName();
 
 	void setupCamera(float fov, float nclip, float fclip, float roll);
-	void positionCamera(Math::Vector3d pos, Math::Vector3d interest);
+	void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest);
 
 	void clearScreen();
 	void flipBuffer();
@@ -61,7 +61,7 @@ public:
 
 	void getBoundingBoxPos(const Mesh *model, int *x1, int *y1, int *x2, int *y2);
 
-	void startActorDraw(Math::Vector3d pos, float scale, const Math::Angle &yaw,
+	void startActorDraw(const Math::Vector3d &pos, float scale, const Math::Angle &yaw,
 						const Math::Angle &pitch, const Math::Angle &roll);
 	void finishActorDraw();
 	void setShadow(Shadow *shadow);

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -284,7 +284,7 @@ void GfxTinyGL::setupCamera(float fov, float nclip, float fclip, float roll) {
 	tglRotatef(roll, 0, 0, -1);
 }
 
-void GfxTinyGL::positionCamera(Math::Vector3d pos, Math::Vector3d interest) {
+void GfxTinyGL::positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest) {
 	Math::Vector3d up_vec(0, 0, 1);
 
 	// EMI only: transform XYZ to YXZ
@@ -319,7 +319,7 @@ bool GfxTinyGL::isHardwareAccelerated() {
 	return false;
 }
 
-static void tglShadowProjection(Math::Vector3d light, Math::Vector3d plane, Math::Vector3d normal, bool dontNegate) {
+static void tglShadowProjection(const Math::Vector3d &light, const Math::Vector3d &plane, const Math::Vector3d &normal, bool dontNegate) {
 	// Based on GPL shadow projection example by
 	// (c) 2002-2003 Phaetos <phaetos@gaffga.de>
 	float d, c;
@@ -454,7 +454,7 @@ void GfxTinyGL::getBoundingBoxPos(const Mesh *model, int *x1, int *y1, int *x2, 
 	}*/
 }
 
-void GfxTinyGL::startActorDraw(Math::Vector3d pos, float scale, const Math::Angle &yaw,
+void GfxTinyGL::startActorDraw(const Math::Vector3d &pos, float scale, const Math::Angle &yaw,
 							   const Math::Angle &pitch, const Math::Angle &roll) {
 	tglEnable(TGL_TEXTURE_2D);
 	tglMatrixMode(TGL_MODELVIEW);

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -44,7 +44,7 @@ public:
 	const char *getVideoDeviceName();
 
 	void setupCamera(float fov, float nclip, float fclip, float roll);
-	void positionCamera(Math::Vector3d pos, Math::Vector3d interest);
+	void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest);
 
 	void clearScreen();
 	void flipBuffer();
@@ -53,7 +53,7 @@ public:
 
 	void getBoundingBoxPos(const Mesh *model, int *x1, int *y1, int *x2, int *y2);
 
-	void startActorDraw(Math::Vector3d pos, float scale, const Math::Angle &yaw,
+	void startActorDraw(const Math::Vector3d &pos, float scale, const Math::Angle &yaw,
 						const Math::Angle &pitch, const Math::Angle &roll);
 	void finishActorDraw();
 	void setShadow(Shadow *shadow);

--- a/engines/grim/material.cpp
+++ b/engines/grim/material.cpp
@@ -38,13 +38,13 @@ MaterialData::MaterialData(const Common::String &filename, Common::SeekableReadS
 	_fname(filename), _cmap(cmap), _refCount(1) {
 
 	if (g_grim->getGameType() == GType_MONKEY4) {
-		initEMI(filename, data);
+		initEMI(data);
 	} else {
-		initGrim(filename, data, cmap);
+		initGrim(data, cmap);
 	}
 }
 
-void MaterialData::initGrim(const Common::String &filename, Common::SeekableReadStream *data, CMap *cmap) {
+void MaterialData::initGrim(Common::SeekableReadStream *data, CMap *cmap) {
 	uint32 tag = data->readUint32BE();
 	if (tag != MKTAG('M','A','T',' '))
 		error("invalid magic loading texture");
@@ -129,11 +129,11 @@ void loadTGA(Common::SeekableReadStream *data, Texture *t) {
 	}
 }
 	
-void MaterialData::initEMI(const Common::String &filename, Common::SeekableReadStream *data) {
+void MaterialData::initEMI(Common::SeekableReadStream *data) {
 	Common::Array<Common::String> texFileNames;
 	char readFileName[64];
 
-	if (filename.hasSuffix(".sur")) {  // This expects that we want all the materials in the sur-file
+	if (_fname.hasSuffix(".sur")) {  // This expects that we want all the materials in the sur-file
 		TextSplitter *ts = new TextSplitter(data);
 		ts->setLineNumber(2); // Skip copyright-line
 		ts->expectString("version\t1.0");
@@ -163,7 +163,7 @@ void MaterialData::initEMI(const Common::String &filename, Common::SeekableReadS
 		_numImages = texFileNames.size();
 		delete ts;
 		return;
-	} else if(filename.hasSuffix(".tga")) {
+	} else if(_fname.hasSuffix(".tga")) {
 		_numImages = 1;
 		_textures = new Texture();
 		loadTGA(data, _textures);
@@ -171,7 +171,7 @@ void MaterialData::initEMI(const Common::String &filename, Common::SeekableReadS
 		return;
 		
 	} else {
-		warning("Unknown material-format: %s", filename.c_str());
+		warning("Unknown material-format: %s", _fname.c_str());
 	}
 }
 

--- a/engines/grim/material.h
+++ b/engines/grim/material.h
@@ -55,8 +55,8 @@ public:
 	int _refCount;
 
 private:
-	void initGrim(const Common::String &filename, Common::SeekableReadStream *data, CMap *cmap);
-	void initEMI(const Common::String &filename, Common::SeekableReadStream *data);
+	void initGrim(Common::SeekableReadStream *data, CMap *cmap);
+	void initEMI(Common::SeekableReadStream *data);
 };
 
 class Material : public Object {

--- a/engines/grim/model.cpp
+++ b/engines/grim/model.cpp
@@ -703,7 +703,7 @@ void ModelNode::removeChild(ModelNode *child) {
 	}
 }
 
-void ModelNode::setMatrix(Math::Matrix4 matrix) {
+void ModelNode::setMatrix(const Math::Matrix4 &matrix) {
 	_matrix = matrix;
 	if (_sibling)
 		_sibling->setMatrix(matrix);

--- a/engines/grim/model.h
+++ b/engines/grim/model.h
@@ -150,7 +150,7 @@ public:
 	void getBoundingBox(int *x1, int *y1, int *x2, int *y2) const;
 	void addChild(ModelNode *child);
 	void removeChild(ModelNode *child);
-	void setMatrix(Math::Matrix4 matrix);
+	void setMatrix(const Math::Matrix4 &matrix);
 	void update();
 	void addSprite(Sprite *sprite);
 	void removeSprite(Sprite *sprite);
@@ -165,7 +165,7 @@ public:
 	 * discretely.
 	 */
 	int _flags;
-	/** 
+	/**
 	 * Each KeyFrameAnim has a type identifier. This type field is a bitmask which is ANDed againts
 	 * the type in the KeyFrameAnim to control which KeyFrameAnims animate on which nodes of the character.
 	 * This enables selectively controlling the animations to act only on certain bones.

--- a/engines/grim/set.cpp
+++ b/engines/grim/set.cpp
@@ -651,11 +651,11 @@ void Set::setLightPosition(int light, const Math::Vector3d &pos) {
 	_lightsConfigured = false;
 }
 
-void Set::setSoundPosition(const char *soundName, Math::Vector3d pos) {
+void Set::setSoundPosition(const char *soundName, const Math::Vector3d &pos) {
 	setSoundPosition(soundName, pos, _minVolume, _maxVolume);
 }
 
-void Set::setSoundPosition(const char *soundName, Math::Vector3d pos, int minVol, int maxVol) {
+void Set::setSoundPosition(const char *soundName, const Math::Vector3d &pos, int minVol, int maxVol) {
 	// TODO: The volume and pan needs to be updated when the setup changes.
 	Math::Vector3d cameraPos = _currSetup->_pos;
 	Math::Vector3d vector = pos - cameraPos;

--- a/engines/grim/set.h
+++ b/engines/grim/set.h
@@ -61,8 +61,8 @@ public:
 
 	void setupLights();
 
-	void setSoundPosition(const char *soundName, Math::Vector3d pos);
-	void setSoundPosition(const char *soundName, Math::Vector3d pos, int minVol, int maxVol);
+	void setSoundPosition(const char *soundName, const Math::Vector3d &pos);
+	void setSoundPosition(const char *soundName, const Math::Vector3d &pos, int minVol, int maxVol);
 	void setSoundParameters(int minVolume, int maxVolume);
 	void getSoundParameters(int *minVolume, int *maxVolume);
 


### PR DESCRIPTION
Some small changes to improve the code slightly. 

A lot of it is changing Math::Vector3d to const Math::Vector3d & in order to avoid an extra copy (this is probably not all that needed as the optimizer will probably take care of it, but why not be explicit?)
