### PR TITLE
EMI: Use parent sort order for attached actors

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -2126,12 +2126,7 @@ Math::Quaternion Actor::getRotationQuat() const {
 int Actor::getSortOrder() const {
 	if (_attachedActor != 0) {
 		Actor *attachedActor = Actor::getPool().getObject(_attachedActor);
-
-		// FIXME: The + 1 here and in getEffectiveSortOrder is just a guess.
-		// Without it it makes some attachments render on top of their owner.
-		// Theoritically it could cause an issue if the actor is close to the
-		// edge of a sort order boundry.
-		return attachedActor->getSortOrder() + 1;
+		return attachedActor->getSortOrder();
 	}
 	return _sortOrder;
 }
@@ -2139,7 +2134,7 @@ int Actor::getSortOrder() const {
 int Actor::getEffectiveSortOrder() const {
 	if (_attachedActor != 0) {
 		Actor *attachedActor = Actor::getPool().getObject(_attachedActor);
-		return attachedActor->getEffectiveSortOrder() + 1;
+		return attachedActor->getEffectiveSortOrder();
 	}
 	return _haveSectorSortOrder ? _sectorSortOrder : getSortOrder();
 }


### PR DESCRIPTION
When drawing attached actors the engine uses the parent's sort order
plus one. This offset can move the attached actor behind a background
plane, for instance the chess board in the Lucre docks or Guybrush when
riding the manatee.

The +1 offset was introduced in 58b0bed. The comment suggests that there
were some problems without it, but I don't see any. The z-buffer should take
care of which actor covers which.
