### PR TITLE
EMI: Fix actor orientation

### DIFF
--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -506,15 +506,6 @@ public:
 	void detach();
 	Math::Quaternion getRotationQuat() const;
 
-	/**
-	 * Returns the forward direction in the local space of the actor.
-	 */
-	Math::Vector3d actorForward() const;
-	/**
-	 * Returns the up direction in the local space of the actor.
-	 */
-	Math::Vector3d actorUp() const;
-
 	void setInOverworld(bool inOverworld) { _inOverworld = inOverworld; }
 	bool isInOverworld() { return _inOverworld; }
 


### PR DESCRIPTION
I think I finally managed to set the actor orientation issues in EMI straight, although I have to admit that I mainly tried to negate angles and coordinates in random places until all LUA functions did what they were supposed to do. ;-)

The simplified EMI-specific version of calculateOrientation() did not work properly because it only gave the size of the required angle, not its direction. I'm now sharing the full-blown calculation with Grim, with an added coordinate swap to convert between the two engines' coordinate system. All other diffs are in EMI-specific places, so there are no changes affecting Grim.
