### PR TITLE
EMI: Remove clamping from prepareTextures.

### DIFF
--- a/engines/grim/emi/modelemi.cpp
+++ b/engines/grim/emi/modelemi.cpp
@@ -267,7 +267,7 @@ void EMIModel::prepareForRender() {
 void EMIModel::prepareTextures() {
 	_mats = new Material*[_numTextures];
 	for (uint32 i = 0; i < _numTextures; i++) {
-		_mats[i] = _costume->loadMaterial(_texNames[i], true);
+		_mats[i] = _costume->loadMaterial(_texNames[i], false);
 	}
 }
 


### PR DESCRIPTION
The intro looks fine to me with this set to false (it was changed in https://github.com/residualvm/residualvm/commit/4204b2649cb7e4572e168a993a619df4c3a0d2b0), but when it's set to true, it breaks things like the lava texture in the lava puzzle. This reverts the change and restores the lava texture.
