### PR TITLE
EMI: Allow the user to skip the intro movie in the EMI Demo.

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -712,13 +712,18 @@ void GrimEngine::mainLoop() {
 			Common::EventType type = event.type;
 			if (type == Common::EVENT_KEYDOWN || type == Common::EVENT_KEYUP) {
 				if (type == Common::EVENT_KEYDOWN) {
-					// Allow us to disgracefully skip movies in the PS2-version:
-					if (_mode == SmushMode && getGamePlatform() == Common::kPlatformPS2) {
+					// Ignore everything but ESC when movies are playing
+					// This matches the retail and demo versions of EMI
+					// This also allows the PS2 version to skip movies
+					if (_mode == SmushMode && g_grim->getGameType() == GType_MONKEY4) {
 						if (event.kbd.keycode == Common::KEYCODE_ESCAPE) {
 							g_movie->stop();
 							break;
 						}
-					} else if (_mode != DrawMode && _mode != SmushMode && (event.kbd.ascii == 'q')) {
+						continue;
+					}
+
+					if (_mode != DrawMode && _mode != SmushMode && (event.kbd.ascii == 'q')) {
 						handleExit();
 						break;
 					} else if (_mode != DrawMode && (event.kbd.keycode == Common::KEYCODE_PAUSE)) {


### PR DESCRIPTION
This change allows the user to skip the intro movie by pressing ESC. It works on the original engine, but not here. I haven't figured out if there's an error in the scripts, but I'm not seeing a way to skip it.

In the actual game, they wrap StartMovie with the Lua function RunFullscreenMovie which handles skipping the movie by setting a new button handler.
