### PR TITLE
GRIM: If ActorLookAt is called with an actor as the target, look towards...

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -2177,6 +2177,34 @@ Math::Quaternion Actor::getRotationQuat() const {
 	}
 }
 
+Math::Vector3d Actor::getHeadPos() const {
+	for (Common::List<Costume *>::const_iterator i = _costumeStack.begin(); i != _costumeStack.end(); ++i) {
+		int headJoint = (*i)->getHeadJoint();
+		if (headJoint == -1)
+			continue;
+
+		ModelNode *allNodes = (*i)->getModelNodes();
+		ModelNode *node = allNodes + headJoint;
+
+		node->_needsUpdate = true;
+		ModelNode *root = node;
+		while (root->_parent) {
+			root = root->_parent;
+			root->_needsUpdate = true;
+		}
+
+		Math::Matrix4 matrix;
+		matrix.setPosition(_pos);
+		matrix.buildFromPitchYawRoll(_pitch, _yaw, _roll);
+		root->setMatrix(matrix);
+		root->update();
+
+		return node->_pivotMatrix.getPosition();
+	}
+
+	return _pos;
+}
+
 int Actor::getSortOrder() const {
 	if (_attachedActor != 0) {
 		Actor *attachedActor = Actor::getPool().getObject(_attachedActor);

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -510,6 +510,7 @@ public:
 	void detach();
 	Math::Quaternion getRotationQuat() const;
 	const Math::Matrix4 getFinalMatrix() const;
+	Math::Vector3d getHeadPos() const;
 
 	void setInOverworld(bool inOverworld) { _inOverworld = inOverworld; }
 	bool isInOverworld() const { return _inOverworld; }

--- a/engines/grim/costume.cpp
+++ b/engines/grim/costume.cpp
@@ -483,6 +483,10 @@ void Costume::moveHead(bool entering, const Math::Vector3d &lookAt) {
 	_head->lookAt(entering, lookAt, _lookAtRate, _matrix);
 }
 
+int Costume::getHeadJoint() const {
+	return _head->getJoint3();
+}
+
 void Costume::setHead(int joint1, int joint2, int joint3, float maxRoll, float maxPitch, float maxYaw) {
 	_head->setJoints(joint1, joint2, joint3);
 	_head->loadJoints(getModelNodes());

--- a/engines/grim/costume.h
+++ b/engines/grim/costume.h
@@ -75,6 +75,7 @@ public:
 	void setLookAtRate(float rate);
 	float getLookAtRate() const;
 	void moveHead(bool entering, const Math::Vector3d &lookAt);
+	int getHeadJoint() const;
 
 	CMap *getCMap() { return _cmap; }
 

--- a/engines/grim/costume/head.h
+++ b/engines/grim/costume/head.h
@@ -63,6 +63,10 @@ public:
 	void saveState(SaveGame *state) const;
 	void restoreState(SaveGame *state);
 
+	int getJoint1() const { return _joint1Node; }
+	int getJoint2() const { return _joint2Node; }
+	int getJoint3() const { return _joint3Node; }
+
 private:
 	int _joint1Node;
 	int _joint2Node;

--- a/engines/grim/lua_v1_actor.cpp
+++ b/engines/grim/lua_v1_actor.cpp
@@ -1135,7 +1135,7 @@ void Lua_V1::ActorLookAt() {
 			actor->setLookAtRate(lua_getnumber(rateObj));
 	} else if (lua_isuserdata(xObj) && lua_tag(xObj) == MKTAG('A','C','T','R')) { // look at another actor
 		Actor *lookedAct = getactor(xObj);
-		actor->setLookAtVector(lookedAct->getPos());
+		actor->setLookAtVector(lookedAct->getHeadPos());
 
 		if (lua_isnumber(yObj))
 			actor->setLookAtRate(lua_getnumber(yObj));


### PR DESCRIPTION
... the actor's head instead of their origin. Fixes #887
