### PR TITLE
GRIM: Add a few useful debugger commands.

### DIFF
--- a/engines/grim/debugger.cpp
+++ b/engines/grim/debugger.cpp
@@ -35,6 +35,8 @@ Debugger::Debugger() :
 	registerCmd("lua_do", WRAP_METHOD(Debugger, cmd_lua_do));
 	registerCmd("emi_jump", WRAP_METHOD(Debugger, cmd_emi_jump));
 	registerCmd("swap_renderer", WRAP_METHOD(Debugger, cmd_swap_renderer));
+	registerCmd("save", WRAP_METHOD(Debugger, cmd_save));
+	registerCmd("load", WRAP_METHOD(Debugger, cmd_load));
 }
 
 Debugger::~Debugger() {
@@ -83,6 +85,26 @@ bool Debugger::cmd_swap_renderer(int argc, const char **argv) {
 	bool accel = ConfMan.getBool("soft_renderer");
 	ConfMan.setBool("soft_renderer", !accel);
 	g_grim->changeHardwareState();
+	return true;
+}
+
+bool Debugger::cmd_save(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: save <save name>\n");
+		return true;
+	}
+	Common::String file = Common::String::format("%s.gsv", argv[1]);
+	g_grim->saveGame(file);
+	return true;
+}
+
+bool Debugger::cmd_load(int argc, const char **argv) {
+	if (argc < 2) {
+		debugPrintf("Usage: load <save name>\n");
+		return true;
+	}
+	Common::String file = Common::String::format("%s.gsv", argv[1]);
+	g_grim->loadGame(file);
 	return true;
 }
 

--- a/engines/grim/debugger.h
+++ b/engines/grim/debugger.h
@@ -38,6 +38,8 @@ public:
 	bool cmd_lua_do(int argc, const char **argv);
 	bool cmd_emi_jump(int argc, const char **argv);
 	bool cmd_swap_renderer(int argc, const char **argv);
+	bool cmd_save(int argc, const char **argv);
+	bool cmd_load(int argc, const char **argv);
 };
 
 }


### PR DESCRIPTION
EMI, and the demos, does not have a way to change renders, so add a command to do it.

The demos do not have a way to save the game, so having a command would help. Right now it just uses whatever name you give it. Should it add .gsv?
