### PR TITLE
GRIM: Fix the engine description

### DIFF
--- a/engines/configure.engines
+++ b/engines/configure.engines
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine grim "Grim" yes "monkey4" "zlib"
+add_engine grim "Grim" yes "monkey4" "Grim Fandango" "zlib"
 add_engine monkey4 "Escape from Monkey Island" yes
 add_engine myst3 "Myst 3" yes


### PR DESCRIPTION
As it is, the grim engine has a game called "zlib" and no dependencies. Obviously is this not the intended behavior.

To see for yourself.

```
./configure --disable-all-engines --enable-engine=grim
```
