### PR TITLE
GRIM/EMI: Always initialize the fields of BitmapData

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -197,6 +197,9 @@ BitmapData::BitmapData(const Graphics::PixelBuffer &buf, int w, int h, const cha
 	_keepData = true;
 
 	_userData = nullptr;
+	_texc = nullptr;
+	_verts = nullptr;
+	_layers = nullptr;
 
 	g_driver->createBitmap(this);
 }


### PR DESCRIPTION
This fixes a crash when saving the game introduced by a6a2cb71d4b4a. One of BitmapData's constructors used when taking the save screenshot image did not initialize the _texc, _verts and _layers arrays. This caused a segfault later on when the destructor attempted to delete these.
