### PR TITLE
GRIM: Adds a gui option to choose whether to load datausr.lab

### DIFF
--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -42,6 +42,22 @@ static const PlainGameDescriptor grimGames[] = {
 	{0, 0}
 };
 
+#define GAMEOPTION_LOAD_DATAUSR GUIO_GAMEOPTIONS1
+
+static const ADExtraGuiOptionsMap gameGuiOptions[] = {
+	{
+		GAMEOPTION_LOAD_DATAUSR,
+		{
+			"Load user patch (unsupported)",
+			"Load an user patch. Please note that the ResidualVM-team doesn't provide support for using such patches.",
+			"datausr_load",
+			false
+		}
+	},
+
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
 static const GrimGameDescription gameDescriptions[] = {
 	{
 		// Grim Fandango English version (patched)
@@ -52,7 +68,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -65,7 +81,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -78,7 +94,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -91,7 +107,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -104,7 +120,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -117,7 +133,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -130,7 +146,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -143,7 +159,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -156,7 +172,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -169,7 +185,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -182,7 +198,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -195,7 +211,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::PT_BRA,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -208,7 +224,7 @@ static const GrimGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO,
-			GUIO_NONE
+			GUIO1(GAMEOPTION_LOAD_DATAUSR)
 		},
 		GType_GRIM
 	},
@@ -394,7 +410,7 @@ static const Engines::ObsoleteGameID obsoleteGameIDsTable[] = {
 
 class GrimMetaEngine : public AdvancedMetaEngine {
 public:
-	GrimMetaEngine() : AdvancedMetaEngine(Grim::gameDescriptions, sizeof(Grim::GrimGameDescription), grimGames) {
+	GrimMetaEngine() : AdvancedMetaEngine(Grim::gameDescriptions, sizeof(Grim::GrimGameDescription), grimGames, gameGuiOptions) {
 		_singleid = "grim";
 		_guioptions = GUIO_NOMIDI;
 	}

--- a/engines/grim/resource.cpp
+++ b/engines/grim/resource.cpp
@@ -44,7 +44,7 @@
 #include "common/zlib.h"
 #include "common/memstream.h"
 #include "common/file.h"
-#include "gui/message.h"
+#include "common/config-manager.h"
 
 namespace Grim {
 
@@ -108,14 +108,14 @@ ResourceLoader::ResourceLoader() {
 			//Sort the archives in order to ensure that they are loaded with the correct order
 			Common::sort(files.begin(), files.end(), LabListComperator());
 
-			//Check the presence of datausr.lab and ask the user if he wants to load it.
+			//Check the presence of datausr.lab and if the user wants to load it.
 			//In this case put it in the top of the list
 			Common::ArchiveMemberList::iterator datausr_it = Common::find_if(files.begin(), files.end(), LabListComperator("datausr.lab"));
 			if (datausr_it != files.end()) {
-				Grim::InputDialog d("User-patch detected, the ResidualVM-team\n provides no support for using such patches.\n Click OK to load, or Cancel\n to skip the patch.", "OK", false);
-				int res = d.runModal();
-				if (res == GUI::kMessageOK)
+				if (ConfMan.getBool("datausr_load")) {
+					warning("Loading datausr.lab. Please note that the ResidualVM-team doesn't provide support for using such patches");
 					files.push_front(*datausr_it);
+				}
 				files.erase(datausr_it);
 			}
 		}


### PR DESCRIPTION
Instead of prompting the user to choose whether to load datausr.lab every time that he starts GF, this commit adds an option in the "edit game" dialog. It may require to remove and re-add the game from the list to make this option visible
