### PR TITLE
EMI: Save and restore SetShadow data.

### DIFF
--- a/engines/grim/savegame.cpp
+++ b/engines/grim/savegame.cpp
@@ -35,7 +35,7 @@ namespace Grim {
 #define SAVEGAME_FOOTERTAG  'ESAV'
 
 uint SaveGame::SAVEGAME_MAJOR_VERSION = 22;
-uint SaveGame::SAVEGAME_MINOR_VERSION = 18;
+uint SaveGame::SAVEGAME_MINOR_VERSION = 19;
 
 SaveGame *SaveGame::openForLoading(const Common::String &filename) {
 	Common::InSaveFile *inSaveFile = g_system->getSavefileManager()->openForLoading(filename);

--- a/engines/grim/set.h
+++ b/engines/grim/set.h
@@ -194,6 +194,8 @@ struct Light {
 */
 struct SetShadow {
 	void loadBinary(Common::SeekableReadStream *data);
+	void saveState(SaveGame *savedState) const;
+	void restoreState(SaveGame *savedState);
 
 	Common::String _name;
 	Math::Vector3d _shadowPoint;


### PR DESCRIPTION
The set shadow data was previously not saved and restored. I assumed before that Set::loadBinary would be called also when restoring a game, but this is not the case.

Not saving and restoring the shadow data had the side effect that if the game was saved in a set that has shadows enabled, the shadows would not be correctly deactivated when leaving the set after restoring the save. This caused rendering issues and crashes.
