### PR TITLE
RFC: EMI: Implement push and pop text opcodes

### DIFF
--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -307,13 +307,25 @@ void Lua_V2::GetCameraRoll() {
 	lua_pushnumber(0);
 }
 
-// I suspect that pushtext and poptext stack the current text objects.
+Common::List<Common::List<TextObject *> *> textstack;
 void Lua_V2::PushText() {
-	warning("Lua_V2::PushText: implement opcode");
+	Common::List<TextObject *> *textobjects = new Common::List<TextObject *>;
+	TextObject::Pool::iterator it = TextObject::getPool().begin();
+	for (; it != TextObject::getPool().end(); ++it) {
+		textobjects->push_back(*it);
+		TextObject::getPool().removeObject((*it)->getId());
+	}
+	textstack.push_front(textobjects);
 }
 
 void Lua_V2::PopText() {
-	warning("Lua_V2::PopText: implement opcode");
+	Common::List<TextObject *> *textobjects = textstack.front();
+	textstack.pop_front();
+	Common::List<TextObject *>::iterator it = textobjects->begin();
+	for (; it != textobjects->end(); ++it) {
+		TextObject::getPool().addObject(*it);
+	}
+	delete textobjects;
 }
 
 void Lua_V2::GetSectorName() {


### PR DESCRIPTION
This is fairly simple code to implement these opcodes. The only problem is I'm not sure where to store the stack of text objects. One thought I had was to build stacking into the object pool system, but then that would probably end up adding overhead to objects which do not need to be stacked. Any suggestions?

These opcodes are only used in a few places, but are used by the menu to store the text objects when an confirmation window comes up, for example, when you go to load a save game and then cancel, without this patch you get a jumble of both sets of text objects, with it, it looks proper.
