### PR TITLE
GRIM: Enable alpha test when drawing sprites.

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -860,9 +860,12 @@ void GfxOpenGL::drawSprite(const Sprite *sprite) {
 
 	glDisable(GL_LIGHTING);
 
-	if (sprite->_flags2 & Sprite::AlphaTest) {
+	if (g_grim->getGameType() == GType_GRIM) {
 		glEnable(GL_ALPHA_TEST);
-		glAlphaFunc(GL_GEQUAL, g_grim->getGameType() == GType_MONKEY4 ? 0.1f : 0.5f);
+		glAlphaFunc(GL_GEQUAL, 0.5f);
+	}  else if (sprite->_flags2 & Sprite::AlphaTest) {
+		glEnable(GL_ALPHA_TEST);
+		glAlphaFunc(GL_GEQUAL, 0.1f);
 	} else {
 		glDisable(GL_ALPHA_TEST);
 	}

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1001,8 +1001,10 @@ void GfxOpenGLS::drawSprite(const Sprite *sprite) {
 	_spriteProgram->setUniform("textured", GL_TRUE);
 	_spriteProgram->setUniform("isBillboard", GL_TRUE);
 	_spriteProgram->setUniform("lightsEnabled", false);
-	if (sprite->_flags2 & Sprite::AlphaTest) {
-		_spriteProgram->setUniform1f("alphaRef", g_grim->getGameType() == GType_MONKEY4 ? 0.1f : 0.5f);
+	if (g_grim->getGameType() == GType_GRIM) {
+		_spriteProgram->setUniform1f("alphaRef", 0.5f);
+	} else if (sprite->_flags2 & Sprite::AlphaTest) {
+		_spriteProgram->setUniform1f("alphaRef", 0.1f);
 	} else {
 		_spriteProgram->setUniform1f("alphaRef", 0.0f);
 	}

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -782,9 +782,12 @@ void GfxTinyGL::drawSprite(const Sprite *sprite) {
 
 	tglDisable(TGL_LIGHTING);
 
-	if (sprite->_flags2 & Sprite::AlphaTest) {
+	if (g_grim->getGameType() == GType_GRIM) {
 		tglEnable(TGL_ALPHA_TEST);
-		tglAlphaFunc(TGL_GEQUAL, g_grim->getGameType() == GType_MONKEY4 ? 0.1f : 0.5f);
+		tglAlphaFunc(TGL_GEQUAL, 0.5f);
+	} else if (sprite->_flags2 & Sprite::AlphaTest) {
+		tglEnable(TGL_ALPHA_TEST);
+		tglAlphaFunc(TGL_GEQUAL, 0.1f);
 	} else {
 		tglDisable(TGL_ALPHA_TEST);
 	}


### PR DESCRIPTION
The alpha test was accidentally disabled by changes that were intended to be EMI-specific.
