### PR TITLE
TINYGL: rename variable to get rid of warning

### DIFF
--- a/graphics/tinygl/list.cpp
+++ b/graphics/tinygl/list.cpp
@@ -229,8 +229,8 @@ unsigned int glGenLists(int range) {
 			count++;
 			if (count == range) {
 				list = i - range + 1;
-				for (int i = 0; i < range; i++) {
-					alloc_list(c, list + i);
+				for (int j = 0; j < range; j++) {
+					alloc_list(c, list + j);
 				}
 				return list;
 			}


### PR DESCRIPTION
With this fix, ResidualVM compiles without warnings on my box (Linux, GCC).
