### PR TITLE
EMI: Fix font text centering by using just the kerned width.

### DIFF
--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -112,7 +112,15 @@ uint16 Font::getCharIndex(unsigned char c) const {
 	return 0;
 }
 
-int Font::getStringLength(const Common::String &text) const {
+int Font::getKernedStringLength(const Common::String &text) const {
+	int result = 0;
+	for (uint32 i = 0; i < text.size(); ++i) {
+		result += getCharKernedWidth(text[i]);
+	}
+	return result;
+}
+
+int Font::getBitmapStringLength(const Common::String &text) const {
 	int result = 0;
 	for (uint32 i = 0; i < text.size(); ++i) {
 		result += getCharKernedWidth(text[i]) + getCharStartingCol(text[i]);

--- a/engines/grim/font.h
+++ b/engines/grim/font.h
@@ -56,7 +56,8 @@ public:
 	const byte *getFontData() const { return _fontData; }
 	uint32 getDataSize() const { return _dataSize; }
 
-	int getStringLength(const Common::String &text) const;
+	int getKernedStringLength(const Common::String &text) const;
+	int getBitmapStringLength(const Common::String &text) const;
 	int getStringHeight(const Common::String &text) const;
 
 	const void *getUserData() const { return _userData; }

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -1061,7 +1061,7 @@ void GfxTinyGL::createTextObject(TextObject *text) {
 	for (int j = 0; j < numLines; j++) {
 		const Common::String &currentLine = lines[j];
 
-		int width = font->getStringLength(currentLine) + 1;
+		int width = font->getBitmapStringLength(currentLine) + 1;
 		int height = font->getStringHeight(currentLine) + 1;
 
 		uint8 *_textBitmap = new uint8[height * width];

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -276,7 +276,7 @@ void TextObject::setupText() {
 		}
 		Common::String currentLine(message.c_str(), message.c_str() + nextLinePos);
 		_lines[j] = currentLine;
-		int width = _font->getStringLength(currentLine);
+		int width = _font->getKernedStringLength(currentLine);
 		if (width > _maxLineWidth)
 			_maxLineWidth = width;
 		for (int count = 0; count < cutLen; count++)
@@ -288,7 +288,7 @@ void TextObject::setupText() {
 int TextObject::getLineX(int line) const {
 	int x = _x;
 	if (_justify == CENTER)
-		x = _x - (_font->getStringLength(_lines[line]) / 2);
+		x = _x - (_font->getKernedStringLength(_lines[line]) / 2);
 	else if (_justify == RJUSTIFY)
 		x = _x - getBitmapWidth();
 


### PR DESCRIPTION
There are now two functions for finding the text width, a "Kerned" one which uses just the kerned font size and a "Bitmap" one which uses the kerned font size and the column information. When placing text, we use the former, when deciding how much memory to allocate for TinyGL, we use the latter.
