### PR TITLE
EMI: Fix movies for boulder puzzle on vista point

### DIFF
--- a/engines/grim/movie/bink.cpp
+++ b/engines/grim/movie/bink.cpp
@@ -40,6 +40,12 @@ BinkPlayer::BinkPlayer(bool demo) : MoviePlayer(), _demo(demo) {
 	_videoDecoder = new Video::BinkDecoder();
 }
 
+bool BinkPlayer::bikCheck(Common::SeekableReadStream *stream, uint32 pos) {
+	stream->seek(pos);
+	uint32 tag = stream->readUint32BE();
+	return (tag & 0xFFFFFF00) == MKTAG('B', 'I', 'K', 0);
+}
+
 bool BinkPlayer::loadFile(const Common::String &filename) {
 	_fname = filename;
 
@@ -54,29 +60,26 @@ bool BinkPlayer::loadFile(const Common::String &filename) {
 	// Windows/Mac versions have some fake SMUSH info at the beginning
 	// of the video. Weed it out here.
 	Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember(_fname);
-	if (!stream)
-		return false;
-
-	char header[6];
-	stream->read(header, 5);
-	header[5] = 0;
-
-	if (strcmp(header, "SMUSH")) {
-		delete stream;
+	if (!stream) {
+		warning("BinkPlayer::loadFile(): Can't create stream for: %s", _fname.c_str());
 		return false;
 	}
 
-	// Try at 0x200 for the Bink header first
-	// If not there, assume at 0x400
-	stream->seek(0x200);
-	uint32 tag = stream->readUint32BE();
+	uint32 pos;
+	const uint32 maxBikPos = 0x2000;
 
+	for (pos = 0x0; pos <= maxBikPos; pos+= 0x200) {
+		if (bikCheck(stream, pos))
+			break;
+	}
+
+	if (pos > maxBikPos) {
+		warning("BinkPlayer::loadFile(): Could not find BINK header for: %s", _fname.c_str());
+		delete stream;
+		return false;
+	}
 	Common::SeekableReadStream *bink = 0;
-	if ((tag & 0xFFFFFF00) == MKTAG('B', 'I', 'K', 0))
-		bink = new Common::SeekableSubReadStream(stream, 0x200, stream->size(), DisposeAfterUse::YES);
-	else
-		bink = new Common::SeekableSubReadStream(stream, 0x400, stream->size(), DisposeAfterUse::YES);
-
+	bink = new Common::SeekableSubReadStream(stream, pos, stream->size(), DisposeAfterUse::YES);
 	return _videoDecoder->loadStream(bink);
 }
 

--- a/engines/grim/movie/bink.h
+++ b/engines/grim/movie/bink.h
@@ -35,6 +35,7 @@ public:
 private:
 	bool loadFile(const Common::String &filename);
 	bool _demo;
+	bool bikCheck(Common::SeekableReadStream *stream, uint32 pos);
 };
 
 } // end of namespace Grim


### PR DESCRIPTION
- enhance search for BINK header (some movie files don't have a
  SMUSH header)
