### PR TITLE
GRAPHICS: Also add a stencil attachment to framebuffers

### DIFF
--- a/graphics/opengles2/framebuffer.cpp
+++ b/graphics/opengles2/framebuffer.cpp
@@ -33,12 +33,13 @@ FrameBuffer::FrameBuffer(GLuint texture_name, uint width, uint height, uint text
 	glGenRenderbuffers(1, &_depthRenderBuffer);
 
 	glBindRenderbuffer(GL_RENDERBUFFER, _depthRenderBuffer);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, texture_width, texture_height);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, texture_width, texture_height);
 	glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture_name, 0);
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthRenderBuffer);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _depthRenderBuffer);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);
 	GLenum status=glCheckFramebufferStatus(GL_FRAMEBUFFER);

--- a/graphics/opengles2/system_headers.h
+++ b/graphics/opengles2/system_headers.h
@@ -40,6 +40,7 @@
 #define glMapBuffer glMapBufferOES
 #define glUnmapBuffer glUnmapBufferOES
 #define GL_WRITE_ONLY GL_WRITE_ONLY_OES
+#define GL_DEPTH24_STENCIL8 GL_DEPTH24_STENCIL8_OES
 
 #ifndef GL_BGRA
 #	define GL_BGRA GL_BGRA_EXT


### PR DESCRIPTION
This patch enables stencil operations when running in a framebuffer.
It prevents shadows in grim from rendering outside designated shadow areas.

Note that this does require the GL_OES_packed_depth_stencil extension on
ES2. iOS supports it, and so do modern Android devices.

If necessary we could add a separate path that uses regular textures for stencils.
Thoughts on how to handle extensions?
