### PR TITLE
Invalidate activeActors list on mode change.

### DIFF
--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -97,7 +97,7 @@ public:
 	int modifyGameSpeed(int speedChange);
 	int getTimerDelay() const;
 
-	void setMode(EngineMode mode) { _mode = mode; }
+	void setMode(EngineMode mode) { _mode = mode; invalidateActiveActorsList(); }
 	EngineMode getMode() { return _mode; }
 	void setPreviousMode(EngineMode mode) { _previousMode = mode; }
 	EngineMode getPreviousMode() { return _previousMode; }


### PR DESCRIPTION
Pull request #575 broke Grim for me because Grim starts the game in SmushMode for the initial cutscene.  Then, at the end of the cutscene, the mode is changed to NormalMode, but the activeActors list is not invalidated, so Manny isn't an active actor (because the mode wasn't Normal when the list was generated).

This change fixes this problem by invalidating the activeActors list whenever the mode changes.
