### PR TITLE
EMI: Add a stopWalking() call to ActorStopMoving. Fixes #880.

### DIFF
--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -435,8 +435,11 @@ void Lua_V2::ActorStopMoving() {
 
 	Actor *actor = getactor(actorObj);
 
+	actor->stopWalking();
+	// FIXME: Also stop turning?
+
 	warning("Lua_V2::ActorStopMoving, actor: %s", actor->getName().c_str());
-	// FIXME: implement missing rest part of code
+	// FIXME: Inspect the rest of the code to see if there's anything else missing
 }
 
 void Lua_V2::GetActorWorldPos() {


### PR DESCRIPTION
It seemed like Herman was walking backwards, but what was really happening is that the script called ActorStopMoving which was a stub. This adds a call to stopWalking() to stop the actor's movement. I left the FIXME because I haven't yet gone through the assembly to see what else this function does.
