### PR TITLE
GRIM: Remove tag from the pool template

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -63,7 +63,7 @@ void Actor::restoreStaticState(SaveGame *state) {
 }
 
 Actor::Actor(const Common::String &actorName) :
-		PoolObject<Actor, MKTAG('A', 'C', 'T', 'R')>(), _name(actorName), _setName(""),
+		_name(actorName), _setName(""),
 		_talkColor(255, 255, 255), _pos(0, 0, 0),
 		// Some actors don't set walk and turn rates, so we default the
 		// _turnRate so Doug at the cat races can turn and we set the
@@ -98,8 +98,7 @@ Actor::Actor(const Common::String &actorName) :
 	}
 }
 
-Actor::Actor() :
-	PoolObject<Actor, MKTAG('A', 'C', 'T', 'R')>() {
+Actor::Actor() {
 
 	_shadowArray = new Shadow[5];
 	_running = false;

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -63,7 +63,7 @@ struct Shadow {
  *
  * @short Actor represents a 3D character on screen.
  */
-class Actor : public PoolObject<Actor, MKTAG('A', 'C', 'T', 'R')> {
+class Actor : public PoolObject<Actor> {
 public:
 	enum CollisionMode {
 		CollisionOff = 0,
@@ -86,6 +86,8 @@ public:
 	 * The actor is automatically removed from the GrimEngine instance.
 	 */
 	~Actor();
+
+	static int32 getStaticTag() { return MKTAG('A', 'C', 'T', 'R'); }
 
 	/**
 	 * Saves the actor state.

--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -389,20 +389,17 @@ const Graphics::PixelBuffer &BitmapData::getImageData(int num) const {
 
 // Bitmap
 
-Bitmap::Bitmap(const Common::String &fname) :
-		PoolObject<Bitmap, MKTAG('V', 'B', 'U', 'F')>() {
+Bitmap::Bitmap(const Common::String &fname) {
 	_data = BitmapData::getBitmapData(fname);
 	_currImage = 1;
 }
 
-Bitmap::Bitmap(const Graphics::PixelBuffer &buf, int w, int h, const char *fname) :
-		PoolObject<Bitmap, MKTAG('V', 'B', 'U', 'F')>() {
+Bitmap::Bitmap(const Graphics::PixelBuffer &buf, int w, int h, const char *fname) {
 	_data = new BitmapData(buf, w, h, fname);
 	_currImage = 1;
 }
 
-Bitmap::Bitmap() :
-		PoolObject<Bitmap, MKTAG('V', 'B', 'U', 'F')>() {
+Bitmap::Bitmap() {
 	_data = new BitmapData();
 }
 

--- a/engines/grim/bitmap.h
+++ b/engines/grim/bitmap.h
@@ -106,7 +106,7 @@ public:
 	Graphics::PixelBuffer *_data;
 };
 
-class Bitmap : public PoolObject<Bitmap, MKTAG('V', 'B', 'U', 'F')> {
+class Bitmap : public PoolObject<Bitmap> {
 public:
 	/**
 	 * Construct a bitmap from the given data.
@@ -118,6 +118,8 @@ public:
 	Bitmap(const Common::String &filename);
 	Bitmap(const Graphics::PixelBuffer &buf, int width, int height, const char *filename);
 	Bitmap();
+
+	static int32 getStaticTag() { return MKTAG('V', 'B', 'U', 'F'); }
 
 	static Bitmap *create(const Common::String &filename);
 

--- a/engines/grim/costume/chore.h
+++ b/engines/grim/costume/chore.h
@@ -87,9 +87,10 @@ private:
 	friend class EMICostume;
 };
 
-class PoolChore : public PoolObject<PoolChore, MKTAG('C', 'H', 'O', 'R')>, public Chore {
+class PoolChore : public PoolObject<PoolChore>, public Chore {
 public:
-	virtual int getId() { return PoolObject<PoolChore, MKTAG('C', 'H', 'O', 'R')>::getId(); }
+	virtual int getId() { return PoolObject<PoolChore>::getId(); }
+	static int32 getStaticTag() { return MKTAG('C', 'H', 'O', 'R'); }
 };
 
 } // end of namespace Grim

--- a/engines/grim/emi/lua_v2_sound.cpp
+++ b/engines/grim/emi/lua_v2_sound.cpp
@@ -179,9 +179,10 @@ void Lua_V2::ImFlushStack() {
 	warning("Lua_V2::ImFlushStack: implement opcode");
 }
 
-class PoolSound : public PoolObject<PoolSound, MKTAG('A', 'I', 'F', 'F')>{
+class PoolSound : public PoolObject<PoolSound>{
 public:
 	PoolSound(const Common::String &filename);
+	static int32 getStaticTag() { return MKTAG('A', 'I', 'F', 'F'); }
 	AIFFTrack *track;
 };
 

--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -32,13 +32,13 @@
 namespace Grim {
 
 Font::Font(const Common::String &filename, Common::SeekableReadStream *data) :
-		PoolObject<Font, MKTAG('F', 'O', 'N', 'T')>(), _userData(NULL),
+		_userData(NULL),
 		_fontData(NULL), _charHeaders(NULL), _charIndex(NULL) {
 	load(filename, data);
 }
 
 Font::Font() :
-		PoolObject<Font, MKTAG('F', 'O', 'N', 'T')>(), _userData(NULL),
+		_userData(NULL),
 		_fontData(NULL), _charHeaders(NULL), _charIndex(NULL)
 {
 

--- a/engines/grim/font.h
+++ b/engines/grim/font.h
@@ -33,11 +33,14 @@ namespace Grim {
 
 class SaveGame;
 
-class Font : public PoolObject<Font, MKTAG('F', 'O', 'N', 'T')> {
+class Font : public PoolObject<Font> {
 public:
 	Font(const Common::String &filename, Common::SeekableReadStream *data);
 	Font();
 	~Font();
+
+	static int32 getStaticTag() { return MKTAG('F', 'O', 'N', 'T'); }
+
 	void load(const Common::String &filename, Common::SeekableReadStream *data);
 
 	const Common::String &getFilename() const { return _filename; }

--- a/engines/grim/objectstate.cpp
+++ b/engines/grim/objectstate.cpp
@@ -28,7 +28,7 @@
 namespace Grim {
 
 ObjectState::ObjectState(int setup, ObjectState::Position position, const char *bitmap, const char *zbitmap, bool transparency) :
-		PoolObject<ObjectState, MKTAG('S', 'T', 'A', 'T')>(), _setupID(setup), _pos(position), _visibility(false) {
+		_setupID(setup), _pos(position), _visibility(false) {
 
 	_bitmap = Bitmap::create(bitmap);
 	if (zbitmap) {
@@ -38,7 +38,7 @@ ObjectState::ObjectState(int setup, ObjectState::Position position, const char *
 }
 
 ObjectState::ObjectState() :
-		PoolObject<ObjectState, MKTAG('S', 'T', 'A', 'T')>(), _bitmap(NULL), _zbitmap(NULL) {
+		_bitmap(NULL), _zbitmap(NULL) {
 
 }
 

--- a/engines/grim/objectstate.h
+++ b/engines/grim/objectstate.h
@@ -32,7 +32,7 @@ namespace Grim {
 
 class SaveGame;
 
-class ObjectState : public PoolObject<ObjectState, MKTAG('S', 'T', 'A', 'T')> {
+class ObjectState : public PoolObject<ObjectState> {
 public:
 	enum Position {
 		OBJSTATE_BACKGROUND = 0,
@@ -44,6 +44,8 @@ public:
 	ObjectState(int setupID, ObjectState::Position pos, const char *bitmap, const char *zbitmap, bool visible);
 	ObjectState();
 	~ObjectState();
+
+	static int32 getStaticTag() { return MKTAG('S', 'T', 'A', 'T'); }
 
 	void saveState(SaveGame *savedState) const;
 	bool restoreState(SaveGame *savedState);

--- a/engines/grim/primitives.cpp
+++ b/engines/grim/primitives.cpp
@@ -28,8 +28,7 @@
 
 namespace Grim {
 
-PrimitiveObject::PrimitiveObject() :
-	PoolObject<PrimitiveObject, MKTAG('P', 'R', 'I', 'M')>() {
+PrimitiveObject::PrimitiveObject() {
 	_filled = false;
 	_type = 0;
 }

--- a/engines/grim/primitives.h
+++ b/engines/grim/primitives.h
@@ -32,10 +32,12 @@ namespace Grim {
 
 class SaveGame;
 
-class PrimitiveObject : public PoolObject<PrimitiveObject, MKTAG('P', 'R', 'I', 'M')> {
+class PrimitiveObject : public PoolObject<PrimitiveObject> {
 public:
 	PrimitiveObject();
 	~PrimitiveObject();
+
+	static int32 getStaticTag() { return MKTAG('P', 'R', 'I', 'M'); }
 
 	typedef enum {
 		RECTANGLE = 1,

--- a/engines/grim/set.cpp
+++ b/engines/grim/set.cpp
@@ -39,7 +39,7 @@
 namespace Grim {
 
 Set::Set(const Common::String &sceneName, Common::SeekableReadStream *data) :
-		PoolObject<Set, MKTAG('S', 'E', 'T', ' ')>(), _locked(false), _name(sceneName), _enableLights(false) {
+		_locked(false), _name(sceneName), _enableLights(false) {
 
 	char header[7];
 	data->read(header, 7);
@@ -52,8 +52,7 @@ Set::Set(const Common::String &sceneName, Common::SeekableReadStream *data) :
 	}
 }
 
-Set::Set() :
-	PoolObject<Set, MKTAG('S', 'E', 'T', ' ')>(), _cmaps(NULL) {
+Set::Set() : _cmaps(NULL) {
 
 }
 

--- a/engines/grim/set.h
+++ b/engines/grim/set.h
@@ -38,11 +38,13 @@ class SaveGame;
 class CMap;
 class Light;
 
-class Set : public PoolObject<Set, MKTAG('S', 'E', 'T', ' ')> {
+class Set : public PoolObject<Set> {
 public:
 	Set(const Common::String &name, Common::SeekableReadStream *data);
 	Set();
 	~Set();
+
+	static int32 getStaticTag() { return MKTAG('S', 'E', 'T', ' '); }
 
 	void loadText(TextSplitter &ts);
 	void loadBinary(Common::SeekableReadStream *data);

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -37,14 +37,14 @@ TextObjectCommon::TextObjectCommon() :
 }
 
 TextObject::TextObject(bool blastDraw, bool isSpeech) :
-		PoolObject<TextObject, MKTAG('T', 'E', 'X', 'T')>(), TextObjectCommon(), _numberLines(1),
+		TextObjectCommon(), _numberLines(1),
 		_maxLineWidth(0), _lines(0), _userData(0), _created(false) {
 	_blastDraw = blastDraw;
 	_isSpeech = isSpeech;
 }
 
 TextObject::TextObject() :
-	PoolObject<TextObject, MKTAG('T', 'E', 'X', 'T')>(), TextObjectCommon(), _maxLineWidth(0), _lines(NULL) {
+	TextObjectCommon(), _maxLineWidth(0), _lines(NULL) {
 
 }
 

--- a/engines/grim/textobject.h
+++ b/engines/grim/textobject.h
@@ -76,12 +76,14 @@ class TextObjectDefaults : public TextObjectCommon {
 
 };
 
-class TextObject : public PoolObject<TextObject, MKTAG('T', 'E', 'X', 'T')>,
+class TextObject : public PoolObject<TextObject>,
                    public TextObjectCommon {
 public:
 	TextObject(bool blastDraw, bool isSpeech = false);
 	TextObject();
 	~TextObject();
+
+	static int32 getStaticTag() { return MKTAG('T', 'E', 'X', 'T'); }
 
 	void setDefaults(TextObjectDefaults *defaults);
 	void setText(const Common::String &text);


### PR DESCRIPTION
There is no real benefit to this patch, but it does make the code slightly cleaner. Everything should work the same.
