### PR TITLE
EMI: Rework text stack handling

### DIFF
--- a/engines/grim/emi/emi.h
+++ b/engines/grim/emi/emi.h
@@ -37,8 +37,9 @@ public:
 
 	virtual const char *getUpdateFilename();
 
-	void pushText(Common::List<TextObject *> *objects);
-	Common::List<TextObject *> *popText();
+	void pushText();
+	void popText();
+	void purgeText();
 
 	void invalidateActiveActorsList() override;
 	void invalidateTextObjectsSortOrder() override;
@@ -53,7 +54,6 @@ private:
 	static bool compareActor(const Actor *x, const Actor *y);
 	void sortTextObjects();
 
-	Common::List<Common::List<TextObject *> *> _textstack;
 	Common::List<TextObject *> _textObjects;
 
 	bool _textObjectsSortOrderInvalidated;

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -199,7 +199,7 @@ void Lua_V2::GetActiveCD() {
 }
 
 void Lua_V2::PurgeText() {
-	TextObject::getPool().deleteObjects();
+	g_emi->purgeText();
 }
 
 void Lua_V2::GetFontDimensions() {
@@ -314,22 +314,11 @@ void Lua_V2::GetCameraRoll() {
 }
 
 void Lua_V2::PushText() {
-	Common::List<TextObject *> *textobjects = new Common::List<TextObject *>;
-	TextObject::Pool::iterator it = TextObject::getPool().begin();
-	for (; it != TextObject::getPool().end(); ++it) {
-		textobjects->push_back(*it);
-		TextObject::getPool().removeObject((*it)->getId());
-	}
-	g_emi->pushText(textobjects);
+	g_emi->pushText();
 }
 
 void Lua_V2::PopText() {
-	Common::List<TextObject *> *textobjects = g_emi->popText();
-	Common::List<TextObject *>::iterator it = textobjects->begin();
-	for (; it != textobjects->end(); ++it) {
-		TextObject::getPool().addObject(*it);
-	}
-	delete textobjects;
+	g_emi->popText();
 }
 
 void Lua_V2::GetSectorName() {

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -48,7 +48,7 @@ void TextObjectCommon::setLayer(int layer) {
 TextObject::TextObject() :
 		TextObjectCommon(), _numberLines(1), _textID(""), _elapsedTime(0),
 		_maxLineWidth(0), _lines(NULL), _userData(NULL), _created(false),
-		_blastDraw(false), _isSpeech(false) {
+		_blastDraw(false), _isSpeech(false), _stackLevel(0) {
 }
 
 TextObject::~TextObject() {
@@ -92,6 +92,7 @@ void TextObject::saveState(SaveGame *state) const {
 
 	if (g_grim->getGameType() == GType_MONKEY4) {
 		state->writeLESint32(_layer);
+		state->writeLESint32(_stackLevel);
 	}
 }
 
@@ -116,6 +117,7 @@ bool TextObject::restoreState(SaveGame *state) {
 
 	if (g_grim->getGameType() == GType_MONKEY4) {
 		_layer = state->readLESint32();
+		_stackLevel = state->readLESint32();
 		g_grim->invalidateTextObjectsSortOrder();
 	}
 

--- a/engines/grim/textobject.h
+++ b/engines/grim/textobject.h
@@ -118,6 +118,10 @@ public:
 	void saveState(SaveGame *state) const;
 	bool restoreState(SaveGame *state);
 
+	int getStackLevel() { return _stackLevel; }
+	void incStackLevel() { _stackLevel++; }
+	void decStackLevel() { assert(_stackLevel > 0); _stackLevel--; }
+
 	enum Justify {
 		NONE,
 		CENTER,
@@ -141,6 +145,8 @@ protected:
 	bool _blastDraw;
 	bool _isSpeech;
 	bool _created;
+
+	int _stackLevel;
 };
 
 } // end of namespace Grim


### PR DESCRIPTION
The text stack in EMI must be saved and restored in save games because the game will call PopText after returning from the menu. Instead of managing separate lists for each text stack level this patch adds a
_stackLevel field that is incremented for PushText and decremented for PopText. Only text objects from the stack top (level 0) are rendered.

Fixes a false assertion when loading a game from the launcher, when PopText is called without PushText.
