### PR TITLE
EMI: Decrease the iterator position when a material is erased from the material list.

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -2453,6 +2453,7 @@ MaterialPtr Actor::findMaterial(const Common::String &name) {
 			}
 		} else {
 			it = _materials.erase(it);
+			--it;
 		}
 	}
 	return (MaterialPtr)nullptr;


### PR DESCRIPTION
This fixes a crash when restoring a save in the set lav.
