### PR TITLE
EMI: Fix the intro at cs_dock getting stuck in the PS2-version.

### DIFF
--- a/engines/grim/emi/lua_v2.h
+++ b/engines/grim/emi/lua_v2.h
@@ -49,6 +49,7 @@ protected:
 	DECLARE_LUA_OPCODE(LockBackground);
 	DECLARE_LUA_OPCODE(UnLockBackground);
 	DECLARE_LUA_OPCODE(LockChore);
+	DECLARE_LUA_OPCODE(IsActorChoring);
 	DECLARE_LUA_OPCODE(IsChoreValid);
 	DECLARE_LUA_OPCODE(IsChorePlaying);
 	DECLARE_LUA_OPCODE(StopChore);

--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -200,6 +200,45 @@ void Lua_V2::UnlockChore() {
 	// FIXME: implement missing rest part of code
 }
 
+void Lua_V2::IsActorChoring() {
+	lua_Object actorObj = lua_getparam(1);
+	bool excludeLoop = getbool(2);
+
+	if (!lua_isuserdata(actorObj) || lua_tag(actorObj) != MKTAG('A','C','T','R'))
+		return;
+
+	Actor *actor = getactor(actorObj);
+	Costume *costume = actor->getCurrentCostume();
+
+	if (!costume) {
+		lua_pushnil();
+		return;
+	}
+
+	for (int i = 0; i < costume->getNumChores(); i++) {
+		int chore = costume->isChoring(i, excludeLoop);
+		if (chore != -1) {
+			// Ignore talk chores.
+			bool isTalk = false;
+			for (int j = 0; j < 10; j++) {
+				if (costume == actor->getTalkCostume(j) && actor->getTalkChore(j) == chore) {
+					isTalk = true;
+					break;
+				}
+			}
+			if (isTalk)
+				continue;
+
+			lua_pushnumber(chore);
+			
+			pushbool(true);
+			return;
+		}
+	}
+
+	lua_pushnil();
+}
+
 void Lua_V2::IsChoreValid() {
 	lua_Object choreObj = lua_getparam(1);
 


### PR DESCRIPTION
IsActorChoring takes different parameters in EMI than it does in Grim,
the original code was prudent enough about checking it’s parameters that
it actually ran fine, however the problem was that the argument that
said whether we should ignore looping chores was moved. This lets the
intro play the cut scene on the docks.

This does however not fix the movies playing over the first part of the cut-scene, but atleast we can now reach the catapult without pressing ESC.

0 testing was done with Grim, as all this code touches is V2-code. Minimal testing was done against the PC-version.

EDIT: Oh, and by original code above, I mean the V1-code in ResidualVM.
