### PR TITLE
RFC: GRIM: Do not draw textures where all the texture coords are the same point. Fixes #58

### DIFF
--- a/engines/grim/model.cpp
+++ b/engines/grim/model.cpp
@@ -302,7 +302,7 @@ void Model::Geoset::changeMaterials(Material *materials[]) {
 MeshFace::MeshFace() :
 		_material(nullptr), _type(0), _geo(0), _light(0), _tex(0),
 		_extraLight(0), _numVertices(0), _vertices(nullptr),
-		_texVertices(nullptr), _userData(nullptr) {
+		_texVertices(nullptr), _userData(nullptr), _texAllEqual(false) {
 }
 
 MeshFace::~MeshFace() {
@@ -346,8 +346,12 @@ int MeshFace::loadBinary(Common::SeekableReadStream *data, Material *materials[]
 
 	if (texPtr != 0) {
 		_texVertices = new int[_numVertices];
+		_texAllEqual = true;
 		for (int i = 0; i < _numVertices; i++) {
 			_texVertices[i] = data->readUint32LE();
+			if (_texVertices[i] != _texVertices[0]) {
+				_texAllEqual = false;
+			}
 		}
 	}
 

--- a/engines/grim/model.h
+++ b/engines/grim/model.h
@@ -98,7 +98,7 @@ public:
 	void draw(const Mesh *mesh) const;
 	void changeMaterial(Material *material);
 
-	bool hasTexture() const { return _texVertices != nullptr; }
+	bool hasTexture() const { return _texVertices != nullptr && !_texAllEqual; }
 
 	const Math::Vector3d &getNormal() const { return _normal; }
 	void setNormal(const Math::Vector3d &normal) { _normal = normal; }
@@ -115,6 +115,7 @@ private:
 	int _numVertices;
 	int *_vertices, *_texVertices;
 	Math::Vector3d _normal;
+	bool _texAllEqual;
 
 public:
 	void *_userData;


### PR DESCRIPTION
Probably not the best way to do this, but it illustrates the issue. I probably haven't though though all the edge cases though.

Anyone with better graphics knowledge have an opinion here?
