### PR TITLE
RFC/Discussion: GRAPHICS: Proof-of-concept: Render (well, blit) TinyGL using OpenGL 

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -139,6 +139,7 @@ protected:
 
 #ifdef USE_OPENGL
 	bool _opengl;
+	bool _tinygl;
 #endif
 	bool _fullscreen;
 
@@ -161,6 +162,20 @@ protected:
 
 	void updateOverlayTextures();
 	void drawOverlayOpenGL();
+	
+	// For TinyGL-on-OpenGL
+	SDL_Surface *_gameScreen;
+	bool _gameScreenVisible;
+	Graphics::PixelFormat _gameScreenFormat;
+	int _gameScreenWidth, _gameScreenHeight;
+	bool _gameScreenDirty;
+	
+	int _gameScreenNumTex;
+	GLuint *_gameScreenTexIds;
+	GLenum _gameScreenGLFormat;
+
+	void updateGameScreenTextures();
+	void drawGameScreenOpenGL();
 
 #ifdef USE_OPENGL_SHADERS
 	// Overlay

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -48,6 +48,24 @@
 #define USE_SDL_DEBUG_FOCUSRECT
 #endif
 
+struct Drawable2DScreen {
+	// For TinyGL-on-OpenGL
+	SDL_Surface *_screen;
+	bool _visible;
+	Graphics::PixelFormat _format;
+	int _width, _height;
+	bool _dirty;
+	
+#ifdef USE_OPENGL
+	int _numTex;
+	GLuint *_texIds;
+	GLenum _GLFormat;
+#endif
+
+	Drawable2DScreen();
+	void initialize(int width, int height, int rmask, int gmask, int bmask, int amask);
+};
+
 /**
  * SDL graphics manager
  */
@@ -100,14 +118,14 @@ public:
 
 	virtual void showOverlay();
 	virtual void hideOverlay();
-	virtual Graphics::PixelFormat getOverlayFormat() const { return _overlayFormat; }
+	virtual Graphics::PixelFormat getOverlayFormat() const { return _overlayScreen._format; }
 	virtual void clearOverlay();
 	virtual void grabOverlay(void *buf, int pitch);
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h);
 
 	//ResidualVM specific implementions:
-	virtual int16 getOverlayHeight() { return _overlayHeight; }
-	virtual int16 getOverlayWidth() { return _overlayWidth; }
+	virtual int16 getOverlayHeight() { return _overlayScreen._height; }
+	virtual int16 getOverlayWidth() { return _overlayScreen._width; }
 	void closeOverlay(); // ResidualVM specific method
 
 	virtual bool showMouse(bool visible);
@@ -144,38 +162,18 @@ protected:
 	bool _fullscreen;
 
 	// overlay
-	SDL_Surface *_overlayscreen;
-	bool _overlayVisible;
-	Graphics::PixelFormat _overlayFormat;
-	int _overlayWidth, _overlayHeight;
-	bool _overlayDirty;
+	Drawable2DScreen _overlayScreen;
 
 #ifdef USE_OPENGL
 	// Antialiasing
 	int _antialiasing;
 	void setAntialiasing(bool enable);
-
-	// Overlay
-	int _overlayNumTex;
-	GLuint *_overlayTexIds;
-	GLenum _overlayScreenGLFormat;
-
-	void updateOverlayTextures();
-	void drawOverlayOpenGL();
 	
 	// For TinyGL-on-OpenGL
-	SDL_Surface *_gameScreen;
-	bool _gameScreenVisible;
-	Graphics::PixelFormat _gameScreenFormat;
-	int _gameScreenWidth, _gameScreenHeight;
-	bool _gameScreenDirty;
-	
-	int _gameScreenNumTex;
-	GLuint *_gameScreenTexIds;
-	GLenum _gameScreenGLFormat;
+	Drawable2DScreen _gameScreen;
 
-	void updateGameScreenTextures();
-	void drawGameScreenOpenGL();
+	void update2DScreenTextures(Drawable2DScreen &screen);
+	void draw2DScreenOpenGL(Drawable2DScreen &screen);
 
 #ifdef USE_OPENGL_SHADERS
 	// Overlay


### PR DESCRIPTION
This was something I threw together quite rapidly as a proof-of-concept, and is thus not meant for merging, but rather for discussion.

The point here, is to allow for rendering the result of TinyGL using OpenGL (which should be doable with almost any OpenGL(ES)-renderer in theory.

A few points to note:
- I did not do anything other than copy around the Overlay-code (which is now horribly duplicated). I think we can make a struct of the duplicated variables, and thus reuse the existing functions for this, instead of duplicating, passing a flag to the functions to decide whether to work on _overlayX, or _gameScreenX.
- I did not do anything with _gameScreenDirty, as this is a proof-of concept.
- I did not expose a way to set the filter for rendering. (GL_LINEAR vs GL_NEAREST)
- This does not actually handle any aspect/scaling issues, as that depends on adding the GUI-flags etc from #1080.
- It should in theory be a workable solution for drawing TinyGL with arbitrary scaling on any machine that has GLES 1.1 or OpenGL 1.2 available (given that the aspect-flag and some additional code to keep within it is added).
- No code to detect the availability of OpenGL was added, but that should be doable.
- No fallback solution for the cases where absolutely NO OpenGL is available is provided here yet, (indeed this code doesn't even allow for that to happen, but this is, once again, just a proof-of-concept).

Comments on the general idea or overall approach is very welcome.
