### PR TITLE
MYST3: Fix for issue #1040, "MYST3: Subtitles show box at end of every line".

### DIFF
--- a/engines/myst3/subtitles.cpp
+++ b/engines/myst3/subtitles.cpp
@@ -145,15 +145,17 @@ bool Subtitles::loadSubtitles(int32 id) {
 		crypted->seek(_phrases[i].offset);
 
 		uint8 key = 35;
-		uint8 c = 0;
-		do {
-			c = crypted->readByte() ^ key++;
+		while (true) {
+			uint8 c = crypted->readByte() ^ key++;
 
 			if (c >= 32)
 				c = _charset[c - 32];
 
+			if (!c)
+				break;
+
 			_phrases[i].string += c;
-		} while (c);
+		}
 	}
 
 	delete crypted;


### PR DESCRIPTION
This issue, which I could only reproduce by compiling ResidualVM without TTF support, seems to be caused by the subtitle string ending with a '\0' character. This would be correct if it was a C string, but not when it's a Common::String(). This fix simply terminates the loop that reads the subtitle string before it can add the '\0' character.
