### PR TITLE
EMI: fix pause handling (even more)

### DIFF
--- a/engines/grim/lua/lrestore.cpp
+++ b/engines/grim/lua/lrestore.cpp
@@ -558,7 +558,7 @@ void lua_Restore(SaveGame *savedState) {
 
 		byte pauseState = savedState->readByte();
 		state->all_paused = pauseState & LUA_SG_ALL_PAUSED;
-		state->paused = pauseState & LUA_SG_PAUSED;
+		state->paused = (pauseState & LUA_SG_PAUSED) ? true : false;
 
 		state->state_counter1 = savedState->readLESint32();
 		state->state_counter2 = savedState->readLESint32();

--- a/engines/grim/lua/lsave.cpp
+++ b/engines/grim/lua/lsave.cpp
@@ -380,7 +380,7 @@ void lua_Save(SaveGame *savedState) {
 		savedState->writeBool(state->updated);
 
 		byte pauseState = 0;
-		pauseState = state->all_paused ? LUA_SG_ALL_PAUSED : 0;
+		pauseState = state->all_paused & LUA_SG_ALL_PAUSED;
 		pauseState |= state->paused ? LUA_SG_PAUSED : 0;
 		savedState->writeByte(pauseState);
 

--- a/engines/grim/lua/lstate.cpp
+++ b/engines/grim/lua/lstate.cpp
@@ -75,7 +75,7 @@ static void lua_openthr() {
 void lua_stateinit(LState *state) {
 	state->prev = NULL;
 	state->next = NULL;
-	state->all_paused = false;
+	state->all_paused = 0;
 	state->paused = false;
 	state->state_counter1 = 0;
 	state->state_counter2 = 0;

--- a/engines/grim/lua/lstate.h
+++ b/engines/grim/lua/lstate.h
@@ -15,8 +15,19 @@ namespace Grim {
 #define MAX_C_BLOCKS 10
 #define GARBAGE_BLOCK 150
 
-#define LUA_SG_ALL_PAUSED 0x01
-#define LUA_SG_PAUSED     0x02
+/* The pause status for the scripts is stored in one byte in the savegame.
+ *
+ * The "single script pause" status will be stored in the highest significant bit.
+ * For GRIM that flag is never set because GRIM does not pause single scripts.
+ *
+ * The "all scripts pause" status is a number which counts, how often
+ * pause_scripts(TRUE) was called without a corresponding unpause_scripts() call.
+ * The value is stored in the lower 7 bit of the pause status byte.
+ * For GRIM, since the (un)pause_scripts() are called symmetrically, only
+ * the lowest bit will be used.
+ */
+#define LUA_SG_ALL_PAUSED 0x7f
+#define LUA_SG_PAUSED     0x80
 
 typedef int32 StkId;  /* index to stack elements */
 
@@ -78,8 +89,8 @@ extern int32 IMtable_size;
 struct LState {
 	LState *prev; // handle to previous state in list
 	LState *next; // handle to next state in list
-	bool all_paused; // true if all scripts have been paused
-	bool paused;     // true if this particular script has been paused
+	int all_paused; // counter of often pause_scripts(TRUE) was called
+	bool paused;    // true if this particular script has been paused
 	int32 state_counter1;
 	int32 state_counter2;
 	bool updated;

--- a/engines/grim/lua/ltask.cpp
+++ b/engines/grim/lua/ltask.cpp
@@ -244,10 +244,22 @@ void pause_script() {
 
 void pause_scripts() {
 	LState *t;
+	lua_Object boolObj = lua_getparam(1);
+
+	bool p = false;
+	if (!lua_isnil(boolObj))
+		p = true;
+
 
 	for (t = lua_rootState->next; t != NULL; t = t->next) {
-		if (lua_state != t)
-			t->all_paused = true;
+		if (lua_state != t) {
+			if (p) {
+				t->all_paused++;
+			} else {
+				t->all_paused = 1;
+			}
+		}
+
 	}
 }
 
@@ -271,10 +283,21 @@ void unpause_script() {
 
 void unpause_scripts() {
 	LState *t;
+	lua_Object boolObj = lua_getparam(1);
+
+	bool p = false;
+	if (!lua_isnil(boolObj))
+		p = true;
 
 	for (t = lua_rootState->next; t != NULL; t = t->next) {
-		if (lua_state != t)
-			t->all_paused = false;
+		if (lua_state != t) {
+			if (p) {
+				if (t->all_paused > 0)
+					t->all_paused--;
+			} else {
+				t->all_paused = 0;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
On vista point it may happen that two sequences for the rock landings
are executed at the same time. Although they intend to be locked via
pause_scripts(), changing the set will call unpause_scripts() and unlock
all of them. The result are a corrupted lua stack with lots of error messages like:

WARNING: Lua: call expression not a function!
WARNING: Bad argument to start_script, ignoring!
WARNING: Lua: call expression not a function!

and that Guybrush can't be moved or controlled any more.

The patch will use the optional boolean parameter for (un)pause_scripts() to
determine whether the pause calls should be "counting" (e.g. when
switching a set or opening the inventory) or not.

Notes:
- GRIM should not be affected, according to #784 only (un)pause_scripts() calls are used and they are always symmetrical
- in order to not break the Lua bar again, it seems to be necessary that single pause_scripts must not be "counting", because in the Lua bar they are called asymmetrically
- but since "global" pause_scripts() calls should still be effective the flags for local and global pause must still be maintained independently
