### PR TITLE
GRIM: Syntax error when compiling with C++11 enabled

### DIFF
--- a/engines/grim/emi/costumeemi.cpp
+++ b/engines/grim/emi/costumeemi.cpp
@@ -234,7 +234,7 @@ void EMICostume::saveState(SaveGame *state) const {
 	state->writeLESint32(_wearChore ? _wearChore->getChoreId() : -1);
 }
 
-bool EMICostume::restoreState(SaveGame *state) override {
+bool EMICostume::restoreState(SaveGame *state) {
 	bool ret = Costume::restoreState(state);
 	if (ret) {
 		Common::List<Material *>::const_iterator it = _materials.begin();


### PR DESCRIPTION
When compiling with C++11 code enabled, GCC 4.7.2 reports the following error:

```
engines/grim/emi/costumeemi.cpp:237:48: error: virt-specifiers in ‘restoreState’ not allowed outside a class definition
```

Fixed simply by removing the override specified from the function definition, leaving the header file unchanged.
