### PR TITLE
MYST3: Rotate the shortest distance to look at things

### DIFF
--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1147,6 +1147,13 @@ void Myst3Engine::animateDirectionChange(float targetPitch, float targetHeading,
 	float pitchDistance = targetPitch - startPitch;
 	float headingDistance = targetHeading - startHeading;
 
+
+	if (headingDistance > 180) {
+		headingDistance -= 360;
+	} else if (headingDistance < -180) {
+		headingDistance += 360;
+	}
+
 	// Compute animation duration in frames
 	float numFrames;
 	if (scriptFrames) {


### PR DESCRIPTION
This makes the player rotate correctly when clicking the left side of the door near the start of the game.

Not sure if the logic is right in all cases. This door has a heading of 0, so it at least works in the basic case. 
