### PR TITLE
EMI: Fix font rendering with TinyGL.

### DIFF
--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -115,7 +115,18 @@ uint16 Font::getCharIndex(unsigned char c) const {
 int Font::getStringLength(const Common::String &text) const {
 	int result = 0;
 	for (uint32 i = 0; i < text.size(); ++i) {
-		result += getCharKernedWidth(text[i]);
+		result += getCharKernedWidth(text[i]) + getCharStartingCol(text[i]);
+	}
+	return result;
+}
+
+int Font::getStringHeight(const Common::String &text) const {
+	int result = 0;
+	for (uint32 i = 0; i < text.size(); ++i) {
+		int verticalOffset = getCharStartingLine(text[i]) + getBaseOffsetY();
+		int charHeight = verticalOffset + getCharBitmapHeight(text[i]);
+		if (charHeight > result)
+			result = charHeight;
 	}
 	return result;
 }

--- a/engines/grim/font.h
+++ b/engines/grim/font.h
@@ -57,6 +57,7 @@ public:
 	uint32 getDataSize() const { return _dataSize; }
 
 	int getStringLength(const Common::String &text) const;
+	int getStringHeight(const Common::String &text) const;
 
 	const void *getUserData() const { return _userData; }
 	void setUserData(void *data) { _userData = data; }

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -1312,31 +1312,30 @@ void GfxTinyGL::createTextObject(TextObject *text) {
 		const Common::String &currentLine = lines[j];
 
 		int width = font->getStringLength(currentLine) + 1;
-		int height = font->getKernedHeight();
+		int height = font->getStringHeight(currentLine) + 1;
 
 		uint8 *_textBitmap = new uint8[height * width];
 		memset(_textBitmap, 0, height * width);
 
-		// Fill bitmap
-		int startOffset = 0;
+		int startColumn = 0;
 		for (unsigned int d = 0; d < currentLine.size(); d++) {
 			int ch = currentLine[d];
-			int8 startingLine = font->getCharStartingLine(ch) + font->getBaseOffsetY();
 			int32 charBitmapWidth = font->getCharBitmapWidth(ch);
-			int32 charKernedWidth = font->getCharKernedWidth(ch);
-			int8 startingCol = font->getCharStartingCol(ch);
+			int8 fontRow = font->getCharStartingLine(ch) + font->getBaseOffsetY();
+			int8 fontCol = font->getCharStartingCol(ch);
+
 			for (int line = 0; line < font->getCharBitmapHeight(ch); line++) {
-				int offset = startOffset + (width * (line + startingLine));
-				for (int r = 0; r < charBitmapWidth; r++) {
-					const byte pixel = *(font->getCharData(ch) + r + (charBitmapWidth * line));
-					byte *dst = _textBitmap + offset + startingCol + r;
-					if (*dst == 0 && pixel != 0)
-						_textBitmap[offset + startingCol + r] = pixel;
+				int lineOffset = ((fontRow + line) * width);
+				for (int bitmapCol = 0; bitmapCol < charBitmapWidth; bitmapCol++) {
+					int columnOffset = startColumn + fontCol + bitmapCol;
+					int fontOffset = (charBitmapWidth * line) + bitmapCol;
+					int8 pixel = font->getCharData(ch)[fontOffset];
+					assert(lineOffset + columnOffset < width*height);
+					if (pixel != 0)
+						_textBitmap[lineOffset + columnOffset] = pixel;
 				}
-				if (line + startingLine >= font->getKernedHeight())
-					break;
 			}
-			startOffset += charKernedWidth;
+			startColumn += font->getCharKernedWidth(ch);
 		}
 
 		Graphics::PixelBuffer buf(_pixelFormat, width * height, DisposeAfterUse::NO);


### PR DESCRIPTION
This PR fixes the text drawing segfaults when using TinyGL. The issue was that the size of the bitmap was being calculated incorrectly, causing a buffer overrun. This adds a function to the Font class that finds the height of the bitmap version of the string. I also add the remainder of the difference between the kerned width and the bitmap font character for the last character to the string width. Finally, I added an assert to make sure that this fix is correct which could be removed if it's not needed in the main branch.
