### PR TITLE
GRIM: Remove usage of _currentQuat since it's just an identity for GRIM.

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -552,11 +552,7 @@ void GfxOpenGL::startActorDraw(const Actor *actor) {
 		const Math::Quaternion &quat = actor->getRotationQuat();
 		const float &scale = actor->getScale();
 
-		Math::Matrix4 worldRot = _currentQuat.toMatrix();
-		worldRot.inverseRotate(&pos);
 		glTranslatef(pos.x(), pos.y(), pos.z());
-		glMultMatrixf(worldRot.getData());
-
 		glScalef(scale, scale, scale);
 		glMultMatrixf(quat.toMatrix().getData());
 	}

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -660,11 +660,7 @@ void GfxTinyGL::startActorDraw(const Actor *actor) {
 		const Math::Quaternion &quat = actor->getRotationQuat();
 		const float &scale = actor->getScale();
 
-		Math::Matrix4 worldRot = _currentQuat.toMatrix();
-		worldRot.inverseRotate(&pos);
 		tglTranslatef(pos.x(), pos.y(), pos.z());
-		tglMultMatrixf(worldRot.getData());
-
 		tglScalef(scale, scale, scale);
 		tglMultMatrixf(quat.toMatrix().getData());
 	}


### PR DESCRIPTION
_currentQuat isn't updated from the initial identity state when using the GRIM engine, so it makes no sense to do this work.
