### PR TITLE
EMI: Fix initialization of textures

### DIFF
--- a/engines/grim/material.cpp
+++ b/engines/grim/material.cpp
@@ -142,6 +142,7 @@ void MaterialData::initEMI(Common::SeekableReadStream *data) {
 				_textures[i]._width = 0;
 				_textures[i]._height = 0;
 				_textures[i]._texture = new int(1); // HACK to avoid initializing.
+				_textures[i]._data = NULL;
 				continue;
 			}
 			loadTGA(texData, _textures + i);


### PR DESCRIPTION
Residualvm crashes when leaving the campfire szene on Knutting Town due
to a NULL-pointer dereference.

When initializing the texture with dummy values due to a missing tex
file, set _data to NULL so that a free doesn't cause any harm when
destructing the MaterialData objects.
