### PR TITLE
GRIM: Stop a segfault when saving.

### DIFF
--- a/engines/grim/set.cpp
+++ b/engines/grim/set.cpp
@@ -113,6 +113,7 @@ void Set::loadText(TextSplitter &ts) {
 		_setups[i].load(this, i, ts);
 	_currSetup = _setups;
 
+	_numShadows = 0;
 	_numSectors = -1;
 	_numLights = -1;
 	_lights = nullptr;


### PR DESCRIPTION
GRIM was segfaulting when I tried to save. This fixes it by initializing the _numShadows value.
