### PR TITLE
EMI/GRIM: Fix unaligned sprites

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -665,23 +665,23 @@ void GfxOpenGL::drawSprite(const Sprite *sprite) {
 	glLoadIdentity();
 	glMatrixMode(GL_MODELVIEW);
 	glPushMatrix();
-	glTranslatef(sprite->_pos.x(), sprite->_pos.y(), sprite->_pos.z());
-
-	GLdouble modelview[16];
-	glGetDoublev(GL_MODELVIEW_MATRIX, modelview);
 
 	if (g_grim->getGameType() == GType_MONKEY4) {
-		const Math::Quaternion quat =
-			_currentActor->isInOverworld()
-			? Math::Quaternion::fromEuler(0, 0, _currentActor->getYaw())
-			: Math::Quaternion::fromEuler(0, 0, _currentActor->getRoll());
+		GLdouble modelview[16];
+		glGetDoublev(GL_MODELVIEW_MATRIX, modelview);
+		const Math::Quaternion quat = Math::Quaternion::fromEuler(0, 0, _currentActor->getYaw());
 		Math::Matrix4 act = quat.toMatrix();
 		act.transpose();
 		act(3,0) = modelview[12];
 		act(3,1) = modelview[13];
 		act(3,2) = modelview[14];
 		glLoadMatrixf(act.getData());
+		glTranslatef(sprite->_pos.x(), sprite->_pos.y(), sprite->_pos.z());
 	} else {
+		glTranslatef(sprite->_pos.x(), sprite->_pos.y(), sprite->_pos.z());
+		GLdouble modelview[16];
+		glGetDoublev(GL_MODELVIEW_MATRIX, modelview);
+
 		// We want screen-aligned sprites so reset the rotation part of the matrix.
 		for (int i = 0; i < 3; i++) {
 			for (int j = 0; j < 3; j++) {


### PR DESCRIPTION
When an actor which is drawn using sprites moved due to water float
effects and if that actor uses multiple sprites, then these sprites are
not aligned (e.g. in the very first scene, the ship in the background is
not shown as one piece).

That is cause because the sprites are first rotated and then moved to
the correct position. It is necessary to first move them to their
correct position on the actor and then rotate the whole actor.

This changes fixes:
- the ship in the background in the first scene
- the clock hands in the swamp

Comments:
- I'm not very familiar with OpenGL, so this patch needs to be carefully reviewed.
- I could not get it working correctly for tinyGL.
