### PR TITLE
EMI/GRIM: Make the setupCamera function more clear

### DIFF
--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -102,7 +102,7 @@ public:
 	virtual uint getScreenWidth() { return _screenWidth; }
 	virtual uint getScreenHeight() { return _screenHeight; }
 
-	virtual void setupCamera(float fov, float nclip, float fclip) = 0;
+	virtual void setupCameraFrustum(float fov, float nclip, float fclip) = 0;
 	virtual void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest, float roll) = 0;
 
 	virtual Math::Matrix4 getModelView() = 0;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -228,7 +228,7 @@ const char *GfxOpenGL::getVideoDeviceName() {
 	return "OpenGL Renderer";
 }
 
-void GfxOpenGL::setupCamera(float fov, float nclip, float fclip) {
+void GfxOpenGL::setupCameraFrustum(float fov, float nclip, float fclip) {
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -49,7 +49,7 @@ public:
 
 	const char *getVideoDeviceName() override;
 
-	void setupCamera(float fov, float nclip, float fclip) override;
+	void setupCameraFrustum(float fov, float nclip, float fclip) override;
 	void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest, float roll) override;
 
 	Math::Matrix4 getModelView() override;

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -412,7 +412,7 @@ byte *GfxOpenGLS::setupScreen(int screenW, int screenH, bool fullscreen) {
 	return NULL;
 }
 
-void GfxOpenGLS::setupCamera(float fov, float nclip, float fclip) {
+void GfxOpenGLS::setupCameraFrustum(float fov, float nclip, float fclip) {
 	if (_fov == fov && _nclip == nclip && _fclip == fclip)
 		return;
 

--- a/engines/grim/gfx_opengl_shaders.h
+++ b/engines/grim/gfx_opengl_shaders.h
@@ -51,7 +51,7 @@ public:
 	 */
 	virtual bool isHardwareAccelerated() override { return true; };
 	virtual bool supportsShaders() override { return true; }
-	virtual void setupCamera(float fov, float nclip, float fclip) override;
+	virtual void setupCameraFrustum(float fov, float nclip, float fclip) override;
 	virtual void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest, float roll) override;
 
 	virtual Math::Matrix4 getModelView() override;

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -193,7 +193,7 @@ const char *GfxTinyGL::getVideoDeviceName() {
 	return "TinyGL Software Renderer";
 }
 
-void GfxTinyGL::setupCamera(float fov, float nclip, float fclip) {
+void GfxTinyGL::setupCameraFrustum(float fov, float nclip, float fclip) {
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
 

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -47,7 +47,7 @@ public:
 
 	const char *getVideoDeviceName() override;
 
-	void setupCamera(float fov, float nclip, float fclip) override;
+	void setupCameraFrustum(float fov, float nclip, float fclip) override;
 	void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest, float roll) override;
 
 	Math::Matrix4 getModelView() override;

--- a/engines/grim/set.cpp
+++ b/engines/grim/set.cpp
@@ -607,7 +607,7 @@ void Set::Setup::setupCamera() const {
 		fclip = 3276.8f;
 	}
 
-	g_driver->setupCamera(_fov, nclip, fclip);
+	g_driver->setupCameraFrustum(_fov, nclip, fclip);
 	g_driver->positionCamera(_pos, _interest, _roll);
 }
 


### PR DESCRIPTION
1. The roll parameter isn't used in the function setupCamera, so remove it.
2. Rename setupCamera to setupCameraFrustum to better describe what the function is doing.
