### PR TITLE
EMI: save/restore layer pool

### DIFF
--- a/engines/grim/emi/layer.cpp
+++ b/engines/grim/emi/layer.cpp
@@ -60,10 +60,21 @@ void Layer::advanceFrame(int num) {
 }
 
 void Layer::saveState(SaveGame *state) {
-
+	if (_bitmap) {
+		state->writeBool(true);
+		state->writeString(_bitmap->getFilename());
+	} else {
+		state->writeBool(false);
+	}
+	state->writeLESint32(_frame);
+	state->writeLESint32(_sortOrder);
 }
 
 void Layer::restoreState(SaveGame *state) {
-
+	bool hasBitmap = state->readBool();
+	if (hasBitmap)
+		_bitmap = Bitmap::create(state->readString());
+	_frame = state->readLESint32();
+	_sortOrder = state->readLESint32();
 }
 }

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -465,6 +465,10 @@ void Lua_V2::AdvanceLayerFrame() {
 		int layer = (int)lua_getuserdata(param1);
 		int one = (int)lua_getnumber(param2);
 		Layer *l = Layer::getPool().getObject(layer);
+		if (!l) {
+			warning("Lua_V2::AdvanceLayerFrame: no layer found");
+			return;
+		}
 		l->advanceFrame(one);
 	}
 }

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -47,6 +47,7 @@
 #include "engines/grim/lua.h"
 #include "engines/grim/lua_v1.h"
 #include "engines/grim/emi/poolsound.h"
+#include "engines/grim/emi/layer.h"
 #include "engines/grim/actor.h"
 #include "engines/grim/movie/movie.h"
 #include "engines/grim/savegame.h"
@@ -833,6 +834,9 @@ void GrimEngine::savegameRestore() {
 	if (getGameType() == GType_MONKEY4) {
 		PoolSound::getPool().restoreObjects(_savedState);
 		Debug::debug(Debug::Engine, "Pool sounds saved successfully.");
+
+		Layer::getPool().restoreObjects(_savedState);
+		Debug::debug(Debug::Engine, "Layers restored successfully.");
 	}
 
 	restoreGRIM();
@@ -993,6 +997,9 @@ void GrimEngine::savegameSave() {
 	if (getGameType() == GType_MONKEY4) {
 		PoolSound::getPool().saveObjects(_savedState);
 		Debug::debug(Debug::Engine, "Pool sounds saved successfully.");
+
+		Layer::getPool().saveObjects(_savedState);
+		Debug::debug(Debug::Engine, "Layers saved successfully.");
 	}
 
 	saveGRIM();


### PR DESCRIPTION
This fixes one crash after savegame restore when
Lua_V2::AdvanceLayerFrame() was trying to dereference a non-existing
layer object.
