### PR TITLE
EMI: Fix invisible floor in the Hall of Justice

### DIFF
--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -523,6 +523,7 @@ public:
 
 	int getSortOrder() const { return _sortOrder; }
 	void setSortOrder(const int order) { _sortOrder = order; }
+	int getEffectiveSortOrder() const { return _haveSectorSortOrder ? _sectorSortOrder : _sortOrder; }
 
 	void activateShadow(bool active) { _shadowActive = active; }
 
@@ -677,6 +678,8 @@ private:
 	bool _inOverworld;
 
 	int _sortOrder;
+	bool _haveSectorSortOrder;
+	int _sectorSortOrder;
 
 	bool _shadowActive;
 	int _cleanBuffer;

--- a/engines/grim/emi/emi.cpp
+++ b/engines/grim/emi/emi.cpp
@@ -117,7 +117,7 @@ void EMIEngine::drawNormalMode() {
 	uint32 numLayers = background->_data->_numLayers;
 	int32 currentLayer = numLayers - 1;
 	foreach (Actor *a, _activeActors) {
-		int sortorder = a->getSortOrder();
+		int sortorder = a->getEffectiveSortOrder();
 		if (sortorder < 0)
 			break;
 
@@ -151,10 +151,10 @@ void EMIEngine::invalidateSortOrder() {
 }
 
 bool EMIEngine::compareActor(const Actor *x, const Actor *y) {
-	if (x->getSortOrder() == y->getSortOrder()) {
+	if (x->getEffectiveSortOrder() == y->getEffectiveSortOrder()) {
 		return x->getId() < y->getId();
 	}
-	return x->getSortOrder() > y->getSortOrder();
+	return x->getEffectiveSortOrder() > y->getEffectiveSortOrder();
 }
 
 void EMIEngine::sortActiveActorsList() {


### PR DESCRIPTION
This is a second attempt at fixing the invisible floor in the Hall of Justice. My initial approach had the problem that it updated the actor's sort order with the value from the sector's sort plane. This broke things when moving from a sector with sort information to a sector without.

The new version keeps the original sort order set by the game script and returns to it when entering a sector without sort information.
