### PR TITLE
EMI: Implement setting actor sort order based on sector sort planes

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1361,6 +1361,22 @@ void Actor::update(uint frameTime) {
 		g_grim->getCurrSet()->findClosestSector(_pos, NULL, &_pos);
 	}
 
+	if (g_grim->getGameType() == GType_MONKEY4) {
+		Set *set = g_grim->getCurrSet();
+		Sector *sect = set->findPointSector(_pos, Sector::WalkType);
+		int setup = set->getSetup();
+		if (sect) {
+			int sortorder = 0;
+			if (setup < sect->getNumSortplanes()) {
+				sortorder = sect->getSortplane(setup);
+			}
+			if (getSortOrder() != sortorder) {
+				setSortOrder(sortorder);
+				g_grim->invalidateActiveActorsList();
+			}
+		}
+	}
+
 	if (_turning) {
 		float turnAmt = g_grim->getPerSecond(_turnRate) * _turnRateMultiplier;
 		_currTurnDir = animTurn(turnAmt, _moveYaw, &_yaw);

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -567,12 +567,15 @@ void GrimEngine::updateDisplayScene() {
 				if (a->getSortOrder() < 0)
 					break;
 
-				while (a->getSortOrder() < currentLayer * 10 && currentLayer >= 0) {
+				while (a->getSortOrder() <= currentLayer * 10 && currentLayer >= 0) {
 					background->drawLayer(currentLayer--);
 				}
 
 				if (a->isVisible())
 					a->draw();
+			}
+			while (currentLayer >= 0) {
+				background->drawLayer(currentLayer--);
 			}
 		}
 

--- a/engines/grim/sector.h
+++ b/engines/grim/sector.h
@@ -84,6 +84,8 @@ public:
 	};
 	void getExitInfo(const Math::Vector3d &start, const Math::Vector3d &dir, struct ExitInfo *result) const;
 
+	int getNumSortplanes() { return _numSortplanes; }
+	int getSortplane(int setup) { return _sortplanes[setup]; }
 	int getNumVertices() { return _numVertices; }
 	Math::Vector3d *getVertices() { return _vertices; }
 	Math::Vector3d getNormal() { return _normal; }


### PR DESCRIPTION
This commit makes it so that all the background pieces render in front of the actors when they should, and behind when they should. The only thing I'm not happy with is that it is run every frame, but I'm not sure if there are situations later on where this may be required.
