### PR TITLE
EMI: Correct sign error when walking on slopes

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -783,8 +783,8 @@ void Actor::walkForward() {
 				Math::Angle ax = Math::Vector2d(normal.x(), normal.y()).getAngle();
 				Math::Angle az = Math::Vector2d(normal.z(), normal.y()).getAngle();
 
-				float y1 = -_moveYaw.getCosine() * (az - _pitch).getCosine();
-				float y2 = -_moveYaw.getSine() * (ax - _pitch).getCosine();
+				float y1 = _moveYaw.getCosine() * (az - _pitch).getCosine();
+				float y2 = _moveYaw.getSine() * (ax - _pitch).getCosine();
 				forwardVec = Math::Vector3d(-_moveYaw.getSine() * ax.getSine() * _pitch.getCosine(), y1 + y2,
 											-_moveYaw.getCosine() * az.getSine() * _pitch.getCosine());
 			}


### PR DESCRIPTION
Due to a sign error in Actor::walkForward() it is frequently difficult or
impossible to walk on sloped sectors (stairs or ramps), e.g. in Meathook's
place or in front of Pegnose's house.
