### PR TITLE
RFC: GRIM: Allow changing opengl modes on the fly

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -159,6 +159,7 @@ void registerDefaults() {
 	ConfMan.registerDefault("fullscreen", false);
 	ConfMan.registerDefault("soft_renderer", false);
 	ConfMan.registerDefault("show_fps", false);
+	ConfMan.registerDefault("shaders", false);
 
 	// Sound & Music
 	ConfMan.registerDefault("music_volume", 192);

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -289,6 +289,7 @@ protected:
 
 // Factory-like functions:
 
+GfxBase *CreateGfxOpenGLS();
 GfxBase *CreateGfxOpenGL();
 GfxBase *CreateGfxTinyGL();
 

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -30,7 +30,7 @@
 #include "common/system.h"
 #include "common/config-manager.h"
 
-#if defined(USE_OPENGL) && !defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL)
 
 #include "graphics/surface.h"
 #include "graphics/pixelbuffer.h"

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -170,7 +170,7 @@ Math::Matrix4 makeRotationMatrix(const Math::Angle& angle, Math::Vector3d axis) 
 	return rotate;
 }
 
-GfxBase *CreateGfxOpenGL() {
+GfxBase *CreateGfxOpenGLS() {
 	return new GfxOpenGLS();
 }
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -228,7 +228,12 @@ void GrimEngine::createRenderer() {
 		g_driver = CreateGfxTinyGL();
 #ifdef USE_OPENGL
 	} else {
-		g_driver = CreateGfxOpenGL();
+#ifdef USE_OPENGL_SHADERS
+		if (ConfMan.getBool("shaders"))
+			g_driver = CreateGfxOpenGLS();
+		else
+#endif
+			g_driver = CreateGfxOpenGL();
 #endif
 	}
 }


### PR DESCRIPTION
If the platform supports both the new OpenGL with shaders and the old OpenGL we want to be able to switch between them at run time. This PR will let the user choose which OpenGL mode they want to use.

More changes will be needed to the configure script in order to actually build with both I think. I've only tested it on Windows by manually enabling shaders.

I added the "shaders" option. Maybe a better name is in order? We already have "use_arb_shaders" as well.