### PR TITLE
GRIM: Set g_grim to nullptr in the deconstructor

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -196,6 +196,8 @@ GrimEngine::~GrimEngine() {
 
 	ConfMan.flushToDisk();
 	DebugMan.clearAllDebugChannels();
+
+	g_grim = nullptr;
 }
 
 void GrimEngine::clearPools() {


### PR DESCRIPTION
If you start grim (or emi), have the md5 fail the verify. Tell it you do not want to play anyway, and then try again, it'll crash as g_grim is pointing to a non existent object.

I'm making a pull request because I want to make sure that this is not bad for some strange reason. I don't think there is any issue here, but I figure it's good to check.
