### PR TITLE
WIP: GRIM: Use Vertex Buffer Objects for meshes, when supported

### DIFF
--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -65,6 +65,17 @@ public:
 	Texture *_texture;
 };
 
+struct GrimVertex {
+	GrimVertex(const float *verts, const float *texVerts, const float *normals) {
+		memcpy(_position, verts, 3 * sizeof(float));
+		memcpy(_texcoord, texVerts, 2 * sizeof(float));
+		memcpy(_normal, normals, 3 * sizeof(float));
+	}
+	float _position[3];
+	float _texcoord[2];
+	float _normal[3];
+};
+
 /**
  * The Color-formats used for bitmaps in Grim Fandango/Escape From Monkey Island
  */
@@ -264,6 +275,7 @@ public:
 	virtual void createModel(Mesh *mesh) {}
 	virtual void createEMIModel(EMIModel *model) {}
 	virtual void updateEMIModel(const EMIModel *model) {}
+	virtual void destroyMesh(Mesh *mesh) {}
 
 	virtual int genBuffer() { return 0; }
 	virtual void delBuffer(int buffer) {}

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -85,6 +85,7 @@ public:
 	void drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face) override;
 	void drawModelFace(const Mesh *mesh, const MeshFace *face) override;
 	void drawSprite(const Sprite *sprite) override;
+	void drawMesh(const Mesh *mesh) override;
 
 	void enableLights() override;
 	void disableLights() override;
@@ -126,6 +127,9 @@ public:
 
 	void createSpecialtyTextures() override;
 
+	void createModel(Mesh *mesh) override;
+	void destroyMesh(Mesh *mesh) override;
+
 protected:
 	void drawDepthBitmap(int x, int y, int w, int h, char *data);
 	void initExtensions();
@@ -140,6 +144,7 @@ private:
 	GLuint _fragmentProgram;
 	bool _useDimShader;
 	GLuint _dimFragProgram;
+	bool _useVBO;
 	GLint _maxLights;
 	float _alpha;
 	const Actor *_currentActor;

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -99,17 +99,6 @@ static float textured_quad_centered[] = {
 
 static float zero_texVerts[] = { 0.0, 0.0 };
 
-struct GrimVertex {
-	GrimVertex(const float *verts, const float *texVerts, const float *normals) {
-		memcpy(_position, verts, 3 * sizeof(float));
-		memcpy(_texcoord, texVerts, 2 * sizeof(float));
-		memcpy(_normal, normals, 3 * sizeof(float));
-	}
-	float _position[3];
-	float _texcoord[2];
-	float _normal[3];
-};
-
 struct TextUserData {
 	Graphics::Shader * shader;
 	uint32 characters;

--- a/engines/grim/model.cpp
+++ b/engines/grim/model.cpp
@@ -407,6 +407,7 @@ Mesh::Mesh() :
 
 
 Mesh::~Mesh() {
+	g_driver->destroyMesh(this);
 	delete[] _vertices;
 	delete[] _verticesI;
 	delete[] _vertNormals;


### PR DESCRIPTION
This greatly reduces the number of OpenGL calls needed each frame.

I'm not really happy with the state of the creation code right now, and additionally it is very similar to the code from the OpenGL Shaders backend, so it could potentially be merged somehow.

There are also still a few issues, for example on Eva

![screenshot 2014-07-04 18 04 10](https://cloud.githubusercontent.com/assets/240865/3485466/4df5d3ec-03e0-11e4-81e2-e720ac8c146b.png)
