### PR TITLE
GRIM/EMI: Fix sprite scaling with non-native screen resolutions

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -702,8 +702,8 @@ void GfxOpenGL::drawSprite(const Sprite *sprite) {
 	if (g_grim->getGameType() == GType_MONKEY4) {
 		glDepthMask(GL_FALSE);
 
-		float halfWidth = (sprite->_width / 2) * _scaleW;
-		float halfHeight = (sprite->_height / 2) * _scaleH;
+		float halfWidth = sprite->_width / 2;
+		float halfHeight = sprite->_height / 2;
 
 		glBegin(GL_POLYGON);
 		glColor4f(1.0f, 1.0f, 1.0f, _alpha);
@@ -720,8 +720,8 @@ void GfxOpenGL::drawSprite(const Sprite *sprite) {
 	} else {
 		// In Grim, the bottom edge of the sprite is at y=0 and
 		// the texture is flipped along the X-axis.
-		float halfWidth = (sprite->_width / 2) * _scaleW;
-		float height = sprite->_height * _scaleH;
+		float halfWidth = sprite->_width / 2;
+		float height = sprite->_height;
 
 		glBegin(GL_POLYGON);
 		glTexCoord2f(0.0f, 1.0f);

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -828,8 +828,8 @@ void GfxTinyGL::drawSprite(const Sprite *sprite) {
 	tglDisable(TGL_LIGHTING);
 
 	if (g_grim->getGameType() == GType_MONKEY4) {
-		float halfWidth = (sprite->_width / 2) * _scaleW;
-		float halfHeight = (sprite->_height / 2) * _scaleH;
+		float halfWidth = sprite->_width / 2;
+		float halfHeight = sprite->_height / 2;
 
 		tglBegin(TGL_POLYGON);
 		tglColor4f(1.0f, 1.0f, 1.0f, _alpha);
@@ -846,8 +846,8 @@ void GfxTinyGL::drawSprite(const Sprite *sprite) {
 	} else {
 		// In Grim, the bottom edge of the sprite is at y=0 and
 		// the texture is flipped along the X-axis.
-		float halfWidth = (sprite->_width / 2) * _scaleW;
-		float height = sprite->_height * _scaleH;
+		float halfWidth = sprite->_width / 2;
+		float height = sprite->_height;
 
 		tglBegin(TGL_POLYGON);
 		tglTexCoord2f(0.0f, 1.0f);


### PR DESCRIPTION
When mapping a sprite to a GL polygon its dimensions are scaled by the ratio
between the current screen resolution and the native game resolution. When
the polygon is rendered it is scaled again, causing sprites to be displayed
unproportionally big when using larger screen resolutions.

The effect is hard to notice in Grim where the only sprites seem to be puffs of
smoke, but it's obvious in EMI which makes heavy use of sprites.
