### PR TITLE
EMI: TextSplitter supports spaces in %[...] format

### DIFF
--- a/engines/grim/textsplit.cpp
+++ b/engines/grim/textsplit.cpp
@@ -169,7 +169,7 @@ static void parse(const char *line, const char *fmt, int field_count, va_list va
 					++src;
 				}
 
-				delete allowed;
+				delete[] allowed;
 			} else {
 				char nextChar = format[i];
 				while (src[0] == ' ') { //skip initial whitespace


### PR DESCRIPTION
As discussed on IRC, this patch accounts for the spaces in filenames in the EMI demo music table.
