### PR TITLE
TINYGL: Do not write to the depth buffer if depth test is disabled.

### DIFF
--- a/graphics/tinygl/zline.cpp
+++ b/graphics/tinygl/zline.cpp
@@ -153,14 +153,14 @@ void FrameBuffer::plot(ZBufferPoint *p) {
 	pz = zbuf + (p->y * xsize + p->x);
 	int col = RGB_TO_PIXEL(p->r, p->g, p->b);
 	unsigned int z = p->z;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		putPixel<false, true, true>(this, linesize * p->y + p->x * PSZB, cmode, pz, z, col, r, g, b);
 	else 
 		putPixel<false, true, false>(this, linesize * p->y + p->x * PSZB, cmode, pz, z, col, r, g, b);
 }
 
 void FrameBuffer::fillLineFlatZ(ZBufferPoint *p1, ZBufferPoint *p2, int color) {
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillLineGeneric<false, true, true>(p1, p2, color);
 	else
 		fillLineGeneric<false, true, false>(p1, p2, color);
@@ -168,7 +168,7 @@ void FrameBuffer::fillLineFlatZ(ZBufferPoint *p1, ZBufferPoint *p2, int color) {
 
 // line with color interpolation
 void FrameBuffer::fillLineInterpZ(ZBufferPoint *p1, ZBufferPoint *p2) {
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillLineGeneric<true, true, true>(p1, p2, 0);
 	else
 		fillLineGeneric<true, true, false>(p1, p2, 0);
@@ -176,14 +176,14 @@ void FrameBuffer::fillLineInterpZ(ZBufferPoint *p1, ZBufferPoint *p2) {
 
 // no Z interpolation
 void FrameBuffer::fillLineFlat(ZBufferPoint *p1, ZBufferPoint *p2, int color) {
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillLineGeneric<false, false, true>(p1, p2, color);
 	else
 		fillLineGeneric<false, false, false>(p1, p2, color);
 }
 
 void FrameBuffer::fillLineInterp(ZBufferPoint *p1, ZBufferPoint *p2) {
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillLineGeneric<false, true, true>(p1, p2, 0);
 	else
 		fillLineGeneric<false, true, false>(p1, p2, 0);

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -653,7 +653,7 @@ void FrameBuffer::fillTriangleDepthOnly(ZBufferPoint *p0, ZBufferPoint *p1, ZBuf
 	const bool interpRGB = false;
 	const bool interpST = false;
 	const bool interpSTZ = false;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_DEPTH_ONLY, true>(p0, p1, p2);
 	else 
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_DEPTH_ONLY, false>(p0, p1, p2);
@@ -664,7 +664,7 @@ void FrameBuffer::fillTriangleFlat(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPo
 	const bool interpRGB = false;
 	const bool interpST = false;
 	const bool interpSTZ = false;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_FLAT, true>(p0, p1, p2);
 	else
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_FLAT, false>(p0, p1, p2);
@@ -676,7 +676,7 @@ void FrameBuffer::fillTriangleSmooth(ZBufferPoint *p0, ZBufferPoint *p1, ZBuffer
 	const bool interpRGB = true;
 	const bool interpST = false;
 	const bool interpSTZ = false;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SMOOTH, true>(p0, p1, p2);
 	else
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SMOOTH, false>(p0, p1, p2);
@@ -687,7 +687,7 @@ void FrameBuffer::fillTriangleTextureMappingPerspectiveSmooth(ZBufferPoint *p0, 
 	const bool interpRGB = true;
 	const bool interpST = false;
 	const bool interpSTZ = true;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SMOOTH, true>(p0, p1, p2);
 	else
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SMOOTH, false>(p0, p1, p2);
@@ -698,7 +698,7 @@ void FrameBuffer::fillTriangleTextureMappingPerspectiveFlat(ZBufferPoint *p0, ZB
 	const bool interpRGB = true;
 	const bool interpST = false;
 	const bool interpSTZ = true;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_FLAT, true>(p0, p1, p2);
 	else
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_FLAT, false>(p0, p1, p2);
@@ -709,7 +709,7 @@ void FrameBuffer::fillTriangleFlatShadowMask(ZBufferPoint *p0, ZBufferPoint *p1,
 	const bool interpRGB = false;
 	const bool interpST = false;
 	const bool interpSTZ = false;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SHADOW_MASK, true>(p0, p1, p2);
 	else
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SHADOW_MASK, false>(p0, p1, p2);
@@ -720,7 +720,7 @@ void FrameBuffer::fillTriangleFlatShadow(ZBufferPoint *p0, ZBufferPoint *p1, ZBu
 	const bool interpRGB = false;
 	const bool interpST = false;
 	const bool interpSTZ = false;
-	if (_depthWrite)
+	if (_depthWrite && _depthTestEnabled)
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SHADOW, true>(p0, p1, p2);
 	else
 		fillTriangle<interpRGB, interpZ, interpST, interpSTZ, DRAW_SHADOW, false>(p0, p1, p2);


### PR DESCRIPTION
According to the OpenGL spec the depth buffer should not be updated if the depth test is disabled, even if the depth mask is non-zero (see the notes in https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthFunc.xml).
