### PR TITLE
EMI: Fix segfault when cancelling a save.

### DIFF
--- a/engines/grim/lua_v1_text.cpp
+++ b/engines/grim/lua_v1_text.cpp
@@ -61,6 +61,12 @@ void Lua_V1::ChangeTextObject() {
 			lua_Object paramObj = lua_getparam(paramId++);
 			if (!paramObj)
 				break;
+
+			// If the text object is invalid (deleted) ignore the request
+			// We do the check here so that all of the params are used
+			if (!textObject)
+				continue;
+
 			if (!lua_isstring(paramObj)) {
 				if (!lua_istable(paramObj))
 					break;


### PR DESCRIPTION
It looks like the textObject is deleted as the save text is being updated, so the object is null. This just ignores the text settings if the textObject is null. Note that we also had to pull the Lua parameters off the stack, which is why this is written this way.

Fixes issue #1009 .
