### PR TITLE
GRIM: Remove now unneeded buffer flip

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -270,8 +270,6 @@ Common::Error GrimEngine::run() {
 	if (splash_bm != NULL)
 		splash_bm->draw();
 
-	g_driver->flipBuffer();
-
 	LuaBase *lua = NULL;
 	if (getGameType() == GType_GRIM) {
 		lua = new Lua_V1();


### PR DESCRIPTION
This fixes the loading bitmap going blank for me, but I don't know if this works everywhere. Maybe test this a bit before committing.
