### PR TITLE
GRIM: Filter savegame list to avoid EMI-saves polluting it.

### DIFF
--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -407,7 +407,7 @@ void Lua_V1::FileFindFirst() {
 
 	const char *extension = lua_getstring(extObj);
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
-	g_grim->_listFiles = saveFileMan->listSavefiles(extension);
+	g_grim->_listFiles = saveFileMan->listSavefiles(Common::String("grim??") + extension);
 	Common::sort(g_grim->_listFiles.begin(), g_grim->_listFiles.end());
 	g_grim->_listFilesIter = g_grim->_listFiles.begin();
 


### PR DESCRIPTION
The current code simply filters savegames based on *.gsv, this quick-fix adds "grim" to the filter, to avoid including "efmi"-saves in the Grim-list of saves.

There are probably better ways to resolve this, but I thought I'd PR this to make the issue visible.
