### PR TITLE
EMI: Implement adding actors to the overworld

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -89,6 +89,7 @@ Actor::Actor(const Common::String &actorName) :
 	_collisionScale = 1.f;
 	_puckOrient = false;
 	_talking = false;
+	_inOverworld = false;
 
 	for (int i = 0; i < MAX_SHADOWS; i++) {
 		_shadowArray[i].active = false;

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -462,6 +462,9 @@ public:
 	void attachToActor(Actor *other, const char *joint);
 	void detach();
 
+	void setInOverworld(bool inOverworld) { _inOverworld = inOverworld; }
+	bool isInOverworld() { return _inOverworld; }
+
 private:
 	void costumeMarkerCallback(int marker);
 	void collisionHandlerCallback(Actor *other) const;
@@ -589,6 +592,8 @@ private:
 	static bool _isTalkingBackground;
 	Actor *_attachedActor;
 	Common::String _attachedJoint;
+
+	bool _inOverworld;
 
 	friend class GrimEngine;
 };

--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -81,6 +81,17 @@ void Lua_V2::SetActorGlobalAlpha() {
 	*/
 }
 
+void Lua_V2::PutActorInOverworld() {
+	lua_Object actorObj = lua_getparam(1);
+
+	if (!lua_isuserdata(actorObj) || lua_tag(actorObj) != MKTAG('A','C','T','R'))
+		return;
+
+	Actor *actor = getactor(actorObj);
+
+	actor->setInOverworld(true);
+}
+
 void Lua_V2::RemoveActorFromOverworld() {
 	lua_Object actorObj = lua_getparam(1);
 
@@ -91,8 +102,7 @@ void Lua_V2::RemoveActorFromOverworld() {
 	if (!actor)
 		return;
 
-	warning("Lua_V2::RemoveActorFromOverworld: actor: %s", actor->getName().c_str());
-	// FIXME actor->func();
+	actor->setInOverworld(false);
 }
 
 void Lua_V2::UnloadActor() {
@@ -292,19 +302,6 @@ void Lua_V2::ActorStopMoving() {
 
 	warning("Lua_V2::ActorStopMoving, actor: %s", actor->getName().c_str());
 	// FIXME: implement missing rest part of code
-}
-
-void Lua_V2::PutActorInOverworld() {
-	lua_Object actorObj = lua_getparam(1);
-
-	if (!lua_isuserdata(actorObj) || lua_tag(actorObj) != MKTAG('A','C','T','R'))
-		return;
-
-	Actor *actor = getactor(actorObj);
-
-	warning("Lua_V2::PutActorInOverworld, actor: %s", actor->getName().c_str());
-	// FIXME: implement missing func
-	//actor->func();
 }
 
 void Lua_V2::GetActorWorldPos() {

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1089,7 +1089,7 @@ void GrimEngine::buildActiveActorsList() {
 
 	_activeActors.clear();
 	foreach (Actor *a, Actor::getPool()) {
-		if (a->isInSet(_currSet->getName())) {
+		if ((_mode == NormalMode && a->isInSet(_currSet->getName())) || a->isInOverworld()) {
 			_activeActors.push_back(a);
 		}
 	}


### PR DESCRIPTION
I'm not sure if this is the best way to do it. Right now I am assuming that an actor is always drawn when in the overworld and normal actors are not drawn when the game is in the overworld mode.
