### PR TITLE
RFC: EMI/GRIM: Fix segfault when font isn't specified.

### DIFF
--- a/engines/grim/lua.cpp
+++ b/engines/grim/lua.cpp
@@ -525,6 +525,10 @@ void LuaBase::setTextObjectParams(TextObjectCommon *textObject, lua_Object table
 			textObject->setFont(*Font::getPool().begin());
 		}
 	}
+	if (textObject->getFont() == nullptr) {
+		warning("No font set, using the first one!");
+		textObject->setFont(*Font::getPool().begin());
+	}
 
 	lua_pushobject(tableObj);
 	lua_pushobject(lua_getref(refTextObjectWidth));


### PR DESCRIPTION
I don't think this segfault is reachable from the game scripts, but I noticed it while working on font issues.
