### PR TITLE
GUI: Remove "soft_renderer" setting when not overriding defaults

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -287,10 +287,7 @@ void OptionsDialog::close() {
 				ConfMan.setBool("soft_renderer", _softwareRenderingCheckbox->getState(), _domain);
 			} else {
 				ConfMan.removeKey("fullscreen", _domain);
-				ConfMan.removeKey("aspect_ratio", _domain);
-				ConfMan.removeKey("disable_dithering", _domain);
-				ConfMan.removeKey("gfx_mode", _domain);
-				ConfMan.removeKey("render_mode", _domain);
+				ConfMan.removeKey("soft_renderer", _domain);
 			}
 		}
 


### PR DESCRIPTION
There are still lots of references to GUI options that - as far as I know - aren't used by ResidualVM, but I left those alone.

I was also wondering if changing the software rendering setting should cause graphicsModeChanged to be set to true, but I don't know if the launcher dialog is affected by that setting so perhaps not.
