### PR TITLE
GRIM: draw clean-buffer before text objects

### DIFF
--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -249,6 +249,7 @@ public:
 	virtual void selectScreenBuffer() {}
 	virtual void selectCleanBuffer() {}
 	virtual void clearCleanBuffer() {}
+	virtual void drawCleanBuffer() {}
 
 	virtual void createSpecialtyTextures() = 0;
 	virtual Material *getSpecialtyTexture(int n) { return &_specialty[n]; }

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -311,8 +311,6 @@ void GfxTinyGL::clearScreen() {
 }
 
 void GfxTinyGL::flipBuffer() {
-	TinyGL::ZB_blitOffscreenBuffer(_zb);
-
 	g_system->updateScreen();
 }
 
@@ -326,6 +324,10 @@ void GfxTinyGL::selectCleanBuffer() {
 
 void GfxTinyGL::clearCleanBuffer() {
 	TinyGL::ZB_clearOffscreenBuffer(_zb);
+}
+
+void GfxTinyGL::drawCleanBuffer() {
+	TinyGL::ZB_blitOffscreenBuffer(_zb);
 }
 
 bool GfxTinyGL::isHardwareAccelerated() {

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -117,6 +117,7 @@ public:
 	void selectScreenBuffer();
 	void selectCleanBuffer();
 	void clearCleanBuffer();
+	void drawCleanBuffer();
 
 	void createSpecialtyTextures();
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -555,6 +555,7 @@ void GrimEngine::updateDisplayScene() {
 		// including 3D objects such as Manny and the message tube
 		_currSet->drawBitmaps(ObjectState::OBJSTATE_OVERLAY);
 
+		g_driver->drawCleanBuffer();
 		drawPrimitives();
 	} else if (_mode == DrawMode) {
 		_doFlip = false;


### PR DESCRIPTION
 to avoid them being overdrawn by actors
