### PR TITLE
TinyGL: Fix ZB_fillTriangleSmooth to support the colour-support patch.

### DIFF
--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -43,23 +43,24 @@ void ZB_fillTriangleSmooth(ZBuffer *zb, ZBufferPoint *p0, ZBufferPoint *p1, ZBuf
 	_drgbdx |= (SAR_RND_TO_ZERO(dbdx, 7) << 12) & 0x001FF000; 	\
 }
 
-#define PUT_PIXEL(_a) {						\
-	if (ZCMP(z, pz[_a])) {					\
-		tmp = rgb & 0xF81F07E0;				\
-		pp[_a] = tmp | (tmp >> 16);			\
-		pz[_a] = z;							\
-	}										\
-	z += dzdx;								\
-	rgb = (rgb + drgbdx) & (~0x00200800);	\
+#define PUT_PIXEL(_a) {							\
+	if (ZCMP(z, pz[_a])) {						\
+		tmp = rgb & 0xF81F07E0;					\
+		buf.setPixelAt(_a, tmp | (tmp >> 16));	\
+		pz[_a] = z;								\
+	}											\
+	z += dzdx;									\
+	rgb = (rgb + drgbdx) & (~0x00200800);		\
 }
 
 #define DRAW_LINE()	{								\
 	register unsigned int *pz;						\
-	register PIXEL *pp;								\
+	Graphics::PixelBuffer buf = zb->pbuf;			\
 	register unsigned int z, rgb, drgbdx;			\
 	register int n;									\
 	n = (x2 >> 16) - x1;							\
-	pp = pp1 + x1;									\
+	int bpp = buf.getFormat().bytesPerPixel;		\
+	buf = (byte *)pp1 + x1 * bpp;					\
 	pz = pz1 + x1;									\
 	z = z1;											\
 	rgb =(r1 << 16) & 0xFFC00000;					\
@@ -72,13 +73,13 @@ void ZB_fillTriangleSmooth(ZBuffer *zb, ZBufferPoint *p0, ZBufferPoint *p1, ZBuf
 		PUT_PIXEL(2);								\
 		PUT_PIXEL(3);								\
 		pz += 4;									\
-		pp += 4;									\
+		buf.shiftBy(4);								\
 		n -= 4;										\
 	}												\
 	while (n >= 0) {								\
 		PUT_PIXEL(0);								\
+		buf.shiftBy(1);								\
 		pz += 1;									\
-		pp += 1;									\
 		n -= 1;										\
 	}												\
 }


### PR DESCRIPTION
This seems to fix the TinyGL-issues in EMI, I'm not at all sure if this is the right way to do this.

The problem seems to be that this code ZB_fillTriangleSmooth still expects the buffer to be
16-bit, (as changing pp to be unsigned short\* instead of PIXEL (which changed to byte\* in 158a19df319d1c7aec8013ac308917800b22ea09) also yields good results.

The multiplication by bytesPerPixel is the thing I'm the most unsure about, most of this was written based on reading the above mentioned commit, and guessing.

No thorough testing has been done on Grim for this (does Grim even use fillTriangleSmooth?), as this pull request is mostly made to ask "Is this a decent fix?"

Comments very welcome.
