### PR TITLE
Improve light intensity

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -801,6 +801,7 @@ void GfxOpenGL::setupLight(Light *light, int lightId) {
 	GLfloat lightPos[] = { 0.0f, 0.0f, 0.0f, 1.0f };
 	GLfloat lightDir[] = { 0.0f, 0.0f, -1.0f };
 	GLfloat cutoff = 180.0f;
+	GLfloat spot_exp = 0.0f;
 
 	GLfloat intensity = light->_intensity;
 	diffuse[0] = ((GLfloat)light->_color.getRed() / 15.0f) * intensity;
@@ -826,6 +827,7 @@ void GfxOpenGL::setupLight(Light *light, int lightId) {
 		specular[0] = diffuse[0];
 		specular[1] = diffuse[1];
 		specular[2] = diffuse[2];
+		spot_exp = 2.0f;
 		cutoff = light->_penumbraangle;
 	}
 
@@ -834,6 +836,7 @@ void GfxOpenGL::setupLight(Light *light, int lightId) {
 	glLightfv(GL_LIGHT0 + lightId, GL_SPECULAR, specular);
 	glLightfv(GL_LIGHT0 + lightId, GL_POSITION, lightPos);
 	glLightfv(GL_LIGHT0 + lightId, GL_SPOT_DIRECTION, lightDir);
+	glLightf(GL_LIGHT0 + lightId, GL_SPOT_EXPONENT, spot_exp);
 	glLightf(GL_LIGHT0 + lightId, GL_SPOT_CUTOFF, cutoff);
 	glLightf(GL_LIGHT0 + lightId, GL_QUADRATIC_ATTENUATION, 0.2f);
 	glEnable(GL_LIGHT0 + lightId);


### PR DESCRIPTION
Reduces a log the difference with original's software renderer. The following sets were checked: mo, ga, al, do, su.
In do and su, there is a light which seems misbehaving (chepito_light in su, newlight1 in "do"): they are removing light from the scene in some conditions. Tests were done with these lights disabled when this happens. More details:
In su, chepito's light darkens scene center when intensity is low (=when chepito is far).
In do, the window spotlight darkens hall-side of the room and the bottle.

There are still glitches around "do"'s window: if you stick to the left (screen-wise when camera points away from the window) wall and walk toward the window, polygons get illuminated a bit crudely. Setting GL_SPOT_EXPONENT improves this, but reduces peak light intensity somehow, so I did not include a change for this.
