### PR TITLE
EMI: Allow actors to be hidden by a call to set_wear_chore(nil).

### DIFF
--- a/engines/grim/emi/costumeemi.cpp
+++ b/engines/grim/emi/costumeemi.cpp
@@ -125,6 +125,9 @@ void EMICostume::load(Common::SeekableReadStream *data) {
 	for (int i = 0; i < _numComponents; ++i) {
 		_components[i] = components[i];
 	}
+
+	// The wearChore is active by default
+	_isWearChoreActive = true;
 }
 
 void EMICostume::playChore(int num) {
@@ -196,7 +199,7 @@ void EMICostume::draw() {
 		}
 	}
 
-	if (_wearChore && !drewMesh) {
+	if (_wearChore && !drewMesh && _isWearChoreActive) {
 		_wearChore->getMesh()->draw();
 	}
 }
@@ -289,6 +292,10 @@ void EMICostume::setWearChore(EMIChore *chore) {
 		}
 		_emiSkel = chore->getSkeleton();
 	}
+}
+
+void EMICostume::setWearChoreActive(bool isActive) {
+	_isWearChoreActive = isActive;
 }
 
 } // end of namespace Grim

--- a/engines/grim/emi/costumeemi.h
+++ b/engines/grim/emi/costumeemi.h
@@ -71,11 +71,13 @@ public:
 			}
 		}
 	}
+	void setWearChoreActive(bool isActive);
 public:
 	EMIChore *_wearChore;
 	EMISkelComponent *_emiSkel;
 	Common::List<Material *> _materials;
 private:
+	bool _isWearChoreActive;
 	static bool compareChores(const Chore *c1, const Chore *c2);
 	virtual void sortPlayingChores();
 	Component *loadEMIComponent(Component *parent, int parentID, const char *name, Component *prevComponent);

--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -705,6 +705,8 @@ void Lua_V2::PlayActorChore() {
 
 	EMIChore *chore = (EMIChore *)costume->getChore(choreName);
 	if (0 == strncmp("wear_", choreName, 5)) {
+		EMICostume *emiCostume = static_cast<EMICostume *>(costume);
+		emiCostume->setWearChoreActive(true);
 		actor->setLastWearChore(costume->getChoreId(choreName), costume);
 	}
 
@@ -734,6 +736,11 @@ void Lua_V2::StopActorChores() {
 		return;
 
 	actor->stopAllChores(ignoreLoopingChores);
+
+	// Reset the wearChore as well
+	EMICostume *cost = static_cast<EMICostume *>(actor->getCurrentCostume());
+	if (cost != NULL)
+		cost->setWearChoreActive(false);
 }
 
 void Lua_V2::SetActorLighting() {


### PR DESCRIPTION
In EMI, actors are hidden by a call to set_wear_chore(nil). An early example of this is when Guybrush eats the pretzels in the SCUMM bar. It appears that the original engine stops the actor's wearChore as well when StopActorChores() is called, but ResidualVM wasn't doing that.

This code adds a new private variable to keep track of whether the wearChore is visible. When the wearChore is not visible, the draw() command is bypassed.
