### PR TITLE
GRIM: Don't save and restore last_set anymore

### DIFF
--- a/README
+++ b/README
@@ -174,19 +174,13 @@ Unix users may be able to achieve playable framerates by using Mesa 5.0 or
 above, but people unable to upgrade or Windows users must use software
 renderer. Software renderer is generally faster on modern platforms.
 
-6.2 - I played a bit, but can't start a new game!
--------------------------------------------------
-This is because the last save and visited scene is stored in your configuration
-file, either delete grim-fandango from the ResidualVM-menu, and re-add it, or 
-go to your configuration file, and clean out the last-save and last-set entries.
-
-6.3 - My Save Games don't work any more
+6.2 - My Save Games don't work any more
 ---------------------------------------
 Did you recently update to a newer build of ResidualVM? 
 Grim engine is still a work in progress, which means that it might
 change between builds. 
 
-6.4 - In fullscreen mode picture is stretched!
+6.3 - In fullscreen mode picture is stretched!
 ----------------------------------------------
 This is know issue, in future versions it will be resolved.
 

--- a/engines/grim/registry.cpp
+++ b/engines/grim/registry.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "engines/grim/registry.h"
+#include "engines/grim/debug.h"
 
 #include "audio/mixer.h"
 
@@ -131,6 +132,8 @@ Registry::Registry() : _dirty(true) {
 	_movement.setString(ConfMan.get("movement"));
 	_joystick.setString(ConfMan.get("joystick"));
 	_transcript.setString(ConfMan.get("transcript"));
+
+	_emptyString.setString(Common::String(""));
 }
 
 Registry::Value &Registry::value(const Common::String &key) {
@@ -141,7 +144,11 @@ Registry::Value &Registry::value(const Common::String &key) {
 	} else if (scumm_stricmp("savepath", key.c_str()) == 0) {
 		return _savePath;
 	} else if (scumm_stricmp("GrimLastSet", key.c_str()) == 0) {
-		return _lastSet;
+		//Restore last_set only if engine debugflag is set
+		if (!Debug::isChannelEnabled(Debug::Engine))
+			return _emptyString;
+		else
+			return _lastSet;
 	} else if (scumm_stricmp("MusicVolume", key.c_str()) == 0) {
 		return _musicVolume;
 	} else if (scumm_stricmp("SfxVolume", key.c_str()) == 0) {
@@ -189,7 +196,11 @@ const Registry::Value &Registry::value(const Common::String &key) const {
 	} else if (scumm_stricmp("savepath", key.c_str()) == 0) {
 		return _savePath;
 	} else if (scumm_stricmp("GrimLastSet", key.c_str()) == 0) {
-		return _lastSet;
+		//Restore last_set only if engine debugflag is set
+		if (!Debug::isChannelEnabled(Debug::Engine))
+			return _emptyString;
+		else
+			return _lastSet;
 	} else if (scumm_stricmp("MusicVolume", key.c_str()) == 0) {
 		return _musicVolume;
 	} else if (scumm_stricmp("SfxVolume", key.c_str()) == 0) {

--- a/engines/grim/registry.h
+++ b/engines/grim/registry.h
@@ -98,6 +98,7 @@ private:
 	Value _engineSpeed;
 	Value _transcript;
 	Value _useArbShaders;
+	Value _emptyString;
 
 	bool _dirty;
 


### PR DESCRIPTION
With this commit ResidualVM doesn't save and restore the last_set key anymore, so even if developer mode is set, it start from the intro every time and not from the last set.

Does anyone find this feature useful and prefer the standard behavior?
