### PR TITLE
EMI/GRIM: Allow integer arguments for MakeSectorActive

### DIFF
--- a/engines/grim/lua_v1_set.cpp
+++ b/engines/grim/lua_v1_set.cpp
@@ -191,15 +191,7 @@ void Lua_V1::MakeSectorActive() {
 
 	bool visible = !lua_isnil(lua_getparam(2));
 
-	if (lua_isstring(sectorObj)) {
-		const char *name = lua_getstring(sectorObj);
-		// a search by name here is needed for set bv, since it calls MakeSectorActive with sectors
-		// "bw_gone" and "bw_gone2", and a substring search would return "bw_gone2" for both.
-		Sector *sector = g_grim->getCurrSet()->getSectorByName(name);
-		if (sector) {
-			sector->setVisible(visible);
-		}
-	} else if (lua_isnumber(sectorObj)) {
+	if (lua_isnumber(sectorObj)) {
 		int numSectors = g_grim->getCurrSet()->getSectorCount();
 		int id = (int)lua_getnumber(sectorObj);
 		for (int i = 0; i < numSectors; i++) {
@@ -208,6 +200,14 @@ void Lua_V1::MakeSectorActive() {
 				sector->setVisible(visible);
 				return;
 			}
+		}
+	} else if (lua_isstring(sectorObj)) {
+		const char *name = lua_getstring(sectorObj);
+		// a search by name here is needed for set bv, since it calls MakeSectorActive with sectors
+		// "bw_gone" and "bw_gone2", and a substring search would return "bw_gone2" for both.
+		Sector *sector = g_grim->getCurrSet()->getSectorByName(name);
+		if (sector) {
+			sector->setVisible(visible);
 		}
 	}
 }


### PR DESCRIPTION
The first argument of MakeSectorActive can be either a string or a
number. If a number is used by the lua call lua_isstring will also return
true (see engines/grim/lua/lapi.cpp) and so the correct code which
handles the integer case is never called.

This patch reverses the order of the tests via lua_isstring and
lua_isnumber.

In EMI this fixes the following:
- big monkey head on Monkey Island stays open even after set or setup
  change
- the lights in the bank on lucre island stay off until Guybrush turns
  them on
- shadow of Pegnose's nose is visible in close-up camera view
