### PR TITLE
EMI/GRIM: Nothing should be visible if actor is not in current set

### DIFF
--- a/engines/grim/lua_v1_actor.cpp
+++ b/engines/grim/lua_v1_actor.cpp
@@ -1406,13 +1406,15 @@ void Lua_V1::GetVisibleThings() {
 	lua_Object result = lua_createtable();
 
 	// TODO verify code below
-	foreach (Actor *a, g_grim->getActiveActors()) {
-		// Consider the active actor visible
-		if (actor == a || actor->getYawTo(a) < 90) {
-			lua_pushobject(result);
-			lua_pushusertag(a->getId(), MKTAG('A','C','T','R'));
-			lua_pushnumber(1);
-			lua_settable();
+	if (actor->isInSet(g_grim->getCurrSet()->getName())) {
+		foreach (Actor *a, g_grim->getActiveActors()) {
+			// Consider the active actor visible
+			if (actor == a || actor->getYawTo(a) < 90) {
+				lua_pushobject(result);
+				lua_pushusertag(a->getId(), MKTAG('A','C','T','R'));
+				lua_pushnumber(1);
+				lua_settable();
+			}
 		}
 	}
 	lua_pushobject(result);


### PR DESCRIPTION
When fiddling with the controls in the Palace of Prosthetics Guybrush is
temporarily put into set "nil". No items should be visible to him in this
situation.
