### PR TITLE
EMI: Free materials as soon as they are no longer in use by any costumes

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -125,11 +125,6 @@ Actor::~Actor() {
 	if (_cleanBuffer) {
 		g_driver->delBuffer(_cleanBuffer);
 	}
-
-	Common::List<Material *>::iterator it = _materials.begin();
-	for (; it != _materials.end(); ++it) {
-		delete (*it);
-	}
 }
 
 void Actor::saveState(SaveGame *savedState) const {
@@ -259,9 +254,12 @@ void Actor::saveState(SaveGame *savedState) const {
 
 		_lastWearChore.saveState(savedState);
 
-		Common::List<Material *>::const_iterator it = _materials.begin();
+		Common::List<MaterialPtr>::const_iterator it = _materials.begin();
 		for (; it != _materials.end(); ++it) {
-			savedState->writeLESint32((*it)->getActiveTexture());
+			if (*it) {
+				warning((*it)->getFilename().c_str());
+				savedState->writeLESint32((*it)->getActiveTexture());
+			}
 		}
 
 		savedState->writeLESint32(_lookAtActor);
@@ -275,9 +273,6 @@ bool Actor::restoreState(SaveGame *savedState) {
 		delete *i;
 	}
 	_costumeStack.clear();
-	for (Common::List<Material *>::const_iterator i = _materials.begin(); i != _materials.end(); ++i) {
-		delete *i;
-	}
 	_materials.clear();
 
 	// load actor name
@@ -440,9 +435,11 @@ bool Actor::restoreState(SaveGame *savedState) {
 		_lastWearChore.restoreState(savedState, this);
 
 		if (savedState->saveMinorVersion() >= 13) {
-			Common::List<Material *>::const_iterator it = _materials.begin();
+			Common::List<MaterialPtr>::const_iterator it = _materials.begin();
 			for (; it != _materials.end(); ++it) {
-				(*it)->setActiveTexture(savedState->readLESint32());
+				if (*it) {
+					(*it)->setActiveTexture(savedState->readLESint32());
+				}
 			}
 		}
 
@@ -2343,22 +2340,28 @@ void Actor::restoreCleanBuffer() {
 	}
 }
 
-Material *Actor::findMaterial(const Common::String &name) {
+MaterialPtr Actor::findMaterial(const Common::String &name) {
 	Common::String fixedName = g_resourceloader->fixFilename(name, false);
-	Common::List<Material *>::iterator it = _materials.begin();
+	Common::List<MaterialPtr>::iterator it = _materials.begin();
 	for (; it != _materials.end(); ++it) {
-		if ((*it)->getFilename() == fixedName) {
-			return *it;
+		if (*it) {
+			if ((*it)->getFilename() == fixedName) {
+				return *it;
+			}
+		} else {
+			it = _materials.erase(it);
 		}
 	}
 	return nullptr;
 }
 
-Material *Actor::loadMaterial(const Common::String &name, bool clamp) {
-	Material *mat = findMaterial(name);
+MaterialPtr Actor::loadMaterial(const Common::String &name, bool clamp) {
+	MaterialPtr mat = findMaterial(name);
 	if (!mat) {
 		mat = g_resourceloader->loadMaterial(name.c_str(), nullptr, clamp);
+		// Note: We store a weak reference.
 		_materials.push_back(mat);
+		mat->dereference();
 	}
 	return mat;
 }

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -550,8 +550,8 @@ public:
 	LightMode getLightMode() const { return _lightMode; }
 	void setLightMode(LightMode lightMode) { _lightMode = lightMode; }
 
-	Material *loadMaterial(const Common::String &name, bool clamp);
-	Material *findMaterial(const Common::String &name);
+	ObjectPtr<Material> loadMaterial(const Common::String &name, bool clamp);
+	ObjectPtr<Material> findMaterial(const Common::String &name);
 
 private:
 	void costumeMarkerCallback(int marker);
@@ -709,7 +709,7 @@ private:
 
 	LightMode _lightMode;
 
-	Common::List<Material *> _materials;
+	Common::List<ObjectPtr<Material> > _materials;
 };
 
 } // end of namespace Grim

--- a/engines/grim/emi/costumeemi.cpp
+++ b/engines/grim/emi/costumeemi.cpp
@@ -283,12 +283,10 @@ Material *EMICostume::findMaterial(const Common::String &name) {
 }
 
 Material *EMICostume::loadMaterial(const Common::String &name, bool clamp) {
-	Material *mat = _owner->loadMaterial(name, clamp);
+	MaterialPtr mat = _owner->loadMaterial(name, clamp);
 	if (mat) {
-		// We keep track of the list of materials per costume, so we
-		// can load older savegames from a time when materials were managed
-		// by EMICostume instead of Actor. Once support for older saves is
-		// dropped, this list can be removed.
+		// Save a reference to the material, so it will not be freed during the
+		// lifetime of this costume.
 		if (Common::find(_materials.begin(), _materials.end(), mat) == _materials.end())
 			_materials.push_back(mat);
 	}

--- a/engines/grim/emi/costumeemi.h
+++ b/engines/grim/emi/costumeemi.h
@@ -63,7 +63,7 @@ public:
 	EMISkelComponent *_emiSkel;
 private:
 	bool _isWearChoreActive;
-	Common::List<Material *> _materials;
+	Common::List<ObjectPtr<Material> > _materials;
 	static bool compareChores(const Chore *c1, const Chore *c2);
 	Component *loadEMIComponent(Component *parent, int parentID, const char *name, Component *prevComponent);
 	void setWearChore(EMIChore *chore);


### PR DESCRIPTION
This fixes a crash on save restore introduced by 5c20f0f4a. The crash can be reproduced with the following savegame: https://cloud.githubusercontent.com/assets/757718/3635539/4d9722ec-0f7b-11e4-85aa-c2bd98ee64c9.png (change the suffix to .gsv)

With 5c20f0f4a, the loaded materials were not freed until the actor object was destructed. For example, if materials were loaded by a costume and the actor then switched to another costume, the materials loaded by the former costume were kept around although they were no longer in use.

In Actor save/restore, the list of loaded materials at the time of restoring is expected to match the list of materials at the time of saving. This was not the case if at the time of saving the list contained materials that were loaded by costumes that were no longer active. When restoring, the list will only contain the materials that are loaded by the active costumes. This caused the save restore to go out of sync.

This fix adds reference counting to the materials, so they will be freed as soon as they are no longer referenced by any costumes.
