### PR TITLE
EMI: Make SCXTrack behave like MP3Track in regards to isPlaying

### DIFF
--- a/engines/grim/emi/sound/scxtrack.cpp
+++ b/engines/grim/emi/sound/scxtrack.cpp
@@ -49,4 +49,11 @@ bool SCXTrack::openSound(const Common::String &soundName, Common::SeekableReadSt
 	return true;
 }
 
+bool SCXTrack::isPlaying() {
+	if (!_handle)
+		return false;
+
+	return g_system->getMixer()->isSoundHandleActive(*_handle);
+}
+
 } // end of namespace Grim

--- a/engines/grim/emi/sound/scxtrack.h
+++ b/engines/grim/emi/sound/scxtrack.h
@@ -39,7 +39,7 @@ public:
 	SCXTrack(Audio::Mixer::SoundType soundType);
 	~SCXTrack();
 	bool openSound(const Common::String &soundName, Common::SeekableReadStream *file) override;
-	bool isPlaying() override { return true; }
+	bool isPlaying() override;
 };
 
 }


### PR DESCRIPTION
Apparently SCXTrack always returned true for isPlaying. I have no idea why I wrote the code to behave that way, and since d58b770b0b9f542f511524e883c9e5c0a4f81e3d this meant that no SCXTrack would ever get started. So, this changes SCXTrack to use the same solution as MP3Track (i.e. I just copied the MP3Track code over).

I'm not sure if this is the correct fix though, as SCX is quite different from the system used with MP3s.
