### PR TITLE
EMI: Load TIL files correctly

### DIFF
--- a/engines/grim/bitmap.h
+++ b/engines/grim/bitmap.h
@@ -102,6 +102,24 @@ public:
 
 	int _refCount;
 
+	float *_texc;
+
+	struct Vert {
+		uint32 _texid;
+		uint32 _pos;
+		uint32 _verts;
+	};
+	struct Offset {
+		uint32 _offset;
+		uint32 _numImages;
+	};
+	Vert *_verts;
+	Offset *_offsets;
+	uint32 _numCoords;
+	uint32 _numVerts;
+	uint32 _numOffsets;
+	uint32 _curOffset;
+
 // private:
 	Graphics::PixelBuffer *_data;
 };
@@ -153,7 +171,7 @@ public:
 
 	virtual ~Bitmap();
 
-private:
+//private:
 	void freeData();
 
 	BitmapData *_data;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -805,6 +805,42 @@ void GfxOpenGL::createBitmap(BitmapData *bitmap) {
 }
 
 void GfxOpenGL::drawBitmap(const Bitmap *bitmap, int dx, int dy) {
+
+	if (g_grim->getGameType() == GType_MONKEY4) {
+		glMatrixMode(GL_PROJECTION);
+		glLoadIdentity();
+		glOrtho(-1, 1, -1, 1, 0, 1);
+
+		glDisable(GL_LIGHTING);
+		glEnable(GL_TEXTURE_2D);
+
+		glDisable(GL_DEPTH_TEST);
+		glDepthMask(GL_FALSE);
+
+		BitmapData *data = bitmap->_data;
+		GLuint *textures = (GLuint *)bitmap->getTexIds();
+		float *texc = data->_texc;
+		uint32 offset = data->_offsets[data->_curOffset]._offset;
+		for (uint32 i = offset; i < offset + data->_offsets[data->_curOffset]._numImages; ++i) {
+			glBindTexture(GL_TEXTURE_2D, textures[data->_verts[i]._texid]);
+			glBegin(GL_QUADS);
+			uint32 ntex = data->_verts[i]._pos * 4;
+			for (uint32 x = 0; x < data->_verts[i]._verts; ++x) {
+				glTexCoord2f(texc[ntex + 2], texc[ntex + 3]);
+				glVertex2f(texc[ntex + 0], texc[ntex + 1]);
+				ntex += 4;
+			}
+			glEnd();
+		}
+
+		glDisable(GL_TEXTURE_2D);
+		glDepthMask(GL_TRUE);
+		glEnable(GL_DEPTH_TEST);
+		glEnable(GL_LIGHTING);
+
+		return;
+	}
+
 	int format = bitmap->getFormat();
 	if ((format == 1 && !_renderBitmaps) || (format == 5 && !_renderZBitmaps)) {
 		return;


### PR DESCRIPTION
This uses the data in the TIL to position the bitmaps instead of the way we made up to do it. This makes it call the exact same OpenGL functions that Monkey4.exe does.

The only problems I see with it are that there is no TinyGL version, because I don't know TinyGL enough and that I had to make BitmapData in Bitmap no longer private, or add a large number of accessor functions. If anyone can solve either of those problems that would be awesome.

I should be able to have the simulated depth that emi uses working soon as all the information is loaded. I just need to figure out the order to draw things.
