### PR TITLE
GRIM/EMI: Ignore Actor:walkTo() if destination is unreachable

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -546,6 +546,8 @@ void Actor::walkTo(const Math::Vector3d &p) {
 		_path.clear();
 
 		if (_followBoxes) {
+			bool pathFound = false;
+
 			Set *currSet = g_grim->getCurrSet();
 			currSet->findClosestSector(p, NULL, &_destPos);
 
@@ -598,6 +600,7 @@ void Actor::walkTo(const Math::Vector3d &p) {
 						n = n->parent;
 					}
 
+					pathFound = true;
 					break;
 				}
 
@@ -669,6 +672,14 @@ void Actor::walkTo(const Math::Vector3d &p) {
 			}
 			for (Common::List<PathNode *>::iterator j = openList.begin(); j != openList.end(); ++j) {
 				delete *j;
+			}
+
+			if (!pathFound) {
+				warning("Actor::walkTo(): No path found for %s", _name.c_str());
+				if (g_grim->getGameType() == GType_MONKEY4) {
+					_walking = false;
+					return;
+				}
 			}
 		}
 


### PR DESCRIPTION
The path to the Curch of LeChuck has bogus coordinates as out point, so
the game will walk Guybrush to an invalid position when entering that
set. This patch will detect when no path can be found to the destination
position and ignore the walkTo() request in that case.
