### PR TITLE
MATH: Remove duplicated deg/rad-conversions, replacing them by common/ma...

### DIFF
--- a/engines/myst3/scene.cpp
+++ b/engines/myst3/scene.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include "common/math.h"
+
 #include "engines/myst3/scene.h"
 #include "engines/myst3/node.h"
 #include "engines/myst3/myst3.h"
@@ -111,8 +113,8 @@ void Scene::drawSunspotFlare(const SunSpot &s) {
 static Math::Vector3d directionToVector(float pitch, float heading) {
 	Math::Vector3d v;
 
-	float radHeading = Math::degreeToRadian(heading);
-	float radPitch = Math::degreeToRadian(pitch);
+	float radHeading = Common::deg2rad(heading);
+	float radPitch = Common::deg2rad(pitch);
 
 	v.setValue(0, cos(radPitch) * cos(radHeading));
 	v.setValue(1, sin(radPitch));

--- a/math/angle.cpp
+++ b/math/angle.cpp
@@ -21,9 +21,9 @@
  */
 
 #include "common/streamdebug.h"
+#include "common/math.h"
 
 #include "math/angle.h"
-#include "math/utils.h"
 
 namespace Math {
 
@@ -57,7 +57,7 @@ void Angle::setDegrees(float degrees) {
 }
 
 void Angle::setRadians(float radians) {
-	_degrees = radianToDegree(radians);
+	_degrees = Common::rad2deg(radians);
 }
 
 float Angle::getDegrees() const {
@@ -65,7 +65,7 @@ float Angle::getDegrees() const {
 }
 
 float Angle::getRadians() const {
-	return degreeToRadian(getDegrees());
+	return Common::deg2rad(getDegrees());
 }
 
 float Angle::getDegrees(float low) const {
@@ -82,7 +82,7 @@ float Angle::getDegrees(float low) const {
 
 float Angle::getRadians(float low) const {
 	float d = getDegrees(low);
-	return degreeToRadian(d);
+	return Common::deg2rad(d);
 }
 
 float Angle::getCosine() const {
@@ -134,7 +134,7 @@ Angle &Angle::operator-=(float degrees) {
 }
 
 Angle Angle::fromRadians(float radians) {
-	return Angle(radianToDegree(radians));
+	return Angle(Common::rad2deg(radians));
 }
 
 Angle Angle::arcCosine(float x) {

--- a/math/utils.h
+++ b/math/utils.h
@@ -27,14 +27,6 @@
 
 namespace Math {
 
-inline float radianToDegree(float rad) {
-	return rad * 180.f / LOCAL_PI;
-}
-
-inline float degreeToRadian(float degree) {
-	return degree * LOCAL_PI / 180.f;
-}
-
 inline float square(float x) {
 	return x * x;
 }


### PR DESCRIPTION
...th.h-functionality

The only real difference between the common/math.h and math/utils.h deg/rad-conversion functions were the use of LOCAL_PI vs M_PI, so, I suggest we avoid the duplication.
