### PR TITLE
GRIM: Fix race condition where g_movies may not be initialized in time

### DIFF
--- a/engines/grim/movie/movie.cpp
+++ b/engines/grim/movie/movie.cpp
@@ -48,15 +48,9 @@ MoviePlayer::MoviePlayer() {
 	_videoDecoder = NULL;
 	_internalSurface = NULL;
 	_externalSurface = new Graphics::Surface();
-
-	g_system->getTimerManager()->installTimerProc(&timerCallback, 10000, NULL, "movieLoop");
 }
 
 MoviePlayer::~MoviePlayer() {
-	// Remove the callback immediately, so we're sure timerCallback() doesn't get called
-	// after the deinit() or the deletes.
-	g_system->getTimerManager()->removeTimerProc(&timerCallback);
-
 	deinit();
 	delete _videoDecoder;
 	delete _externalSurface;
@@ -124,10 +118,16 @@ void MoviePlayer::init() {
 	_movieTime = 0;
 	_updateNeeded = false;
 	_videoFinished = false;
+
+	g_system->getTimerManager()->installTimerProc(&timerCallback, 10000, NULL, "movieLoop");
 }
 
 void MoviePlayer::deinit() {
 	Debug::debug(Debug::Movie, "Deinitting video '%s'.\n", _fname.c_str());
+
+	// Remove the callback immediately, so we're sure timerCallback() doesn't get called
+	// after the deinit finishes
+	g_system->getTimerManager()->removeTimerProc(&timerCallback);
 
 	if (_videoDecoder)
 		_videoDecoder->close();


### PR DESCRIPTION
I tested it and it seems to work the same in call cases. It is also an improvement in that timerCallback is only run when it needs to be instead of being run all the time.
