### PR TITLE
GRIM: Fix regression in sprite drawing

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -609,8 +609,7 @@ void GfxOpenGL::drawSprite(const Sprite *sprite) {
 		glTexCoord2f(1.0f, 1.0f);
 		glVertex3f(+halfWidth, -halfHeight, 0.0f);
 		glEnd();
-	}
-	else {
+	} else {
 		// In Grim, the bottom edge of the sprite is at y=0 and
 		// the texture is flipped along the X-axis.
 		float halfWidth = (sprite->_width / 2) * _scaleW;

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -685,8 +685,7 @@ void GfxTinyGL::drawSprite(const Sprite *sprite) {
 
 	tglDisable(TGL_LIGHTING);
 
-	if (g_grim->getGameType() == GType_MONKEY4)
-	{
+	if (g_grim->getGameType() == GType_MONKEY4) {
 		float halfWidth = (sprite->_width / 2) * _scaleW;
 		float halfHeight = (sprite->_height / 2) * _scaleH;
 
@@ -700,9 +699,7 @@ void GfxTinyGL::drawSprite(const Sprite *sprite) {
 		tglTexCoord2f(1.0f, 1.0f);
 		tglVertex3f(+halfWidth, -halfHeight, 0.0f);
 		tglEnd();
-	}
-	else
-	{
+	} else {
 		// In Grim, the bottom edge of the sprite is at y=0 and
 		// the texture is flipped along the X-axis.
 		float halfWidth = (sprite->_width / 2) * _scaleW;


### PR DESCRIPTION
The commit 92213b0 which was apparently meant to fix EMI-specific issues with sprites, also changed behavior in Grim.

The old code constructed the sprite polygon so that the center of the bottom edge was at the sprite's origin, and the texture was flipped along the X-axis. With the current code the sprite is centered on the origin and the texture is no longer flipped on the X-axis.

The old way may seem wrong, but it is in fact the same behavior as in the original game. Because of the change, sprites now appear somewhat lower than in the original Grim and the textures are flipped when compared to the original.

This request restores the old behavior which is correct in Grim, but EMI will keep the current behavior. I'm assuming here that the current behavior (center sprite on origin, do not flip the texture) is desired in EMI, but I don't have a working copy of EMI so I can't test to see.
