### PR TITLE
GRIM: fix lighthouse door by drawing underlays on top of movies

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -501,9 +501,6 @@ void GrimEngine::updateDisplayScene() {
 		// There are a bunch of these, especially in the tube-switcher room
 		_currSet->drawBitmaps(ObjectState::OBJSTATE_BACKGROUND);
 
-		// Underlay objects are just above the background
-		_currSet->drawBitmaps(ObjectState::OBJSTATE_UNDERLAY);
-
 		// State objects are drawn on top of other things, such as the flag
 		// on Manny's message tube
 		_currSet->drawBitmaps(ObjectState::OBJSTATE_STATE);
@@ -525,6 +522,11 @@ void GrimEngine::updateDisplayScene() {
 			else
 				g_driver->releaseMovieFrame();
 		}
+
+		// Underlay objects must be drawn on top of movies
+		// Otherwise the lighthouse door will always be open as the underlay for
+		// the closed door will be overdrawn by a movie used as background image.
+		_currSet->drawBitmaps(ObjectState::OBJSTATE_UNDERLAY);
 
 		// Draw Primitives
 		foreach (PrimitiveObject *p, PrimitiveObject::getPool()) {


### PR DESCRIPTION
The lighthouse door in the close lighthouse view seems to be open even if it is closed. 
The open door is part of the background image which is overlayed with an underlay if the door is closed. 
The scene consists of a background image which is overdrawn by a movie used for animating the waves. As the movie also contains the lighhouse the bg-image is completely overdrawn by the movie, so that not a single part of the bg-image is visible. At the moment, movies are drawn before underlays so the closed door will be overdrawn by the movie.

Changing the order in which movies and underlays are drawn fixes this problem.
