### PR TITLE
EMI: Properly handle endianness of TIL backgrounds

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -316,6 +316,20 @@ bool BitmapData::loadTile(Common::SeekableReadStream *o) {
 		data[i] = new char[size];
 		o->seek(8, SEEK_CUR);
 		o->read(data[i], size);
+
+#ifdef SCUMM_BIG_ENDIAN
+		if (_bpp == 16) {
+			uint16 *d = (uint16 *)data[i];
+			for (int j = 0; j < _width * _height; ++j) {
+				d[j] = SWAP_BYTES_16(d[j]);
+			}
+		} else if (_bpp == 32) {
+			uint32 *d = (uint32 *)data[i];
+			for (int j = 0; j < _width * _height; ++j) {
+				d[j] = SWAP_BYTES_32(d[j]);
+			}
+		}
+#endif
 	}
 
 	Graphics::PixelFormat pixelFormat;


### PR DESCRIPTION
This code is essentially the same as what grim uses for it's backgrounds. We could also do a read loop, but that would hurt LE performance (a tiny bit). Any opinions?

Is there some way to make the code accept 16 bpp and 32 bpp without the same code twice?
