### PR TITLE
GRIM: Avoid compressing LUA-output Savedata

### DIFF
--- a/engines/grim/lua/liolib.cpp
+++ b/engines/grim/lua/liolib.cpp
@@ -232,7 +232,7 @@ static void io_writeto() {
 		LuaFile *current;
 		Common::WriteStream *outFile = NULL;
 		Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
-		outFile = saveFileMan->openForSaving(s);
+		outFile = saveFileMan->openForSaving(s, false);
 		if (!outFile) {
 			pushresult(0);
 			return;


### PR DESCRIPTION
The current LUA code GZips the output from LUA-file I/O that goes to the savegame folder, this makes some of the files rather useless.
- Grim's dialog transcript needs decompressing to be user-readable. Thus it makes little sense to have it stored like that if users want to read outside of ResidualVM.
- efmi.cfg for EFMI is currently stored gzipped, thus hard to edit/read outside of ResidualVM.

This simple fix disables the gzipping of these files, making them user-editable.
