### PR TITLE
RFC: EMI: Check for collisions when using updateWalk().

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1426,6 +1426,21 @@ void Actor::updateWalk() {
 
 	dir = destPos - _pos;
 	dir.normalize();
+
+	// If we're not in a collision mode an walking, turn it on...
+	CollisionMode mode = _collisionMode;
+	if (_collisionMode == CollisionOff) {
+		mode = CollisionSphere;
+	}
+
+	// Find the amount we're walking
+	Math::Vector3d newWalkAmt = dir * walkAmt;
+	foreach (Actor *a, g_grim->getActiveActors()) {
+		// Don't move if we've collided
+		if(handleCollisionWith(a, mode, &newWalkAmt)) {
+			return;
+		}
+	}
 	_pos += dir * walkAmt;
 }
 


### PR DESCRIPTION
This forces a check for collisions when updateWalk is called. This fixes Timmy running through the legs of Guybrush on the beach in the set mib. I think it fixes the logs in the flume puzzle as well, but I need to finish with that PR first to be sure since they're not visible right now.
