### PR TITLE
RFC: EMI: Fix ps2movies

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -727,7 +727,11 @@ void GrimEngine::mainLoop() {
 				// if the button is not kept pressed the KEYUP will arrive just after the KEYDOWN
 				// and it will break the lua scripts that checks for the state of the button
 				// with GetControlState()
-				luaUpdate();
+
+				// We do not want the scripts to update while a movie is playing in the PS2-version.
+				if (!(getGamePlatform() == Common::kPlatformPS2 && _mode == SmushMode)) {
+					luaUpdate();
+				}
 			}
 			if (type == Common::EVENT_SCREEN_CHANGED)
 				_refreshDrawNeeded = true;
@@ -743,7 +747,10 @@ void GrimEngine::mainLoop() {
 			updateDisplayScene();
 		}
 
-		luaUpdate();
+		// We do not want the scripts to update while a movie is playing in the PS2-version.
+		if (!(getGamePlatform() == Common::kPlatformPS2 && _mode == SmushMode)) {
+			luaUpdate();
+		}
 
 		if (_mode != PauseMode) {
 			doFlip();


### PR DESCRIPTION
This adds support for skipping movies in EMI-PS2, and does a simple hack to allow the movies to complete before the scripts continue.

One drawback, is that the flicker that can be seen at the bottom during movies, will continue after the movies have completed.

Opinions?
