### PR TITLE
EMI: Change drawing order of faces

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -101,6 +101,12 @@ GfxOpenGL::GfxOpenGL() : _smushNumTex(0),
 		_dimFragProgram(0), _maxLights(0), _storedDisplay(NULL), 
 		_emergFont(0), _alpha(1.f) {
 	g_driver = this;
+	// GL_LEQUAL as glDepthFucn ensures that subsequent drawing attempts for
+	// the same triangles are not ignored by the depth test.
+	// That's necessary for EMI where some models have multiple faces which
+	// refer to the same vertices. The first face is usually using the
+	// color map and the following are using textures.
+	_depthFunc = (g_grim->getGameType() == GType_MONKEY4) ? GL_LEQUAL : GL_LESS;
 }
 
 GfxOpenGL::~GfxOpenGL() {
@@ -610,7 +616,7 @@ void GfxOpenGL::getShadowColor(byte *r, byte *g, byte *b) {
 void GfxOpenGL::set3DMode() {
 	glMatrixMode(GL_MODELVIEW);
 	glEnable(GL_DEPTH_TEST);
-	glDepthFunc(GL_LESS);
+	glDepthFunc(_depthFunc);
 }
 
 void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face) {
@@ -1076,7 +1082,7 @@ void GfxOpenGL::drawBitmap(const Bitmap *bitmap, int dx, int dy, uint32 layer) {
 		glEnable(GL_DEPTH_TEST);
 	} else {
 		glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glDepthFunc(GL_LESS);
+		glDepthFunc(_depthFunc);
 #ifdef GL_ARB_fragment_program
 		glDisable(GL_FRAGMENT_PROGRAM_ARB);
 #endif
@@ -1367,7 +1373,7 @@ void GfxOpenGL::drawDepthBitmap(int x, int y, int w, int h, char *data) {
 
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glDepthFunc(GL_LESS);
+	glDepthFunc(_depthFunc);
 }
 
 void GfxOpenGL::prepareMovieFrame(Graphics::Surface *frame) {

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -138,6 +138,7 @@ private:
 	GLint _maxLights;
 	float _alpha;
 	const Actor *_currentActor;
+	GLenum _depthFunc;
 };
 
 } // end of namespace Grim

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -343,7 +343,14 @@ byte *GfxOpenGLS::setupScreen(int screenW, int screenH, bool fullscreen) {
 
 	_screenSize = _screenWidth * _screenHeight * 4;
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
+	if (g_grim->getGameType() == GType_MONKEY4) {
+		// GL_LEQUAL as glDepthFucn ensures that subsequent drawing attempts for
+		// the same triangles are not ignored by the depth test.
+		// That's necessary for EMI where some models have multiple faces which
+		// refer to the same vertices. The first face is usually using the
+		// color map and the following are using textures.
+		glDepthFunc(GL_LEQUAL);
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
If multiple faces of one model are referring to the same triangles, let
them overwrite each other so that the latest one will be visible. For
this purpose glDepthFunc is changed from GL_LESS to GL_LEQUAL so
that subsequent drawing attempts for the same triangle are not ignored by
the depth test.

This fixes the issue of the colored leg of the monkey bot in the end
scenes: the leg is drawn using color maps by the first face and using
textures by a following face.

The commit fixes the problem for the OpenGL and the OpenGLS renderer. The "colored leg" issue did not happen with TinyGL.

It looks like that TinyGL is already using a hard-coded equivalent to GL_LEQUAL:
# define ZCMP(z, zpix) ((z) >= (zpix))

so we could consider to use GL_LEQUAL unconditional for all game engines.

The current proposal only effects EMI in order to be less invasive.
