### PR TITLE
GRIM: Fix the head tracking broken by the changes to Rotation3D

### DIFF
--- a/math/rotation3d.h
+++ b/math/rotation3d.h
@@ -107,68 +107,68 @@ Rotation3D<T>::Rotation3D() : Transform<T>() {}
 template<class T>
 void Rotation3D<T>::buildFromXYZ(const Angle &rotX, const Angle &rotY, const Angle &rotZ, EulerOrder order) {
 	// Build a matrix around each rotation angle
-	T m1, m2, m3;
+	T m2, m3;
 
 	// Combine them in the order requested
 	switch (order) {
 		case EO_XYX:
-			m1.buildAroundX(rotX);
+			this->buildAroundX(rotX);
 			m2.buildAroundY(rotY);
 			m3.buildAroundX(rotZ);
 			break;
 		case EO_XYZ:
-			m1.buildAroundX(rotX);
+			this->buildAroundX(rotX);
 			m2.buildAroundY(rotY);
 			m3.buildAroundZ(rotZ);
 			break;
 		case EO_XZX:
-			m1.buildAroundX(rotX);
+			this->buildAroundX(rotX);
 			m2.buildAroundZ(rotY);
 			m3.buildAroundX(rotZ);
 			break;
 		case EO_XZY:
-			m1.buildAroundX(rotX);
+			this->buildAroundX(rotX);
 			m2.buildAroundZ(rotY);
 			m3.buildAroundY(rotZ);
 			break;
 		case EO_YXY:
-			m1.buildAroundY(rotX);
+			this->buildAroundY(rotX);
 			m2.buildAroundX(rotY);
 			m3.buildAroundY(rotZ);
 			break;
 		case EO_YXZ:
-			m1.buildAroundY(rotX);
+			this->buildAroundY(rotX);
 			m2.buildAroundX(rotY);
 			m3.buildAroundZ(rotZ);
 			break;
 		case EO_YZX:
-			m1.buildAroundY(rotX);
+			this->buildAroundY(rotX);
 			m2.buildAroundZ(rotY);
 			m3.buildAroundX(rotZ);
 			break;
 		case EO_YZY:
-			m1.buildAroundY(rotX);
+			this->buildAroundY(rotX);
 			m2.buildAroundZ(rotY);
 			m3.buildAroundY(rotZ);
 			break;
 		// Original ResidualVM Implementation
 		case EO_ZXY:
-			m1.buildAroundZ(rotX);
+			this->buildAroundZ(rotX);
 			m2.buildAroundX(rotY);
 			m3.buildAroundY(rotZ);
 			break;
 		case EO_ZXZ:
-			m1.buildAroundZ(rotX);
+			this->buildAroundZ(rotX);
 			m2.buildAroundX(rotY);
 			m3.buildAroundZ(rotZ);
 			break;
 		case EO_ZYX:
-			m1.buildAroundZ(rotX);
+			this->buildAroundZ(rotX);
 			m2.buildAroundY(rotY);
 			m3.buildAroundX(rotZ);
 			break;
 		case EO_ZYZ:
-			m1.buildAroundZ(rotX);
+			this->buildAroundZ(rotX);
 			m2.buildAroundY(rotY);
 			m3.buildAroundZ(rotZ);
 			break;
@@ -177,7 +177,7 @@ void Rotation3D<T>::buildFromXYZ(const Angle &rotX, const Angle &rotY, const Ang
 			break;
 	}
 	// Combine the rotations
-	this->getMatrix() = m1 * m2 * m3;
+	this->getMatrix() = this->getMatrix() * m2 * m3;
 }
 
 // at. Rotates about the +X axis.


### PR DESCRIPTION
When updating the Rotation3D implementation, I missed that the position portion of the rotation matrix was retained after building a rotation. The second patch addresses that. This patch also adds a fix for gimbal lock for the ZXY (ResidualVM default) case of getXYZ. I'll implement the others later, as needed.
