### PR TITLE
EMI: Skip setting up the text when it will be repositioned later.

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1222,7 +1222,7 @@ void Actor::sayLine(const char *msgId, bool background) {
 				textObject->setY(463);
 			}
 		}
-		textObject->setText(msgId);
+		textObject->setText(msgId, _mustPlaceText);
 		if (g_grim->getMode() != GrimEngine::SmushMode)
 			_sayLineText = textObject->getId();
 	}
@@ -1683,6 +1683,7 @@ void Actor::draw() {
 				textObject->setX((x1 + x2) / 2);
 				textObject->setY(y1);
 			}
+			// Deletes the original text and rebuilds it with the newly placed text
 			textObject->reset();
 		}
 		_mustPlaceText = false;

--- a/engines/grim/lua_v1_text.cpp
+++ b/engines/grim/lua_v1_text.cpp
@@ -69,7 +69,7 @@ void Lua_V1::ChangeTextObject() {
 				textObject->destroy();
 			} else {
 				const char *line = lua_getstring(paramObj);
-				textObject->setText(line);
+				textObject->setText(line, false);
 				lua_getstring(paramObj);
 
 			}
@@ -111,7 +111,7 @@ void Lua_V1::MakeTextObject() {
 	if (lua_istable(tableObj))
 		setTextObjectParams(textObject, tableObj);
 
-	textObject->setText(line);
+	textObject->setText(line, false);
 
 	lua_pushusertag(textObject->getId(), MKTAG('T', 'E', 'X', 'T'));
 	if (!(g_grim->getGameFlags() & ADGF_DEMO)) {
@@ -163,7 +163,7 @@ void Lua_V1::BlastText() {
 	if (lua_istable(tableObj))
 		setTextObjectParams(textObject, tableObj);
 
-	textObject->setText(line);
+	textObject->setText(line, false);
 	textObject->draw();
 	delete textObject;
 }

--- a/engines/grim/movie/bink.cpp
+++ b/engines/grim/movie/bink.cpp
@@ -80,7 +80,7 @@ void BinkPlayer::handleFrame() {
 				textObject->setX(640 / 2);
 				textObject->setY(40);
 			}
-			textObject->setText(g_localizer->localize(_subtitleIndex->_textId.c_str()));
+			textObject->setText(g_localizer->localize(_subtitleIndex->_textId.c_str()), false);
 			g_grim->setMovieSubtitle(textObject);
 			_subtitleIndex->active = true;
 		}

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -60,10 +60,11 @@ TextObject::~TextObject() {
 		g_grim->invalidateTextObjectsSortOrder();
 }
 
-void TextObject::setText(const Common::String &text) {
+void TextObject::setText(const Common::String &text, bool delaySetup) {
 	destroy();
 	_textID = text;
-	setupText();
+	if (!delaySetup)
+		setupText();
 }
 
 void TextObject::reset() {

--- a/engines/grim/textobject.h
+++ b/engines/grim/textobject.h
@@ -89,7 +89,7 @@ public:
 	static int32 getStaticTag() { return MKTAG('T', 'E', 'X', 'T'); }
 
 	void setDefaults(const TextObjectDefaults *defaults);
-	void setText(const Common::String &text);
+	void setText(const Common::String &text, bool delaySetup);
 	void reset();
 
 	int getBitmapWidth() const;


### PR DESCRIPTION
This is an optimization so that the text is only setup once, rather than twice when an actor speaks.
