### PR TITLE
Fix image decoder FIXMEs after recent sync with ScummVM

### DIFF
--- a/engines/myst3/cursor.cpp
+++ b/engines/myst3/cursor.cpp
@@ -27,7 +27,7 @@
 #include "engines/myst3/state.h"
 
 #include "graphics/surface.h"
-#include "graphics/decoders/image_decoder.h"
+#include "graphics/decoders/bmp.h"
 
 namespace Myst3 {
 
@@ -77,8 +77,12 @@ void Cursor::loadAvailableCursors() {
 			error("Cursor %d does not exist", availableCursors[i].nodeID);
 
 		Common::MemoryReadStream *bmpStream = cursorDesc->getData();
-		// FIXME:
-		Graphics::Surface *surface;// = Graphics::ImageDecoder::loadFile(*bmpStream, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+
+		Graphics::BitmapDecoder bitmapDecoder;
+		if (!bitmapDecoder.loadStream(*bmpStream))
+			error("Could not decode Myst III bitmap");
+		const Graphics::Surface *surface = bitmapDecoder.getSurface();
+
 		delete bmpStream;
 
 		// Apply the colorkey for transparency
@@ -92,9 +96,6 @@ void Cursor::loadAvailableCursors() {
 		}
 
 		availableCursors[i].texture = _vm->_gfx->createTexture(surface);
-
-		surface->free();
-		delete surface;
 	}
 }
 

--- a/engines/myst3/node.cpp
+++ b/engines/myst3/node.cpp
@@ -169,9 +169,9 @@ void Node::loadSpotItem(uint16 id, uint16 condition, bool fade) {
 		Common::MemoryReadStream *jpegStream = jpegDesc->getData();
 
 		Graphics::JPEGDecoder jpeg;
-		//FIXME
-		//jpeg.read(jpegStream);
-
+		if (!jpeg.loadStream(*jpegStream))
+			error("Could not decode Myst III JPEG");
+		
 		spotItemFace->loadData(&jpeg);
 
 		delete jpegStream;

--- a/engines/myst3/nodecube.cpp
+++ b/engines/myst3/nodecube.cpp
@@ -40,8 +40,8 @@ NodeCube::NodeCube(Myst3Engine *vm, uint16 id) :
 
 		if (jpegStream) {
 			Graphics::JPEGDecoder jpeg;
-			//FIXME
-			//jpeg.read(jpegStream);
+			if (!jpeg.loadStream(*jpegStream))
+				error("Could not decode Myst III JPEG");
 
 			_faces[i] = new Face(_vm);
 			_faces[i]->setTextureFromJPEG(&jpeg);

--- a/engines/myst3/nodeframe.cpp
+++ b/engines/myst3/nodeframe.cpp
@@ -45,8 +45,8 @@ NodeFrame::NodeFrame(Myst3Engine *vm, uint16 id) :
 
 	if (jpegStream) {
 		Graphics::JPEGDecoder jpeg;
-		//FIXME
-		//jpeg.read(jpegStream);
+		if (!jpeg.loadStream(*jpegStream))
+			error("Could not decoder Myst III JPEG");
 
 		_faces[0] = new Face(_vm);
 		_faces[0]->setTextureFromJPEG(&jpeg);


### PR DESCRIPTION
This is an attempt at getting Myst III up and running again after the recent ScummVM sync. I'm not entirely sure I'm doing it correctly, but it doesn't crash for me at least.
