### PR TITLE
EMI: Fix color of menu entries

### DIFF
--- a/engines/grim/emi/emi.cpp
+++ b/engines/grim/emi/emi.cpp
@@ -36,7 +36,8 @@ namespace Grim {
 EMIEngine *g_emi = NULL;
 
 EMIEngine::EMIEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, Common::Platform platform, Common::Language language) :
-		GrimEngine(syst, gameFlags, gameType, platform, language), _sortOrderInvalidated(false) {
+		GrimEngine(syst, gameFlags, gameType, platform, language), _sortOrderInvalidated(false), _textObjectsSortOrderInvalidated(true) {
+
 	g_emi = this;
 	g_emiregistry = new EmiRegistry();
 }
@@ -141,6 +142,10 @@ void EMIEngine::drawNormalMode() {
 
 }
 
+void EMIEngine::invalidateTextObjectsSortOrder() {
+	_textObjectsSortOrderInvalidated = true;
+}
+
 void EMIEngine::invalidateActiveActorsList() {
 	GrimEngine::invalidateActiveActorsList();
 	invalidateSortOrder();
@@ -148,6 +153,31 @@ void EMIEngine::invalidateActiveActorsList() {
 
 void EMIEngine::invalidateSortOrder() {
 	_sortOrderInvalidated = true;
+}
+
+bool EMIEngine::compareTextLayer(const TextObject *x, const TextObject *y) {
+	return x->getLayer() < y->getLayer();
+}
+
+void EMIEngine::drawTextObjects() {
+	sortTextObjects();
+	foreach (TextObject *t, _textObjects) {
+		t->draw();
+	}
+}
+
+void EMIEngine::sortTextObjects() {
+	if (!_textObjectsSortOrderInvalidated)
+		return;
+
+	_textObjectsSortOrderInvalidated = false;
+
+	_textObjects.clear();
+	foreach (TextObject *t, TextObject::getPool()) {
+		_textObjects.push_back(t);
+	}
+
+	Common::sort(_textObjects.begin(), _textObjects.end(), compareTextLayer);
 }
 
 bool EMIEngine::compareActor(const Actor *x, const Actor *y) {

--- a/engines/grim/emi/emi.h
+++ b/engines/grim/emi/emi.h
@@ -41,16 +41,22 @@ public:
 	Common::List<TextObject *> *popText();
 
 	void invalidateActiveActorsList() override;
+	void invalidateTextObjectsSortOrder() override;
 	void invalidateSortOrder();
 	void sortActiveActorsList();
 
 private:
 	LuaBase *createLua() override;
 	void drawNormalMode() override;
+	static bool compareTextLayer(const TextObject *x, const TextObject *y);
+	void drawTextObjects() override;
 	static bool compareActor(const Actor *x, const Actor *y);
+	void sortTextObjects();
 
 	Common::List<Common::List<TextObject *> *> _textstack;
+	Common::List<TextObject *> _textObjects;
 
+	bool _textObjectsSortOrderInvalidated;
 	bool _sortOrderInvalidated;
 };
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -420,6 +420,12 @@ void GrimEngine::handleDebugLoadResource() {
 		warning("Requested resouce (%s) not found", buf);
 }
 
+void GrimEngine::drawTextObjects() {
+	foreach (TextObject *t, TextObject::getPool()) {
+		t->draw();
+	}
+}
+
 void GrimEngine::drawPrimitives() {
 	_iris->draw();
 
@@ -429,9 +435,7 @@ void GrimEngine::drawPrimitives() {
 			_movieSubtitle->draw();
 		}
 	} else {
-		foreach (TextObject *t, TextObject::getPool()) {
-			t->draw();
-		}
+		drawTextObjects();
 	}
 }
 

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -115,6 +115,7 @@ public:
 	void setFlipEnable(bool state) { _flipEnable = state; }
 	bool getFlipEnable() { return _flipEnable; }
 	void refreshDrawMode() { _refreshDrawNeeded = true; }
+	virtual void drawTextObjects();
 	void drawPrimitives();
 	void playIrisAnimation(Iris::Direction dir, int x, int y, int time);
 
@@ -155,6 +156,7 @@ public:
 	 * and so that it should rebuild the list of active ones.
 	 */
 	virtual void invalidateActiveActorsList();
+	virtual void invalidateTextObjectsSortOrder() {};
 	/**
 	 * Return a list of the currently active actors, i. e. the actors in the current set.
 	 */

--- a/engines/grim/lua.cpp
+++ b/engines/grim/lua.cpp
@@ -230,6 +230,8 @@ void LuaBase::registerLua() {
 	refTextObjectPan = lua_ref(true);
 	lua_pushstring("background");
 	refTextObjectBackground = lua_ref(true);
+	lua_pushstring("layer");
+	refTextObjectLayer = lua_ref(true);
 }
 
 struct luaL_reg baseOpcodes[] = {
@@ -606,6 +608,20 @@ void LuaBase::setTextObjectParams(TextObjectCommon *textObject, lua_Object table
 			textObject->setDuration((int)lua_getnumber(keyObj));
 		}
 	}
+
+	// FIXME: remove check once the major save version is updated
+	// currently it is needed for backward compatibility of old savegames
+	if (lua_getref(refTextObjectLayer) == LUA_NOOBJECT)
+		return;
+	lua_pushobject(tableObj);
+	lua_pushobject(lua_getref(refTextObjectLayer));
+	keyObj = lua_gettable();
+	if (keyObj) {
+		if (lua_isnumber(keyObj)) {
+			textObject->setLayer(lua_getnumber(keyObj));
+		}
+	}
+
 }
 
 void LuaBase::typeOverride() {

--- a/engines/grim/lua.h
+++ b/engines/grim/lua.h
@@ -181,6 +181,7 @@ private:
 	int refTextObjectVolume;
 	int refTextObjectBackground;
 	int refTextObjectPan;
+	int refTextObjectLayer;
 
 	static LuaBase *s_instance;
 

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -34,7 +34,15 @@ namespace Grim {
 TextObjectCommon::TextObjectCommon() :
 		_x(0), _y(0), _fgColor(0), _justify(0), _width(0), _height(0),
 		_font(NULL), _duration(0), _positioned(false),
-		_posX(0), _posY(0) {
+		_posX(0), _posY(0), _layer(0) {
+	if (g_grim)
+		g_grim->invalidateTextObjectsSortOrder();
+}
+
+void TextObjectCommon::setLayer(int layer) {
+	_layer = layer;
+	if (g_grim)
+		g_grim->invalidateTextObjectsSortOrder();
 }
 
 TextObject::TextObject() :
@@ -48,6 +56,8 @@ TextObject::~TextObject() {
 	if (_created) {
 		g_driver->destroyTextObject(this);
 	}
+	if (g_grim)
+		g_grim->invalidateTextObjectsSortOrder();
 }
 
 void TextObject::setText(const Common::String &text) {
@@ -79,6 +89,10 @@ void TextObject::saveState(SaveGame *state) const {
 	state->writeLESint32(_font->getId());
 
 	state->writeString(_textID);
+
+	if (g_grim->getGameType() == GType_MONKEY4) {
+		state->writeLESint32(_layer);
+	}
 }
 
 bool TextObject::restoreState(SaveGame *state) {
@@ -99,6 +113,11 @@ bool TextObject::restoreState(SaveGame *state) {
 	_font = Font::getPool().getObject(state->readLESint32());
 
 	_textID = state->readString();
+
+	if (g_grim->getGameType() == GType_MONKEY4) {
+		_layer = state->readLESint32();
+		g_grim->invalidateTextObjectsSortOrder();
+	}
 
 	setupText();
 	_created = false;

--- a/engines/grim/textobject.h
+++ b/engines/grim/textobject.h
@@ -59,6 +59,9 @@ public:
 	void setDuration(int duration) { _duration = duration; }
 	int getDuration() const { return _duration; }
 
+	void setLayer(int layer);
+	int getLayer() const { return _layer; }
+
 protected:
 	TextObjectCommon();
 
@@ -68,6 +71,7 @@ protected:
 	int _width, _height;
 	int _justify;
 	int _duration;
+	int _layer;
 	Color _fgColor;
 	bool _positioned;
 };


### PR DESCRIPTION
The highlighted menu entry is sometimes not correctly colored.
There are multiple textObjects per string (one for each color) and
residualvm draws them in an unspecified order.

To ensure that the correct textObject is drawn on top, each
object gets a layer attribute assigned by the lua code.

The patch adds the layer attribute to the runtime engine and orders the
textObjects by layer before drawing them.
