### PR TITLE
GRIM: Use quaternions for animation.

### DIFF
--- a/engines/grim/costume/head.cpp
+++ b/engines/grim/costume/head.cpp
@@ -144,22 +144,11 @@ void Head::Joint::orientTowards(bool entering, const Math::Vector3d &point, floa
 	_yaw = y;
 	_roll = r;
 
-	// Assemble ypr back to a matrix.
-	// This matrix is the head orientation with respect to parent-with-keyframe-animation space.
-	lookAtTM.buildFromXYZ(y, pt, r, Math::EO_ZXY);
+	// Assemble ypr to a quaternion.
+	// This is the head orientation with respect to parent-with-keyframe-animation space.
+	Math::Quaternion lookAtQuat = Math::Quaternion::fromXYZ(y, pt, r, Math::EO_ZXY);
 
-	// What follows is a hack: Since translateObject(ModelNode *node, bool reset) in this file,
-	// and GfxOpenGL/GfxTinyGL::drawHierachyNode concatenate transforms incorrectly, by summing up
-	// euler angles, do a hack here where we do the proper transform here already, and *subtract off*
-	// the YPR scalars from the animYPR scalars to cancel out the values that those pieces of code
-	// will later accumulate. After those pieces of code have been fixed, the following lines can
-	// be deleted, and this function can simply output the contents of pt, y and r variables above.
-	lookAtTM = animFrame * lookAtTM;
-
-	lookAtTM.getXYZ(&y, &pt, &r, Math::EO_ZXY);
-	_node->_animYaw = y - _node->_yaw;
-	_node->_animPitch = pt - _node->_pitch;
-	_node->_animRoll = r - _node->_roll;
+	_node->_animRot = _node->_animRot * lookAtQuat;
 }
 
 void Head::Joint::saveState(SaveGame *state) const {

--- a/engines/grim/costume/model_component.cpp
+++ b/engines/grim/costume/model_component.cpp
@@ -125,10 +125,8 @@ AnimManager *ModelComponent::getAnimManager() const {
 int ModelComponent::update(uint time) {
 	// First reset the current animation.
 	for (int i = 0; i < getNumNodes(); i++) {
-		_hier[i]._animPos.set(0, 0, 0);
-		_hier[i]._animPitch = 0;
-		_hier[i]._animYaw = 0;
-		_hier[i]._animRoll = 0;
+		_hier[i]._animPos = _hier[i]._pos;
+		_hier[i]._animRot = _hier[i]._rot;
 	}
 
 	_animated = false;

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -139,6 +139,7 @@ public:
 	virtual void translateViewpointStart() = 0;
 	virtual void translateViewpoint(const Math::Vector3d &vec) = 0;
 	virtual void rotateViewpoint(const Math::Angle &angle, const Math::Vector3d &axis) = 0;
+	virtual void rotateViewpoint(const Math::Matrix4 &rot) = 0;
 	virtual void translateViewpointFinish() = 0;
 
 	virtual void drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face) = 0;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -852,6 +852,10 @@ void GfxOpenGL::rotateViewpoint(const Math::Angle &angle, const Math::Vector3d &
 	glRotatef(angle.getDegrees(), axis.x(), axis.y(), axis.z());
 }
 
+void GfxOpenGL::rotateViewpoint(const Math::Matrix4 &rot) {
+	glMultMatrixf(rot.getData());
+}
+
 void GfxOpenGL::translateViewpointFinish() {
 	glMatrixMode(GL_MODELVIEW);
 	glPopMatrix();

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -79,6 +79,7 @@ public:
 	void translateViewpointStart() override;
 	void translateViewpoint(const Math::Vector3d &vec) override;
 	void rotateViewpoint(const Math::Angle &angle, const Math::Vector3d &axis) override;
+	void rotateViewpoint(const Math::Matrix4 &rot) override;
 	void translateViewpointFinish() override;
 
 	void drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face) override;

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -765,6 +765,11 @@ void GfxOpenGLS::rotateViewpoint(const Math::Angle &angle, const Math::Vector3d 
 	_matrixStack.top() = temp;
 }
 
+void GfxOpenGLS::rotateViewpoint(const Math::Matrix4 &rot) {
+	Math::Matrix4 temp = rot * _matrixStack.top();
+	_matrixStack.top() = temp;
+}
+
 void GfxOpenGLS::translateViewpointFinish() {
 	_matrixStack.pop();
 }

--- a/engines/grim/gfx_opengl_shaders.h
+++ b/engines/grim/gfx_opengl_shaders.h
@@ -82,6 +82,7 @@ public:
 	virtual void translateViewpointStart() override;
 	virtual void translateViewpoint(const Math::Vector3d &vec) override;
 	virtual void rotateViewpoint(const Math::Angle &angle, const Math::Vector3d &axis) override;
+	virtual void rotateViewpoint(const Math::Matrix4 &rot) override;
 	virtual void translateViewpointFinish() override;
 
 	virtual void drawEMIModelFace(const EMIModel* model, const EMIMeshFace* face) override;

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -974,6 +974,10 @@ void GfxTinyGL::rotateViewpoint(const Math::Angle &angle, const Math::Vector3d &
 	tglRotatef(angle.getDegrees(), axis.x(), axis.y(), axis.z());
 }
 
+void GfxTinyGL::rotateViewpoint(const Math::Matrix4 &rot) {
+	tglMultMatrixf(rot.getData());
+}
+
 void GfxTinyGL::translateViewpointFinish() {
 	tglPopMatrix();
 }

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -76,6 +76,7 @@ public:
 	void translateViewpointStart() override;
 	void translateViewpoint(const Math::Vector3d &vec) override;
 	void rotateViewpoint(const Math::Angle &angle, const Math::Vector3d &axis) override;
+	void rotateViewpoint(const Math::Matrix4 &matrix) override;
 	void translateViewpointFinish() override;
 
 	void drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face) override;

--- a/engines/grim/keyframe.h
+++ b/engines/grim/keyframe.h
@@ -43,7 +43,8 @@ public:
 
 	void loadBinary(Common::SeekableReadStream *data);
 	void loadText(TextSplitter &ts);
-	bool animate(ModelNode *nodes, int num, float time, float fade, bool tagged) const;
+	bool isNodeAnimated(ModelNode *nodes, int num, float time, bool tagged) const;
+	void animate(ModelNode *nodes, int num, float time, float fade, bool tagged) const;
 	int getMarker(float startTime, float stopTime) const;
 
 	float getLength() const { return _numFrames / _fps; }
@@ -83,7 +84,7 @@ private:
 		void loadText(TextSplitter &ts);
 		~KeyframeNode();
 
-		bool animate(ModelNode &node, float frame, float fade, bool useDelta) const;
+		void animate(ModelNode &node, float frame, float fade, bool useDelta) const;
 
 		char _meshName[32];
 		int _numEntries;

--- a/engines/grim/model.h
+++ b/engines/grim/model.h
@@ -25,6 +25,7 @@
 
 #include "engines/grim/object.h"
 #include "math/matrix4.h"
+#include "math/quat.h"
 
 namespace Common {
 class SeekableReadStream;
@@ -190,8 +191,9 @@ public:
 	// Specifies the bind pose YPR values for this node. This data
 	// is read from the model file and never altered (could be const).
 	Math::Angle _pitch, _yaw, _roll;
+	Math::Quaternion _rot;
 	Math::Vector3d _animPos;
-	Math::Angle _animPitch, _animYaw, _animRoll;
+	Math::Quaternion _animRot;
 	bool _meshVisible, _hierVisible;
 	bool _initialized;
 	bool _needsUpdate;


### PR DESCRIPTION
This fixes an issue where rotations were concatenated wrong by summing euler angles. Concatenation of rotations is now handled with quaternions. This potentially fixes animation issues and also significantly simplifies the code.
