### PR TITLE
EMI: Reset sort order when changing sets

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1128,6 +1128,7 @@ void GrimEngine::setSet(Set *scene) {
 	foreach (Actor *a, Actor::getPool()) {
 		a->stopWalking();
 		a->clearCleanBuffer();
+		a->setSortOrder(0);
 	}
 	g_driver->refreshBuffers();
 


### PR DESCRIPTION
Some sets (e.g. the big monkey's engine room) set Guybrush's sort order
to a large value, causing him to become invisible in other places. This
patch resets the sort order for all actors when switching to a new set.

Using this patch and Christian's actor collision implementation the game should be completable, just in time for Christmas. :-) I'll try to make a full run tomorrow.
