### PR TITLE
EMI: Add stop turning to actor methods.

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -737,6 +737,15 @@ bool Actor::isTurning() const {
 	return false;
 }
 
+void Actor::stopTurning() {
+	_turning = false;
+	if (_lastTurnDir != 0)
+		getTurnChore(_lastTurnDir)->stop(true);
+
+	_lastTurnDir = 0;
+	_currTurnDir = 0;
+}
+
 void Actor::moveTo(const Math::Vector3d &pos) {
 	// The walking actor doesn't always have the collision mode set, but it must however check
 	// the collisions. E.g. the set hl doesn't set Manny's mode, but it must check for

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -228,6 +228,10 @@ public:
 	 */
 	bool isTurning() const;
 	/**
+	 * Stops the actor from turning
+	 */
+	void stopTurning();
+	/**
 	 * Sets the rotation of the actor in the 3D scene.
 	 * The effect is immediate.
 	 *

--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -448,7 +448,7 @@ void Lua_V2::ActorStopMoving() {
 	Actor *actor = getactor(actorObj);
 
 	actor->stopWalking();
-	// FIXME: Also stop turning?
+	actor->stopTurning();
 
 	warning("Lua_V2::ActorStopMoving, actor: %s", actor->getName().c_str());
 	// FIXME: Inspect the rest of the code to see if there's anything else missing


### PR DESCRIPTION
This adds a stop turning method to the actor class so that when ActorStopMoving is called, the rotation can be stopped as well.
