### PR TITLE
GRIM: Make sure the bitmap data is loaded before setting the active image

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -456,8 +456,9 @@ void Bitmap::draw(int x, int y) {
 
 void Bitmap::setActiveImage(int n) {
 	assert(n >= 0);
+	_data->load();
 	if ((n - 1) >= _data->_numImages) {
-		warning("Bitmap::setNumber: no anim image: %d. (%s)", n, _data->_fname.c_str());
+		warning("Bitmap::setActiveImage: no anim image: %d. (%s)", n, _data->_fname.c_str());
 	} else {
 		_currImage = n;
 	}


### PR DESCRIPTION
Fixes a bug I introduced in my recent commit where I changed the way bitmaps load.
