### PR TITLE
EMI: Implement Lua_V2::SetActorLocalAlpha

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -261,6 +261,15 @@ void Actor::saveState(SaveGame *savedState) const {
 		}
 
 		savedState->writeLESint32(_lookAtActor);
+
+		savedState->writeLEUint32(_localAlpha.size());
+		for (unsigned int i = 0; i < _localAlpha.size(); i++) {
+			savedState->writeFloat(_localAlpha[i]);
+		}
+		savedState->writeLEUint32(_localAlphaMode.size());
+		for (unsigned int i = 0; i < _localAlphaMode.size(); i++) {
+			savedState->writeLESint32(_localAlphaMode[i]);
+		}
 	}
 
 	savedState->writeBool(_drawnToClean);
@@ -456,6 +465,18 @@ bool Actor::restoreState(SaveGame *savedState) {
 
 		if (savedState->saveMinorVersion() >= 17)
 			_lookAtActor = savedState->readLESint32();
+
+		if (savedState->saveMinorVersion() >= 25) {
+			_localAlpha.resize(savedState->readLEUint32());
+			for (unsigned int i = 0; i < _localAlpha.size(); i++) {
+				_localAlpha[i] = savedState->readFloat();
+			}
+
+			_localAlphaMode.resize(savedState->readLEUint32());
+			for (unsigned int i = 0; i < _localAlphaMode.size(); i++) {
+				_localAlphaMode[i] = savedState->readLESint32();
+			}
+		}
 	}
 
 	if (_cleanBuffer) {
@@ -1948,6 +1969,32 @@ Math::Vector3d Actor::getTangentPos(const Math::Vector3d &pos, const Math::Vecto
 //  }
 
 	return dest;
+}
+
+void Actor::setLocalAlpha(unsigned int vertex, float alpha) {
+	if (vertex >= _localAlpha.size()) {
+		_localAlpha.resize(MAX(MAX_LOCAL_ALPHA_VERTICES, vertex + 1));
+	}
+	_localAlpha[vertex] = alpha;
+}
+
+void Actor::setLocalAlphaMode(unsigned int vertex, AlphaMode alphaMode) {
+	if (vertex >= _localAlphaMode.size()) {
+		_localAlphaMode.resize(MAX(MAX_LOCAL_ALPHA_VERTICES, vertex + 1));
+	}
+	_localAlphaMode[vertex] = alphaMode;
+}
+
+bool Actor::hasLocalAlpha() const {
+	return !_localAlphaMode.empty();
+}
+
+float Actor::getLocalAlpha(unsigned int vertex) const {
+	if (vertex < _localAlphaMode.size() && vertex < _localAlpha.size() && _localAlphaMode[vertex] == Actor::AlphaReplace) {
+		return _localAlpha[vertex];
+	} else {
+		return 1.0f;
+	}
 }
 
 void Actor::getBBoxInfo(Math::Vector3d &bboxPos, Math::Vector3d &bboxSize) const {

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -462,6 +462,10 @@ public:
 	void popCostume();
 	void clearCostumes();
 	Costume *getCurrentCostume() const;
+	void setLocalAlphaMode(unsigned int vertex, AlphaMode alphamode);
+	void setLocalAlpha(unsigned int vertex, float alpha);
+	bool hasLocalAlpha() const;
+	float getLocalAlpha(unsigned int vertex) const;
 	Costume *findCostume(const Common::String &name);
 	int getCostumeStackDepth() const {
 		return _costumeStack.size();
@@ -710,6 +714,11 @@ private:
 	LightMode _lightMode;
 
 	Common::List<ObjectPtr<Material> > _materials;
+
+	// Highest vertex used in EMI
+	const static unsigned int MAX_LOCAL_ALPHA_VERTICES = 48;
+	Common::Array<float> _localAlpha;
+	Common::Array<int> _localAlphaMode;
 };
 
 } // end of namespace Grim

--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -40,6 +40,9 @@ namespace Grim {
 
 void Lua_V2::SetActorLocalAlpha() {
 	lua_Object actorObj = lua_getparam(1);
+	lua_Object vertexObj= lua_getparam(2);
+	lua_Object alphaObj = lua_getparam(3);
+	// lua_Object unknownObj = lua_getparam(4);
 
 	if (!lua_isuserdata(actorObj) || lua_tag(actorObj) != MKTAG('A','C','T','R'))
 		return;
@@ -48,8 +51,20 @@ void Lua_V2::SetActorLocalAlpha() {
 	if (!actor)
 		return;
 
-	// FIXME: implement missing code
-	warning("Lua_V2::SetActorLocalAlpha: stub, actor: %s", actor->getName().c_str());
+	if (!lua_isnumber(vertexObj))
+		return;
+
+	if (!lua_isnumber(alphaObj))
+		return;
+
+	int vertex = lua_getnumber(vertexObj);
+	float alpha = lua_getnumber(alphaObj);
+
+	if (alpha == Actor::AlphaOff || alpha == Actor::AlphaReplace || alpha == Actor::AlphaModulate) {
+		actor->setLocalAlphaMode(vertex, Actor::AlphaMode(alpha));
+	} else {
+		actor->setLocalAlpha(vertex, alpha);
+	}
 }
 
 

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -752,8 +752,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 		glEnable(GL_TEXTURE_2D);
 	else
 		glDisable(GL_TEXTURE_2D);
-	if (face->_flags & EMIMeshFace::kAlphaBlend ||
-	    face->_flags & EMIMeshFace::kUnknownBlend)
+	if (face->_flags & EMIMeshFace::kAlphaBlend || face->_flags & EMIMeshFace::kUnknownBlend || _currentActor->hasLocalAlpha())
 		glEnable(GL_BLEND);
 
 	glBegin(GL_TRIANGLES);
@@ -769,7 +768,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 			byte r = (byte)(model->_colorMap[index].r * lighting.x() * dim);
 			byte g = (byte)(model->_colorMap[index].g * lighting.y() * dim);
 			byte b = (byte)(model->_colorMap[index].b * lighting.z() * dim);
-			byte a = (int)(model->_colorMap[index].a * _alpha);
+			byte a = (int)(model->_colorMap[index].a * _alpha * _currentActor->getLocalAlpha(index));
 			glColor4ub(r, g, b, a);
 		}
 

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -678,8 +678,7 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 		tglEnable(TGL_TEXTURE_2D);
 	else
 		tglDisable(TGL_TEXTURE_2D);
-	if (face->_flags & EMIMeshFace::kAlphaBlend ||
-	    face->_flags & EMIMeshFace::kUnknownBlend)
+	if (face->_flags & EMIMeshFace::kAlphaBlend || face->_flags & EMIMeshFace::kUnknownBlend || _currentActor->hasLocalAlpha())
 		tglEnable(TGL_BLEND);
 
 	tglBegin(TGL_TRIANGLES);
@@ -695,7 +694,7 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 			byte r = (byte)(model->_colorMap[index].r * lighting.x() * dim);
 			byte g = (byte)(model->_colorMap[index].g * lighting.y() * dim);
 			byte b = (byte)(model->_colorMap[index].b * lighting.z() * dim);
-			byte a = (int)(model->_colorMap[index].a * _alpha);
+			byte a = (int)(model->_colorMap[index].a * _alpha * _currentActor->getLocalAlpha(index));
 			tglColor4ub(r, g, b, a);
 		}
 

--- a/engines/grim/savegame.cpp
+++ b/engines/grim/savegame.cpp
@@ -35,7 +35,7 @@ namespace Grim {
 #define SAVEGAME_FOOTERTAG  'ESAV'
 
 uint SaveGame::SAVEGAME_MAJOR_VERSION = 22;
-uint SaveGame::SAVEGAME_MINOR_VERSION = 24;
+uint SaveGame::SAVEGAME_MINOR_VERSION = 25;
 
 SaveGame *SaveGame::openForLoading(const Common::String &filename) {
 	Common::InSaveFile *inSaveFile = g_system->getSavefileManager()->openForLoading(filename);


### PR DESCRIPTION
- sets the alpha mode and the alpha value for single vertices
- fixes the issue that the fuse in the first scene on the ship doesn't fully vanish (it partly re-appears) when it burns down
- implemented for OpenGL and works without any problems
- implemented also for TinyGL, but doesn't work here although the alpha values seems to be correctly set
