### PR TITLE
EMI: Move sound-related warnings to a separate Debug-channel.

### DIFF
--- a/engines/grim/debug.cpp
+++ b/engines/grim/debug.cpp
@@ -45,6 +45,7 @@ void Debug::registerDebugChannels() {
 	DebugMan.addDebugChannel(Sets, "sets", "");
 	DebugMan.addDebugChannel(TextObjects, "textobjects", "");
 	DebugMan.addDebugChannel(Patchr, "patchr", "");
+	DebugMan.addDebugChannel(EMISound, "emisound", "");
 	DebugMan.addDebugChannel(All, "all", "");
 }
 

--- a/engines/grim/debug.h
+++ b/engines/grim/debug.h
@@ -50,6 +50,7 @@ public:
 		Sets = 2 << 15,
 		TextObjects = 2 << 16,
 		Patchr = 2 << 17,
+		EMISound = 2 << 18,
 		All = 0xFFFFFF
 	};
 

--- a/engines/grim/emi/lua_v2_sound.cpp
+++ b/engines/grim/emi/lua_v2_sound.cpp
@@ -30,6 +30,7 @@
 #include "engines/grim/emi/poolsound.h"
 #include "engines/grim/lua/lua.h"
 
+#include "engines/grim/debug.h"
 #include "engines/grim/sound.h"
 #include "engines/grim/grim.h"
 #include "engines/grim/resource.h"
@@ -48,7 +49,7 @@ void Lua_V2::ImGetMillisecondPosition() {
 		// Currently a bit of guesswork, and probably wrong, as the stateId
 		// is ignored by emisound (which only has one music-track now).
 		uint32 msPos = g_sound->getMsPos(sound);
-		warning("Lua_V2::ImGetMillisecondPosition: sound: %d ms: %d", sound, msPos);
+		Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::ImGetMillisecondPosition: sound: %d ms: %d", sound, msPos);
 		lua_pushnumber(msPos);
 	}
 }
@@ -90,7 +91,7 @@ void Lua_V2::SetReverb() {
 	if (lua_isnumber(dampingObj))
 		damping = lua_getnumber(dampingObj);
 
-	warning("Lua_V2::SetReverb, eax: %d, decay: %f, mix: %f, predelay: %f, damping: %f", param, decay, mix, predelay, damping);
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::SetReverb, eax: %d, decay: %f, mix: %f, predelay: %f, damping: %f", param, decay, mix, predelay, damping);
 	// FIXME: func(param, decay, mix, predelay, damping);
 }
 
