### PR TITLE
GRIM: Remove _matrix from Component

### DIFF
--- a/engines/grim/costume.cpp
+++ b/engines/grim/costume.cpp
@@ -530,7 +530,6 @@ void Costume::saveState(SaveGame *state) const {
 
 		if (c) {
 			state->writeBool(c->_visible);
-			state->writeVector3d(c->_matrix.getPosition());
 			c->saveState(state);
 		}
 	}
@@ -559,7 +558,10 @@ bool Costume::restoreState(SaveGame *state) {
 
 		if (c) {
 			c->_visible = state->readBool();
-			c->_matrix.setPosition(state->readVector3d());
+			if (state->saveMinorVersion() < 14) {
+				// skip the old _matrix vector
+				state->readVector3d();
+			}
 			c->restoreState(state);
 		}
 	}

--- a/engines/grim/costume/component.h
+++ b/engines/grim/costume/component.h
@@ -68,7 +68,6 @@ protected:
 	int _parentID;
 	bool _visible;
 	Component *_parent, *_child, *_sibling;
-	Math::Matrix4 _matrix;
 	Costume *_cost;
 	Common::String _name;
 

--- a/engines/grim/costume/mesh_component.cpp
+++ b/engines/grim/costume/mesh_component.cpp
@@ -78,10 +78,15 @@ int MeshComponent::update(uint /*time*/) {
 
 void MeshComponent::saveState(SaveGame *state) {
 	state->writeBool(_node->_meshVisible);
+	state->writeVector3d(_matrix.getPosition());
 }
 
 void MeshComponent::restoreState(SaveGame *state) {
 	_node->_meshVisible = state->readBool();
+	if (state->saveMinorVersion() >= 14) {
+		_matrix.setPosition(state->readVector3d());
+		_node->setMatrix(_matrix);
+	}
 }
 
 } // end of namespace Grim

--- a/engines/grim/costume/model_component.h
+++ b/engines/grim/costume/model_component.h
@@ -41,7 +41,6 @@ public:
 	void animate();
 	void reset();
 	void resetColormap();
-	void setMatrix(const Math::Matrix4 &matrix) { _matrix = matrix; };
 	void restoreState(SaveGame *state);
 	void translateObject(bool reset);
 	static void translateObject(ModelNode *node, bool reset);
@@ -56,7 +55,6 @@ public:
 protected:
 	Model *_obj;
 	ModelNode *_hier;
-	Math::Matrix4 _matrix;
 	AnimManager *_animation;
 	Component *_prevComp;
 	bool _animated;

--- a/engines/grim/savegame.cpp
+++ b/engines/grim/savegame.cpp
@@ -35,7 +35,7 @@ namespace Grim {
 #define SAVEGAME_FOOTERTAG  'ESAV'
 
 uint SaveGame::SAVEGAME_MAJOR_VERSION = 22;
-uint SaveGame::SAVEGAME_MINOR_VERSION = 13;
+uint SaveGame::SAVEGAME_MINOR_VERSION = 14;
 
 SaveGame *SaveGame::openForLoading(const Common::String &filename) {
 	Common::InSaveFile *inSaveFile = g_system->getSavefileManager()->openForLoading(filename);


### PR DESCRIPTION
Model and Mesh are the only components that actually use _matrix, and they both have their own local _matrix variable. This remove the confusion over which _matrix variable is actually used and removes saving _matrix for all the components that don't use it.

I figured I'd pull request this as it could mess up saves if I did something wrong.
