### PR TITLE
EMI: invalidate sortorder after changing attached actors

### DIFF
--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -934,6 +934,8 @@ void Lua_V2::DetachActor() {
 
 	warning("Lua_V2::DetachActor: detaching %s from parent actor", attached->getName().c_str());
 	attached->detach();
+
+	g_emi->invalidateSortOrder();
 }
 
 void Lua_V2::WalkActorToAvoiding() {


### PR DESCRIPTION
- the order of the active actors is based on the effective sort order
  which is based on the sortorder of actors itself but also on the
  attached actors
- so the sortorder must also be invalidated when actors are attached or
  detached
- this fixes two glitches in the final end scene (guybrush is still
  displayed after falling from the cliff and monkey robot is drawn in
  the foreground)
