### PR TITLE
EMI: fix crash while trying to play music with PS2 versions

### DIFF
--- a/engines/grim/emi/sound/emisound.cpp
+++ b/engines/grim/emi/sound/emisound.cpp
@@ -132,7 +132,7 @@ void EMISound::setMusicState(int stateId) {
 		delete _music;
 		_music = NULL;
 	}
-	if (stateId == 0 || _musicTable[stateId]._id != stateId) {
+	if (stateId == 0 || (_musicTable != NULL && _musicTable[stateId]._id != stateId)) {
 		return;
 	}
 	Common::String filename;


### PR DESCRIPTION
PS2 versions of EMI doesn't have musicTable yet, so musicTable must be verified that it is not null in this case.
