### PR TITLE
EMI: Fix costume unloading

### DIFF
--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -683,7 +683,7 @@ void Lua_V2::PlayActorChore() {
 		if (0 != strncmp("fx/dumbshadow.cos", costumeName, 17)) {
 			if (actor->getCurrentCostume() != NULL &&
 			    actor->getCurrentCostume()->getFilename() != "fx/dumbshadow.cos" &&
-			    actor->getCurrentCostume() != costume) {
+			    actor->getCurrentCostume()->getFilename().compareToIgnoreCase(costumeName) != 0) {
 				actor->stopAllChores();
 				actor->setRestChore(-1, NULL);
 				actor->setWalkChore(-1, NULL);


### PR DESCRIPTION
- use the costumeName instead of a pointer to the costume object to
  check, whether the current costume matches the requested one
- this fixes an uninitialized pointer read
