### PR TITLE
GRIM: heightcheck fix

### DIFF
--- a/engines/grim/sector.cpp
+++ b/engines/grim/sector.cpp
@@ -392,6 +392,7 @@ Common::List<Math::Line3d> Sector::getBridgesTo(Sector *sector) const {
 	}
 
 	// All the bridges should be at the same height on both sectors.
+	it = bridges.begin();
 	while (it != bridges.end()) {
 		if (g_grim->getGameType() == GType_MONKEY4) {
 			if (fabs(getProjectionToPlane((*it).begin()).y() - sector->getProjectionToPlane((*it).begin()).y()) > 0.01f ||


### PR DESCRIPTION
In Sector::getBridgesTo(), the height check is effectively disabled, as the iterator is not reset. This may lead Manny to jump from high platforms to lower ones. This is especially visible in the mouse mod, which makes use of walkTo more extensively, but is a general bug which is why I'm posting this here.
