### PR TITLE
GRIM/EMI: Count pause/unpause calls of LUA scripts

### DIFF
--- a/engines/grim/lua/lrestore.cpp
+++ b/engines/grim/lua/lrestore.cpp
@@ -555,7 +555,11 @@ void lua_Restore(SaveGame *savedState) {
 		}
 
 		state->updated = savedState->readBool();
-		state->paused = savedState->readBool();
+
+		byte pauseState = savedState->readByte();
+		state->all_paused = pauseState & LUA_SG_ALL_PAUSED;
+		state->paused = pauseState & LUA_SG_PAUSED;
+
 		state->state_counter1 = savedState->readLESint32();
 		state->state_counter2 = savedState->readLESint32();
 

--- a/engines/grim/lua/lsave.cpp
+++ b/engines/grim/lua/lsave.cpp
@@ -378,7 +378,12 @@ void lua_Save(SaveGame *savedState) {
 		savedState->writeLESint32(n);
 
 		savedState->writeBool(state->updated);
-		savedState->writeBool(state->paused);
+
+		byte pauseState = 0;
+		pauseState = state->all_paused ? LUA_SG_ALL_PAUSED : 0;
+		pauseState |= state->paused ? LUA_SG_PAUSED : 0;
+		savedState->writeByte(pauseState);
+
 		savedState->writeLESint32(state->state_counter1);
 		savedState->writeLESint32(state->state_counter2);
 

--- a/engines/grim/lua/lstate.cpp
+++ b/engines/grim/lua/lstate.cpp
@@ -75,6 +75,7 @@ static void lua_openthr() {
 void lua_stateinit(LState *state) {
 	state->prev = NULL;
 	state->next = NULL;
+	state->all_paused = false;
 	state->paused = false;
 	state->state_counter1 = 0;
 	state->state_counter2 = 0;

--- a/engines/grim/lua/lstate.h
+++ b/engines/grim/lua/lstate.h
@@ -15,6 +15,9 @@ namespace Grim {
 #define MAX_C_BLOCKS 10
 #define GARBAGE_BLOCK 150
 
+#define LUA_SG_ALL_PAUSED 0x01
+#define LUA_SG_PAUSED     0x02
+
 typedef int32 StkId;  /* index to stack elements */
 
 struct Stack {
@@ -75,7 +78,8 @@ extern int32 IMtable_size;
 struct LState {
 	LState *prev; // handle to previous state in list
 	LState *next; // handle to next state in list
-	bool paused; // flag mean if task is paused
+	bool all_paused; // true if all scripts have been paused
+	bool paused;     // true if this particular script has been paused
 	int32 state_counter1;
 	int32 state_counter2;
 	bool updated;

--- a/engines/grim/lua/ltask.cpp
+++ b/engines/grim/lua/ltask.cpp
@@ -247,7 +247,7 @@ void pause_scripts() {
 
 	for (t = lua_rootState->next; t != NULL; t = t->next) {
 		if (lua_state != t)
-			t->paused = true;
+			t->all_paused = true;
 	}
 }
 
@@ -274,7 +274,7 @@ void unpause_scripts() {
 
 	for (t = lua_rootState->next; t != NULL; t = t->next) {
 		if (lua_state != t)
-			t->paused = false;
+			t->all_paused = false;
 	}
 }
 
@@ -320,7 +320,7 @@ void runtasks(LState *const rootState) {
 	while (lua_state) {
 		LState *nextState = NULL;
 		bool stillRunning;
-		if (!lua_state->updated && !lua_state->paused) {
+		if (!lua_state->all_paused && !lua_state->updated && !lua_state->paused) {
 			jmp_buf	errorJmp;
 			lua_state->errorJmp = &errorJmp;
 			if (setjmp(errorJmp)) {
@@ -361,7 +361,7 @@ void runtasks(LState *const rootState) {
 	// Check for states that may have been created in this run.
 	LState *state = lua_state->next;
 	while (state) {
-		if (!state->paused && !state->updated) {
+		if (!state->all_paused && !state->paused && !state->updated) {
 			// New state! Run a new pass.
 			runtasks(rootState);
 			return;


### PR DESCRIPTION
Scripts that have explicitly been paused must not be resumed when
pause_scripts/unpause_scripts are called, e.g. when opening the
inventory, pausing the game or changing sets.

Pause calls are now counted, i.e. when a script is paused twice it must
be unpaused twice before resuming. This fixes the flaming sushi boat
puzzle which involves changing sets while a script is paused.

The change does not affect Grim where scripts are always paused/resumed all at once and symmetrically.
