### PR TITLE
GRIM: Don't use wildcards when searching data labs

### DIFF
--- a/engines/grim/resource.cpp
+++ b/engines/grim/resource.cpp
@@ -90,7 +90,13 @@ ResourceLoader::ResourceLoader() {
 				error("residualvm-grim-patch.lab not found");
 
 			SearchMan.listMatchingMembers(files, "residualvm-grim-patch.lab");
-			SearchMan.listMatchingMembers(files, "data???.lab");
+			SearchMan.listMatchingMembers(files, "datausr.lab");
+			SearchMan.listMatchingMembers(files, "data005.lab");
+			SearchMan.listMatchingMembers(files, "data004.lab");
+			SearchMan.listMatchingMembers(files, "data003.lab");
+			SearchMan.listMatchingMembers(files, "data002.lab");
+			SearchMan.listMatchingMembers(files, "data001.lab");
+			SearchMan.listMatchingMembers(files, "data000.lab");
 			SearchMan.listMatchingMembers(files, "movie??.lab");
 			SearchMan.listMatchingMembers(files, "vox????.lab");
 			SearchMan.listMatchingMembers(files, "year?mus.lab");


### PR DESCRIPTION
Some German versions comes with a data006.lab, which is simply data000.lab. Its presence prevents the load of the patched data from data005.lab (see issue #566).
This pull request prevents the load of unneeded data labs. 