@@ -101,7 +102,7 @@ void Lua_V2::ImSetState() {
 
 	int state = (int)lua_getnumber(stateObj);
 	g_imuseState = state;
-	warning("Lua_V2::ImSetState: stub, state: %d", state);
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::ImSetState: stub, state: %d", state);
 }
 
 void Lua_V2::ImStateHasEnded() {
@@ -114,7 +115,7 @@ void Lua_V2::ImStateHasEnded() {
 	// FIXME: Make sure this logic is correct.
 	pushbool(g_imuseState != state);
 
-	warning("Lua_V2::ImStateHasEnded: state %d.", state);
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::ImStateHasEnded: state %d.", state);
 }
 
 void Lua_V2::EnableVoiceFX() {
@@ -125,7 +126,7 @@ void Lua_V2::EnableVoiceFX() {
 		state = true;
 
 	// FIXME: func(state);
-	warning("Lua_V2::EnableVoiceFX: implement opcode, state: %d", (int)state);
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::EnableVoiceFX: implement opcode, state: %d", (int)state);
 }
 
 void Lua_V2::SetGroupVolume() {
@@ -156,7 +157,7 @@ void Lua_V2::SetGroupVolume() {
 			error("Lua_V2::SetGroupVolume - unknown group %d", group);
 	}
 	// FIXME: func(group, volume);
-	warning("Lua_V2::SetGroupVolume: group: %d, volume %d", group, volume);
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::SetGroupVolume: group: %d, volume %d", group, volume);
 }
 
 void Lua_V2::EnableAudioGroup() {
@@ -186,7 +187,7 @@ void Lua_V2::EnableAudioGroup() {
 			error("Lua_V2::EnableAudioGroup - unknown group %d", group);
 	}
 
-	warning("Lua_V2::EnableAudioGroup: group: %d, state %d", group, (int)state);
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::EnableAudioGroup: group: %d, state %d", group, (int)state);
 }
 
 void Lua_V2::ImSelectSet() {
@@ -196,13 +197,13 @@ void Lua_V2::ImSelectSet() {
 		int quality = (int)lua_getnumber(qualityObj);
 		// FIXME: func(quality);
 		g_sound->selectMusicSet(quality);
-		warning("Lua_V2::ImSelectSet: quality mode: %d", quality);
+		Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::ImSelectSet: quality mode: %d", quality);
 	}
 }
 
 void Lua_V2::ImFlushStack() {
 	// FIXME
-	warning("Lua_V2::ImFlushStack: currently guesswork");
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::ImFlushStack: currently guesswork");
 	g_sound->flushStack();
 }
 
@@ -262,7 +263,7 @@ void Lua_V2::PlayLoadedSound() {
 }
 
 void Lua_V2::PlayLoadedSoundFrom() {
-	warning("Lua_V2::PlayLoadedSoundFrom: implement opcode");
+	Debug::debug(Debug::EMISound | Debug::Scripts,"Lua_V2::PlayLoadedSoundFrom: implement opcode");
 }
 
 void Lua_V2::StopSound() {
@@ -291,7 +292,7 @@ void Lua_V2::PlaySound() {
 
 	Common::SeekableReadStream *stream = g_resourceloader->openNewStreamFile(filename, true);
 	if (!stream) {
-		warning("Lua_V2::PlaySound: Could not find sound '%s'", filename.c_str());
+		Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::PlaySound: Could not find sound '%s'", filename.c_str());
 		return;
 	}
 
@@ -323,7 +324,7 @@ void Lua_V2::ImSetMusicVol() {
 	if (!lua_isnumber(volumeObj))
 		return;
 	int volume = (int)lua_getnumber(volumeObj);
-	warning("Lua_V2::ImSetMusicVol: implement opcode, wants volume %d", volume);
+	Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::ImSetMusicVol: implement opcode, wants volume %d", volume);
 }
 
 void Lua_V2::ImSetSfxVol() {
@@ -333,7 +334,7 @@ void Lua_V2::ImSetSfxVol() {
 	if (!lua_isnumber(volumeObj))
 		return;
 	int volume = (int)lua_getnumber(volumeObj);
-	warning("Lua_V2::ImSetSfxVol: implement opcode, wants volume %d", volume);
+	Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::ImSetSfxVol: implement opcode, wants volume %d", volume);
 }
 
 void Lua_V2::ImSetVoiceVol() {
@@ -343,7 +344,7 @@ void Lua_V2::ImSetVoiceVol() {
 	if (!lua_isnumber(volumeObj))
 		return;
 	int volume = (int)lua_getnumber(volumeObj);
-	warning("Lua_V2::ImSetVoiceVol: implement opcode, wants volume %d", volume);
+	Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::ImSetVoiceVol: implement opcode, wants volume %d", volume);
 }
 
 void Lua_V2::ImSetVoiceEffect() {
@@ -354,20 +355,20 @@ void Lua_V2::ImSetVoiceEffect() {
 		return;
 
 	const char *str = lua_getstring(strObj);
-	warning("Lua_V2::ImSetVoiceEffect: implement opcode, wants effect %s", str);
+	Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::ImSetVoiceEffect: implement opcode, wants effect %s", str);
 }
 
 void Lua_V2::StopAllSounds() {
-	warning("Lua_V2::StopAllSounds: implement opcode");
+	Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::StopAllSounds: implement opcode");
 }
 
 void Lua_V2::ImPushState() {
 	g_sound->pushState();
-	warning("Lua_V2::ImPushState: currently guesswork");
+	Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::ImPushState: currently guesswork");
 }
 void Lua_V2::ImPopState() {
 	g_sound->popState();
-	warning("Lua_V2::ImPopState: currently guesswork");
+	Debug::debug(Debug::EMISound | Debug::Scripts, "Lua_V2::ImPopState: currently guesswork");
 }
 
 } // end of namespace Grim

--- a/engines/grim/emi/sound/aifftrack.cpp
+++ b/engines/grim/emi/sound/aifftrack.cpp
@@ -21,10 +21,10 @@
  */
 
 #include "common/mutex.h"
-#include "common/textconsole.h"
 #include "audio/mixer.h"
 #include "audio/audiostream.h"
 #include "audio/decoders/aiff.h"
+#include "engines/grim/debug.h"
 #include "engines/grim/resource.h"
 #include "engines/grim/emi/sound/aifftrack.h"
 
@@ -43,7 +43,7 @@ AIFFTrack::~AIFFTrack() {
 	
 bool AIFFTrack::openSound(Common::String soundName, Common::SeekableReadStream *file) {
 	if (!file) {
-		warning("Stream for %s not open", soundName.c_str());
+		Debug::debug(Debug::EMISound, "Stream for %s not open", soundName.c_str());
 		return false;
 	}
 	_soundName = soundName;

--- a/engines/grim/emi/sound/emisound.cpp
+++ b/engines/grim/emi/sound/emisound.cpp
@@ -25,6 +25,7 @@
 #include "audio/audiostream.h"
 #include "audio/decoders/raw.h"
 #include "audio/mixer.h"
+#include "engines/grim/debug.h"
 #include "engines/grim/sound.h"
 #include "engines/grim/grim.h"
 #include "engines/grim/resource.h"
@@ -128,7 +129,7 @@ void EMISound::setVolume(const char *soundName, int volume) {
 }
 
 void EMISound::setPan(const char *soundName, int pan) {
-	warning("EMI doesn't support sound-panning yet, %s", soundName);
+	Debug::debug(Debug::EMISound, "EMI doesn't support sound-panning yet, %s", soundName);
 }
 	
 void EMISound::setMusicState(int stateId) {
@@ -139,16 +140,16 @@ void EMISound::setMusicState(int stateId) {
 	if (stateId == 0)
 		return;
 	if (_musicTable == NULL) {
-		warning("No music table loaded");
+		Debug::debug(Debug::EMISound, "No music table loaded");
 		return;
 	}
 	if (_musicTable[stateId]._id != stateId) {
-		warning("Attempted to play track #%d, not found in music table!", stateId);
+		Debug::debug(Debug::EMISound, "Attempted to play track #%d, not found in music table!", stateId);
 		return;
 	}
 	Common::String filename;
 	if (g_grim->getGamePlatform() == Common::kPlatformPS2) {
-		warning("PS2 doesn't have musictable yet %d ignored, just playing 1195.SCX", stateId);
+		Debug::debug(Debug::EMISound, "PS2 doesn't have musictable yet %d ignored, just playing 1195.SCX", stateId);
 		// So, we just rig up the menu-song hardcoded for now, as a test of the SCX-code.
 		filename = "1195.SCX";
 		_music = new SCXTrack(Audio::Mixer::kMusicSoundType);
@@ -156,7 +157,7 @@ void EMISound::setMusicState(int stateId) {
 		filename = _musicTable[stateId]._filename;
 		_music = new MP3Track(Audio::Mixer::kMusicSoundType);	
 	}
-	warning("Loading music: %s", filename.c_str());
+	Debug::debug(Debug::EMISound, "Loading music: %s", filename.c_str());
 	Common::SeekableReadStream *str = g_resourceloader->openNewStreamFile(_musicPrefix + filename);
 
 	if (_music->openSound(filename, str))

--- a/engines/grim/emi/sound/mp3track.cpp
+++ b/engines/grim/emi/sound/mp3track.cpp
@@ -21,10 +21,10 @@
  */
 
 #include "common/mutex.h"
-#include "common/textconsole.h"
 #include "audio/mixer.h"
 #include "audio/audiostream.h"
 #include "audio/decoders/mp3.h"
+#include "engines/grim/debug.h"
 #include "engines/grim/resource.h"
 #include "engines/grim/emi/sound/mp3track.h"
 
@@ -68,7 +68,7 @@ bool MP3Track::openSound(Common::String soundName, Common::SeekableReadStream *f
 	return false;
 #else
 	if (!file) {
-		warning("Stream for %s not open", soundName.c_str());
+		Debug::debug(Debug::EMISound, "Stream for %s not open", soundName.c_str());
 		return false;
 	}
 	_soundName = soundName;

--- a/engines/grim/emi/sound/vimatrack.cpp
+++ b/engines/grim/emi/sound/vimatrack.cpp
@@ -26,6 +26,7 @@
 #include "audio/audiostream.h"
 #include "audio/mixer.h"
 #include "audio/decoders/raw.h"
+#include "engines/grim/debug.h"
 #include "engines/grim/imuse/imuse_mcmp_mgr.h"
 #include "engines/grim/emi/sound/vimatrack.h"
 
@@ -188,7 +189,7 @@ void VimaTrack::playTrack() {
 				return;
 			}
 		} else {
-			warning("Out of regions");
+			Debug::debug(Debug::EMISound, "VimaTrack::playTrack() - Out of regions");
 			//return;
 		}
 		mixer_size -= result;


### PR DESCRIPTION
This moves a lot of the noise created from the music-system's various warnings into a separate debug-channel, this helps greatly for i.e. the massive querying that is done during the intro.

However, some of these warnings might be stuff people WANT to be warned about in general (i.e. "TODO: Implement this-style warnings). So, any comments on what keep, and what to move, is greatly appreciated.
