### PR TITLE
EMI/GRIM: TextSplitter::checkString should ignore case

### DIFF
--- a/engines/grim/textsplit.cpp
+++ b/engines/grim/textsplit.cpp
@@ -285,12 +285,15 @@ TextSplitter::~TextSplitter() {
 bool TextSplitter::checkString(const char *needle) {
 	// checkString also needs to check for extremely optional
 	// components like "object_art" which can be missing entirely
-	if (!getCurrentLine())
+	if (!getCurrentLine()) {
 		return false;
-	else if (strstr(getCurrentLine(), needle))
-		return true;
-	else
-		return false;
+	} else {
+		Common::String haystack(getCurrentLine());
+		Common::String needleStr(needle);
+		haystack.toLowercase();
+		needleStr.toLowercase();
+		return haystack.contains(needleStr);
+	}
 }
 
 void TextSplitter::expectString(const char *expected) {


### PR DESCRIPTION
All other methods of TextSplitter ignore the case: the strings of the
splitted text are changed to lowercase and other strings provided via
arguments are compared case-insensitive.

This commit fixes issue #807.
