### PR TITLE
EMI: Fix rotation of overworld actors

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -2034,7 +2034,7 @@ Math::Quaternion Actor::getRotationQuat() const {
 	if (g_grim->getGameType() == GType_MONKEY4) {
 		Math::Quaternion ret = Math::Quaternion::fromEuler(-_yaw, _pitch, _roll);
 		if (_inOverworld)
-			ret = Math::Quaternion::fromEuler(-_roll, -_pitch, -_yaw);
+			ret = Math::Quaternion::fromEuler(-_yaw, -_pitch, -_roll);
 
 		if (isAttached()) {
 			Actor *attachedActor = Actor::getPool().getObject(_attachedActor);


### PR DESCRIPTION
With this quaternion the rotations of inventory objects match those in the original game.
