### PR TITLE
EMI: Make attached objects use their parents sort order

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -2042,6 +2042,27 @@ Math::Quaternion Actor::getRotationQuat() const {
 	}
 }
 
+int Actor::getSortOrder() const {
+	if (_attachedActor != 0) {
+		Actor *attachedActor = Actor::getPool().getObject(_attachedActor);
+
+		// FIXME: The + 1 here and in getEffectiveSortOrder is just a guess.
+		// Without it it makes some attachments render on top of their owner.
+		// Theoritically it could cause an issue if the actor is close to the
+		// edge of a sort order boundry.
+		return attachedActor->getSortOrder() + 1;
+	}
+	return _sortOrder;
+}
+
+int Actor::getEffectiveSortOrder() const {
+	if (_attachedActor != 0) {
+		Actor *attachedActor = Actor::getPool().getObject(_attachedActor);
+		return attachedActor->getEffectiveSortOrder() + 1;
+	}
+	return _haveSectorSortOrder ? _sectorSortOrder : getSortOrder();
+}
+
 void Actor::attachToActor(Actor *other, const char *joint) {
 	assert(other != NULL);
 	if (other->getId() == _attachedActor)

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -512,9 +512,9 @@ public:
 	void setGlobalAlpha(float alpha) { _globalAlpha = alpha; }
 	void setAlphaMode(AlphaMode mode) { _alphaMode = mode; }
 
-	int getSortOrder() const { return _sortOrder; }
+	int getSortOrder() const;
 	void setSortOrder(const int order) { _sortOrder = order; }
-	int getEffectiveSortOrder() const { return _haveSectorSortOrder ? _sectorSortOrder : _sortOrder; }
+	int getEffectiveSortOrder() const;
 
 	void activateShadow(bool active) { _shadowActive = active; }
 

--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -863,6 +863,8 @@ void Lua_V2::AttachActor() {
 
 	attached->attachToActor(actor, joint);
 	warning("Lua_V2::AttachActor: attaching %s to %s (on %s)", attached->getName().c_str(), actor->getName().c_str(), joint ? joint : "(none)");
+
+	g_emi->invalidateSortOrder();
 }
 
 void Lua_V2::DetachActor() {


### PR DESCRIPTION
This makes it so that things guybrush is holding correctly get rendered behind things, but it also breaks the rendering in some places

![untitled](https://f.cloud.github.com/assets/240865/1646236/28eeed3e-5915-11e3-9bc5-86f307344d43.png)

Note that the ripples are drawn on top of the boats. That could be a related bug, or it could just be broken by the new behavior...
