### PR TITLE
EMI: Fix compiler warnings for specialty texture ID.

### DIFF
--- a/engines/grim/gfx_base.cpp
+++ b/engines/grim/gfx_base.cpp
@@ -51,7 +51,7 @@ GfxBase::GfxBase() :
 		_screenWidth(0), _screenHeight(0), _isFullscreen(false),
 		_scaleW(1.0f), _scaleH(1.0f), _currentShadowArray(nullptr),
 		_shadowColorR(255), _shadowColorG(255), _shadowColorB(255) {
-			for (int i = 0; i < _numSpecialtyTextures; i++) {
+			for (unsigned int i = 0; i < _numSpecialtyTextures; i++) {
 				_specialtyTextures[i]._isShared = true;
 			}
 }

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -279,7 +279,7 @@ public:
 	Texture *getSpecialtyTexturePtr(Common::String name);
 protected:
 	Bitmap *createScreenshotBitmap(const Graphics::PixelBuffer src, int w, int h, bool flipOrientation);
-	static const int _numSpecialtyTextures = 22;
+	static const unsigned int _numSpecialtyTextures = 22;
 	Texture _specialtyTextures[_numSpecialtyTextures];
 	static const int _gameHeight = 480;
 	static const int _gameWidth = 640;


### PR DESCRIPTION
This quiets the compiler warnings after the merge of https://github.com/residualvm/residualvm/commit/1e821365
