### PR TITLE
EMI: Remove MusicEntry constructors to fix C++98 compile error.

### DIFF
--- a/engines/grim/emi/sound/emisound.cpp
+++ b/engines/grim/emi/sound/emisound.cpp
@@ -177,13 +177,6 @@ MusicEntry emiPS2MusicTable[] = {
 	{ 0, 0, 0, 127, 125, "episode", "", "1215.scx" }
 };
 
-MusicEntry::MusicEntry() : _x(0), _y(0), _sync(0), _trim(0), _id(-1) {
-}
-
-MusicEntry::MusicEntry(int x, int y, int sync, int trim, int id, Common::String type, Common::String name, Common::String filename) :
-		_x(x), _y(y), _sync(sync), _trim(trim), _id(id), _type(type), _name(name), _filename(filename) {
-}
-
 void EMISound::timerHandler(void *refCon) {
 	EMISound *emiSound = (EMISound *)refCon;
 	emiSound->callback();
@@ -533,6 +526,13 @@ MusicEntry *initMusicTableDemo(const Common::String &filename) {
 		error("Couldn't open %s", filename.c_str());
 	// FIXME, for now we use a fixed-size table, as I haven't looked at the retail-data yet.
 	MusicEntry *musicTable = new MusicEntry[15];
+	for (int i = 0; i < 15; ++i) {
+		musicTable->_x = 0;
+		musicTable->_y = 0;
+		musicTable->_sync = 0;
+		musicTable->_trim = 0;
+		musicTable->_id = i;
+	}
 
 	TextSplitter *ts = new TextSplitter(filename, data);
 	int id, x, y, sync;
@@ -572,6 +572,13 @@ MusicEntry *initMusicTableRetail(MusicEntry *table, const Common::String &filena
 	MusicEntry *musicTable = table;
 	if (!table) {
 		musicTable = new MusicEntry[126];
+	}
+	for (int i = 0; i < 126; ++i) {
+		musicTable->_x = 0;
+		musicTable->_y = 0;
+		musicTable->_sync = 0;
+		musicTable->_trim = 0;
+		musicTable->_id = i;
 	}
 
 	TextSplitter *ts = new TextSplitter(filename, data);

--- a/engines/grim/emi/sound/emisound.h
+++ b/engines/grim/emi/sound/emisound.h
@@ -35,8 +35,6 @@ class SoundTrack;
 class SaveGame;
 
 struct MusicEntry {
-	MusicEntry();
-	MusicEntry(int x, int y, int sync, int trim, int id, Common::String type, Common::String name, Common::String filename);
 	int _x;
 	int _y;
 	int _sync;


### PR DESCRIPTION
Fixes a compile error reported by Raziel.
