### PR TITLE
GRIM: Add a vertex buffer object for blast text drawing

### DIFF
--- a/engines/grim/gfx_opengl_shaders.h
+++ b/engines/grim/gfx_opengl_shaders.h
@@ -261,6 +261,7 @@ private:
 	uint32 _currentPrimitive;
 	void drawGenericPrimitive(const float *vertices, uint32 numVertices, const PrimitiveObject *primitive);
 	GLuint _irisVBO;
+	GLuint _blastVBO;
 };
 }
 #endif

--- a/engines/grim/textobject.h
+++ b/engines/grim/textobject.h
@@ -101,6 +101,7 @@ public:
 
 	void setIsSpeech() { _isSpeech = true; }
 	void setBlastDraw() { _blastDraw = true; }
+	bool isBlastDraw() { return _blastDraw; }
 
 	const void *getUserData() const { return _userData; }
 	void setUserData(void *data) { _userData = data; }


### PR DESCRIPTION
This makes it so that we don't have to destroy the VBO that a blast text object uses. This fixes what is probably a driver bug with the windows nvidia drivers.
