### PR TITLE
RFC GRIM: Move more of the logic regarding GL/TinyGL-selection to gfx_base.

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -157,7 +157,7 @@ void registerDefaults() {
 
 	// Graphics
 	ConfMan.registerDefault("fullscreen", false);
-	ConfMan.registerDefault("soft_renderer", false);
+	ConfMan.registerDefault("renderer", "opengl");
 	ConfMan.registerDefault("show_fps", false);
 
 	// Sound & Music

--- a/engines/grim/gfx_base.cpp
+++ b/engines/grim/gfx_base.cpp
@@ -109,12 +109,29 @@ void GfxBase::drawMesh(const Mesh *mesh) {
 		mesh->_faces[i].draw(mesh);
 }
 
-#ifndef USE_OPENGL
-// Allow CreateGfxOpenGL to be called even if OpenGL isn't included
-GfxBase *CreateGfxOpenGL() {
+// Prototypes for the factory-function below.
+GfxBase *CreateGfxOpenGL();
+GfxBase *CreateGfxOpenGLS();
+GfxBase *CreateGfxTinyGL();
+GfxBase *CreateGfxDriver(RendererType preferredRendererType) {
+#ifdef USE_OPENGL
+	if (preferredRendererType == GFX_DRIVER_OPENGL) {
+		return CreateGfxOpenGL();
+	}
+#endif
+
+#ifdef USE_OPENGL_SHADERS
+	if (preferredRendererType == GFX_DRIVER_OPENGL_SHADERS) {
+		return CreateGfxOpenGLS();
+	}
+#endif
+
+	if (preferredRendererType == GFX_DRIVER_TINYGL) {
+		return CreateGfxTinyGL();
+	}
+	// Fallthrough, in case the relevant if-block above was disabled.
 	return CreateGfxTinyGL();
 }
-#endif // USE_OPENGL
 
 Math::Matrix4 GfxBase::makeLookMatrix(const Math::Vector3d& pos, const Math::Vector3d& interest, const Math::Vector3d& up) {
 	Math::Vector3d f = (interest - pos).getNormalized();

--- a/engines/grim/gfx_base.cpp
+++ b/engines/grim/gfx_base.cpp
@@ -114,7 +114,7 @@ GfxBase *CreateGfxOpenGL();
 GfxBase *CreateGfxOpenGLS();
 GfxBase *CreateGfxTinyGL();
 GfxBase *CreateGfxDriver(RendererType preferredRendererType) {
-#ifdef USE_OPENGL
+#if defined(USE_OPENGL) && !defined(USE_GLES2)
 	if (preferredRendererType == GFX_DRIVER_OPENGL) {
 		return CreateGfxOpenGL();
 	}

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -307,8 +307,13 @@ protected:
 
 // Factory-like functions:
 
-GfxBase *CreateGfxOpenGL();
-GfxBase *CreateGfxTinyGL();
+enum RendererType {
+	GFX_DRIVER_OPENGL,
+	GFX_DRIVER_OPENGL_SHADERS,
+	GFX_DRIVER_TINYGL
+};
+
+GfxBase *CreateGfxDriver(RendererType preferredRendererType);
 
 extern GfxBase *g_driver;
 

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -30,7 +30,7 @@
 #include "common/system.h"
 #include "common/config-manager.h"
 
-#if defined(USE_OPENGL) && !defined(USE_OPENGL_SHADERS)
+#if defined(USE_OPENGL) && !defined(USE_GLES2)
 
 #include "graphics/surface.h"
 #include "graphics/pixelbuffer.h"

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -191,7 +191,7 @@ Math::Matrix4 makeRotationMatrix(const Math::Angle& angle, Math::Vector3d axis) 
 	return rotate;
 }
 
-GfxBase *CreateGfxOpenGL() {
+GfxBase *CreateGfxOpenGLS() {
 	return new GfxOpenGLS();
 }
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -220,9 +220,7 @@ LuaBase *GrimEngine::createLua() {
 }
 
 void GrimEngine::createRenderer() {
-#ifdef USE_OPENGL
 	_softRenderer = ConfMan.getBool("soft_renderer");
-#endif
 
 	if (!_softRenderer && !g_system->hasFeature(OSystem::kFeatureOpenGL)) {
 		warning("gfx backend doesn't support hardware rendering");
@@ -230,11 +228,9 @@ void GrimEngine::createRenderer() {
 	}
 
 	if (_softRenderer) {
-		g_driver = CreateGfxTinyGL();
-#ifdef USE_OPENGL
+		g_driver = CreateGfxDriver(GFX_DRIVER_TINYGL);
 	} else {
-		g_driver = CreateGfxOpenGL();
-#endif
+		g_driver = CreateGfxDriver(GFX_DRIVER_OPENGL);
 	}
 }
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -96,15 +96,12 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 	g_imuse = nullptr;
 
 	//Set default settings
-	ConfMan.registerDefault("soft_renderer", false);
 	ConfMan.registerDefault("engine_speed", 60);
 	ConfMan.registerDefault("fullscreen", false);
 	ConfMan.registerDefault("show_fps", false);
 	ConfMan.registerDefault("use_arb_shaders", true);
 
 	_showFps = ConfMan.getBool("show_fps");
-
-	_softRenderer = true;
 
 	_mixer->setVolumeForSoundType(Audio::Mixer::kPlainSoundType, 192);
 	_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, ConfMan.getInt("sfx_volume"));
@@ -220,18 +217,21 @@ LuaBase *GrimEngine::createLua() {
 }
 
 void GrimEngine::createRenderer() {
-	_softRenderer = ConfMan.getBool("soft_renderer");
+	Common::String type = ConfMan.get("renderer");
+	if (type == "opengl") {
+		_rendererType = GFX_DRIVER_OPENGL;
+	} else if (type == "opengl_shaders") {
+		_rendererType = GFX_DRIVER_OPENGL_SHADERS;
+	} else if (type == "software") {
+		_rendererType = GFX_DRIVER_TINYGL;
+	}
 
-	if (!_softRenderer && !g_system->hasFeature(OSystem::kFeatureOpenGL)) {
+	if (!_rendererType != GFX_DRIVER_TINYGL && !g_system->hasFeature(OSystem::kFeatureOpenGL)) {
 		warning("gfx backend doesn't support hardware rendering");
-		_softRenderer = true;
+		_rendererType = GFX_DRIVER_TINYGL;
 	}
 
-	if (_softRenderer) {
-		g_driver = CreateGfxDriver(GFX_DRIVER_TINYGL);
-	} else {
-		g_driver = CreateGfxDriver(GFX_DRIVER_OPENGL);
-	}
+	g_driver = CreateGfxDriver(_rendererType);
 }
 
 const char *GrimEngine::getUpdateFilename() {
@@ -315,7 +315,7 @@ Common::Error GrimEngine::run() {
 
 	// This flipBuffer() may make the OpenGL renderer show garbage instead of the splash,
 	// while the TinyGL renderer needs it.
-	if (_softRenderer)
+	if (_rendererType == GFX_DRIVER_TINYGL)
 		g_driver->flipBuffer();
 
 	LuaBase *lua = createLua();

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -33,6 +33,7 @@
 
 #include "engines/grim/textobject.h"
 #include "engines/grim/iris.h"
+#include "engines/grim/gfx_base.h"
 
 namespace Grim {
 
@@ -238,7 +239,7 @@ protected:
 	unsigned int _lastFrameTime;
 	unsigned _speedLimitMs;
 	bool _showFps;
-	bool _softRenderer;
+	RendererType _rendererType;
 
 	bool *_controlsEnabled;
 	bool *_controlsState;


### PR DESCRIPTION
This is intended as a proposal to some changes in #820, it moves the checks for what driver to use if the users choice is not compiled in to gfxBase, and thus the relevant ifdefs.I f all else fails, we will fallback to TinyGL-rendering in the factory-function this way.

I have not tested this with the shaders-driver, and just a minimal test was done with the other two.

Another approach entirely would be to move even the ConfMan-check to GfxBase, and thus make grim.cpp completely oblivious about the selection.

All in all, this should leave us with a tad cleaner, and more flexible way to set up the drivers.

Thoughts, and testing with the GLES-backend is very welcome.