### PR TITLE
GRIM: Draw the scene before updating the lua

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -692,10 +692,19 @@ void GrimEngine::mainLoop() {
 				_refreshDrawNeeded = true;
 		}
 
+		if (_mode != PauseMode) {
+			// Draw the display scene before doing the luaUpdate.
+			// This give a large performance boost as OpenGL stores commands
+			// in a queue on the gpu to be rendered later. When doFlip is
+			// called the cpu must wait for the gpu to finish its queue.
+			// Now, it will queue all the OpenGL commands and draw them on the
+			// GPU while the CPU is busy updating the game world.
+			updateDisplayScene();
+		}
+
 		luaUpdate();
 
 		if (_mode != PauseMode) {
-			updateDisplayScene();
 			doFlip();
 		}
 


### PR DESCRIPTION
This change probably doesn't make very much sense at first glance, but for me I get an extra 60fps, or an extra 200fps in debug mode, when I turn frame limiting off. It should potentially help slower devices, provided they have well written opengl drivers. The only downside I see is that what is displayed on the screen could be an entire frame behind what is happening, but for this game that shouldn't matter.

Now why does this help? OpenGL queues each draw command and actually draws it on the graphics card at the same time the cpu is doing other work. As it was there was no other work for the CPU to be doing as it was forced to wait for the GPU to catch up each time the buffers are flipped. With the change, it draws the previous frame while working on the next frame.

I have only done a little bit of testing, but I don't see any problems arising from this.

Thoughts?
