### PR TITLE
RFC: Generic handling of floating point rounding issues

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1128,7 +1128,8 @@ Math::Angle Actor::getYawTo(const Actor *a) const {
 	} else {
 		delta.z() = 0;
 	}
-
+	if (delta.getMagnitude() < Math::epsilon)
+		return Math::Angle(0);
 	return Math::Vector3d::angle(forwardVec, delta);
 }
 
@@ -1971,13 +1972,18 @@ Math::Vector3d Actor::getTangentPos(const Math::Vector3d &pos, const Math::Vecto
 	if (_collisionMode == CollisionOff) {
 		return dest;
 	}
-
+	if (pos.getDistanceTo(dest) < Math::epsilon) {
+		return dest;
+	}
 	Math::Vector3d p;
 	float size;
 	if (!getSphereInfo(false, size, p))
 		return dest;
 	Math::Vector2d p1(pos.x(), pos.y());
 	Math::Vector2d p2(dest.x(), dest.y());
+	if (p1.getDistanceTo(p2) < Math::epsilon) {
+		return dest;
+	}
 	Math::Segment2d segment(p1, p2);
 
 	// TODO: collision with Box

--- a/engines/grim/debug.h
+++ b/engines/grim/debug.h
@@ -26,6 +26,12 @@
 #include "common/debug.h"
 #include "common/streamdebug.h"
 
+#ifdef RELEASE_BUILD
+# define DBGASSERT(x)
+#else
+# define DBGASSERT(x) assert(x)
+#endif
+
 namespace Grim {
 
 class Debug {

--- a/engines/grim/emi/costume/emihead.cpp
+++ b/engines/grim/emi/costume/emihead.cpp
@@ -101,7 +101,8 @@ void EMIHead::lookAt(bool entering, const Math::Vector3d &point, float rate, con
 
 	if (_headRot != lookAtQuat) {
 		Math::Quaternion diff = _headRot.inverse() * lookAtQuat;
-		float angle = 2 * acos(diff.w());
+		diff.normalize();
+		float angle = 2 * acos(fminf(fmaxf(diff.w(), -1.0f), 1.0f));
 		if (diff.w() < 0.0f) {
 			angle = 2 * (float)M_PI - angle;
 		}

--- a/engines/grim/emi/modelemi.cpp
+++ b/engines/grim/emi/modelemi.cpp
@@ -367,7 +367,7 @@ void EMIModel::updateLighting(const Math::Matrix4 &modelToWorld) {
 					if (cosAngle < 0.0f)
 						continue;
 
-					float angle = acos(cosAngle);
+					float angle = acos(fminf(cosAngle, 1.0f));
 					if (angle > l->_penumbraangle)
 						continue;
 

--- a/engines/grim/emi/sound/track.cpp
+++ b/engines/grim/emi/sound/track.cpp
@@ -85,9 +85,10 @@ void SoundTrack::updatePosition() {
 	Math::Vector3d cameraPos = setup->_pos;
 	Math::Vector3d vector = _pos - cameraPos;
 	float distance = vector.getMagnitude();
-	_attenuation = MAX(0.0f, 1.0f - distance / (_volume * 100.0f / Audio::Mixer::kMaxChannelVolume));
-	if (!isfinite(_attenuation)) {
+	if (_volume == 0) {
 		_attenuation = 0.0f;
+	} else {
+		_attenuation = fmaxf(0.0f, 1.0f - distance / (_volume * 100.0f / Audio::Mixer::kMaxChannelVolume));
 	}
 
 	Math::Matrix4 worldRot = setup->_rot;

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -69,6 +69,10 @@
 
 #include "engines/grim/lua/lua.h"
 
+#if defined(__GLIBC__) && (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 2) && !defined(RELEASE_BUILD)
+# include <fenv.h>
+#endif
+
 namespace Grim {
 
 GrimEngine *g_grim = nullptr;
@@ -79,6 +83,14 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 		Engine(syst), _currSet(nullptr), _selectedActor(nullptr), _pauseStartTime(0) {
 	g_grim = this;
 
+	/* Enable reporting of floating point exception for non-release builds
+	 * in order to quickly identify unexpected or unwanted results for
+	 * various floating point operations (e.g. results of NaN or +/-INF)
+	 */
+#if defined(__GLIBC__) && (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 2) && !defined(RELEASE_BUILD)
+	feenableexcept(FE_INVALID | FE_DIVBYZERO);
+	warning("Enabled reporting of floating point exceptions.");
+#endif
 	_debugger = new Debugger();
 	_gameType = gameType;
 	_gameFlags = gameFlags;

--- a/math/angle.cpp
+++ b/math/angle.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include "engines/grim/debug.h"
+
 #include "common/streamdebug.h"
 #include "common/math.h"
 
@@ -148,12 +150,14 @@ Angle Angle::fromRadians(float radians) {
 }
 
 Angle Angle::arcCosine(float x) {
+	DBGASSERT(-1.0f <= x && x <= 1.0f);
 	Angle a;
 	a.setRadians(acosf(x));
 	return a;
 }
 
 Angle Angle::arcSine(float x) {
+	DBGASSERT(-1.0f <= x && x <= 1.0f);
 	Angle a;
 	a.setRadians(asinf(x));
 	return a;

--- a/math/line2d.cpp
+++ b/math/line2d.cpp
@@ -26,40 +26,31 @@
 
 namespace Math {
 
-Line2d::Line2d() :
-	_a(0), _b(0), _c(0) {
+/* Linear equation used to describe the line:
+ *
+ * Ax + By = C
+ *
+ */
 
-}
 
 Line2d::Line2d(const Vector2d &direction, const Vector2d &point) {
-	Vector2d d = direction;
-	if (fabsf(d.getX()) > 0.0001f) {
-		_a = d.getY() / d.getX();
-		_b = -1;
-	} else {
-		_a = 1;
-		_b = 0;
-	}
+	_a = direction.getX();
+	_b = direction.getY();
+	_c = point.getY() * (point.getX() + direction.getX()) - point.getX() * (point.getY() + direction.getY());
 
-	if (_b == 0) {
-		_c = -point.getX();
-	} else {
-		_c = point.getY() - (d.getY() / d.getX()) * point.getX();
-	}
+	DBGASSERT(!(_a == 0.f && _b == 0.f));
 }
 
 Line2d Line2d::getPerpendicular(const Vector2d &point) const {
-	Vector2d v(1, _b / _a);
-
-	return Line2d(v, point);
+	return Line2d(Vector2d(_a, _b), point);
 }
 
 Vector2d Line2d::getDirection() const {
-	return Vector2d(1, _a);
+	return Vector2d(-_b, _a);
 }
 
 float Line2d::getDistanceTo(const Vector2d &point, Vector2d *intersection) const {
-	float dist = fabsf(_a * point.getX() + _b * point.getY() + _c) / sqrt(_a * _a + _b * _b);
+	float dist = fabsf(_a * point.getX() + _b * point.getY() - _c) / sqrt(_a * _a + _b * _b);
 
 	if (intersection) {
 		intersectsLine(getPerpendicular(point), intersection);
@@ -68,28 +59,24 @@ float Line2d::getDistanceTo(const Vector2d &point, Vector2d *intersection) const
 }
 
 bool Line2d::intersectsLine(const Line2d &line, Vector2d *pos) const {
-	// 	if (*this == line) {
-	// 		return false;
-	// 	}
+	float a1 = _a;
+	float b1 = _b;
+	float c1 = _c;
 
-	float a = _a;
-	float b = _b;
-	float c = _c;
-
-	float d = line._a;
-	float e = line._b;
-	float f = line._c;
+	float a2 = line._a;
+	float b2 = line._b;
+	float c2 = line._c;
 
 	float x, y;
 
-	const float det = a * e - b * d;
+	const float det = a1 * b2 - b1 * a2;
 
-	if (fabsf(det) < 0.0001f) {
+	if (fabsf(det) < epsilon) {
 		return false;
 	}
 
-	x = (-c * e + b * f) / det;
-	y = (-a * f + c * d) / det;
+	x = (c1 * b2 - c2 * b1) / det;
+	y = (a1 * c2 - a2 * c1) / det;
 
 	if (pos)
 		*pos = Vector2d(x, y);
@@ -98,19 +85,15 @@ bool Line2d::intersectsLine(const Line2d &line, Vector2d *pos) const {
 }
 
 bool Line2d::containsPoint(const Vector2d &point) const {
-	float n = _a * point.getX() + _b * point.getY() + _c;
-	return (n < 0.0001 && n > -0.0001);
-}
-
-float Line2d::getYatX(float x) const {
-	return -(_a * x + _c) / _b;
+	float n = _a * point.getX() + _b * point.getY() - _c;
+	return (fabsf(n) < epsilon);
 }
 
 Common::Debug &operator<<(Common::Debug &dbg, const Math::Line2d &line) {
-	if (fabsf(line._a) < 0.0001f) {
-		dbg.nospace() << "Line2d: <y = " << (-line._a / line._b) << " * x + " << -line._c / line._b << ">";
+	if (fabsf(line._a) < epsilon) {
+		dbg.nospace() << "Line2d: <y = " << (-line._a / line._b) << " * x + " << line._c / line._b << ">";
 	} else {
-		dbg.nospace() << "Line2d: <x = " << (-line._b / line._a) << " * y + " << -line._c / line._a << ">";
+		dbg.nospace() << "Line2d: <x = " << (-line._b / line._a) << " * y + " << line._c / line._a << ">";
 	}
 
 	return dbg.space();

--- a/math/line2d.cpp
+++ b/math/line2d.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "engines/grim/debug.h"
 #include "math/line2d.h"
 #include "math/rect2d.h"
 
@@ -124,7 +125,7 @@ Segment2d::Segment2d() {
 
 Segment2d::Segment2d(const Vector2d &b, const Vector2d &e) :
 	_begin(b), _end(e) {
-
+	DBGASSERT(_begin.getDistanceTo(_end) > epsilon);
 }
 
 Segment2d::Segment2d(const Segment2d &other) {
@@ -144,6 +145,7 @@ Vector2d Segment2d::middle() const {
 }
 
 Line2d Segment2d::getLine() const {
+	DBGASSERT(_begin.getDistanceTo(_end) > epsilon);
 	float y = _end.getY() - _begin.getY();
 	float x = _end.getX() - _begin.getX();
 	Vector2d v(x, y);
@@ -156,6 +158,7 @@ Line2d Segment2d::getPerpendicular(const Vector2d &point) const {
 }
 
 bool Segment2d::intersectsSegment(const Segment2d &other, Vector2d *pos) {
+	DBGASSERT(_begin.getDistanceTo(_end) > epsilon);
 	float denom = ((other._end.getY() - other._begin.getY()) * (_end.getX() - _begin.getX())) -
 	((other._end.getX() - other._begin.getX()) * (_end.getY() - _begin.getY()));
 
@@ -169,14 +172,14 @@ bool Segment2d::intersectsSegment(const Segment2d &other, Vector2d *pos) {
 	float nume_b = ((_end.getX() - _begin.getX()) * (other._begin.getY() - _begin.getY())) -
 	((_end.getY() - _begin.getY()) * (other._begin.getX() - _begin.getX()));
 
-	if (denom == 0.0f) {
+	if (denom == 0.0f || d == 0.0f ) {
 		return false;
 	}
 
 	float ua = nume_a / denom;
 	float ub = nume_b / d;
 
-	if (ua < 0 || ua > 1 || ub < 0 || ub > 1) {
+	if (ua < 0.0f || ua > 1.0f || ub < 0.0f || ub > 1.0f) {
 		return false;
 	}
 
@@ -207,6 +210,7 @@ bool Segment2d::containsPoint(const Vector2d &point) const {
 }
 
 Segment2d &Segment2d::operator=(const Segment2d &other) {
+	DBGASSERT(other._begin.getDistanceTo(other._end) > epsilon);
 	_begin = other._begin;
 	_end = other._end;
 

--- a/math/line2d.h
+++ b/math/line2d.h
@@ -29,7 +29,6 @@ namespace Math {
 
 class Line2d {
 public:
-	Line2d();
 	Line2d(const Vector2d &direction, const Vector2d &point);
 
 	Line2d getPerpendicular(const Vector2d &point = Vector2d()) const;
@@ -38,8 +37,6 @@ public:
 
 	bool intersectsLine(const Line2d &line, Vector2d *pos) const;
 	bool containsPoint(const Vector2d &point) const;
-
-	float getYatX(float x) const;
 
 	friend Common::Debug &operator<<(Common::Debug &dbg, const Line2d &line);
 

--- a/math/matrix.h
+++ b/math/matrix.h
@@ -206,6 +206,9 @@ Matrix<r, c> operator-(const Matrix<r, c> &m);
 template <int r, int c>
 bool operator==(const Matrix<r, c> &m1, const Matrix<r, c> &m2);
 
+template <int r, int c>
+bool operator!=(const Matrix<r, c> &m1, const Matrix<r, c> &m2);
+
 
 // Constructors
 template<int rows, int cols>
@@ -457,9 +460,13 @@ bool operator==(const Matrix<r, c> &m1, const Matrix<r, c> &m2) {
 			}
 		}
 	}
-	return false;
+	return true;
 }
 
+template <int r, int c>
+bool operator!=(const Matrix<r, c> &m1, const Matrix<r, c> &m2) {
+	return !(m1 == m2);
+}
 
 template<int r, int c>
 Common::Debug &operator<<(Common::Debug dbg, const Math::Matrix<r, c> &m) {

--- a/math/utils.h
+++ b/math/utils.h
@@ -27,6 +27,15 @@
 
 namespace Math {
 
+/* Math::epsilon is a constant with a small value which is used for comparing
+ * floating point numbers.
+ *
+ * The value is based on the previous hard-coded numbers in
+ * Line2d.cpp. Smaller numbers could be used unless they are
+ * smaller than the float granularity.
+ */
+static const float epsilon = 0.0001f;
+
 inline float square(float x) {
 	return x * x;
 }

--- a/math/vector3d.h
+++ b/math/vector3d.h
@@ -23,6 +23,8 @@
 #ifndef MATH_VECTOR3D_H
 #define MATH_VECTOR3D_H
 
+#include "engines/grim/debug.h"
+
 #include "common/scummsys.h"
 #include "common/endian.h"
 
@@ -82,7 +84,8 @@ public:
 	 * @return	The computed angle
 	 */
 	inline static Angle angle(const Vector3d& v1, const Vector3d& v2) {
-		return Angle::arcCosine(dotProduct(v1, v2) / (v1.getMagnitude() * v2.getMagnitude()));
+		DBGASSERT(v1 != Vector3d() && v2 != Vector3d());
+		return Angle::arcCosine(fminf(fmaxf(dotProduct(v1, v2) / (v1.getMagnitude() * v2.getMagnitude()), -1.0f), 1.0f));
 	}
 
 	/**


### PR DESCRIPTION
I have split the original PR #1108 into two PRs. The actual bug fixes for the lava puzzle and the generic handling of the floating point problems.
### Generic floating point issues
- in floating point, some operations are valid (like x / 0.0f) but have an unexpected outcome (+/- inf for x!= 0  or NaN for x = 0.0f)
- these special values are propagated undetected through all calculations and may lead to strange effects (like the invisible boats)
- due to the nature of the limited accuracy of floating point operations, some calculations are critical:
  - arcus cosinus/sinus if variable is outside of -1.0 ... 1.0
    - e.g. the operand of arcCosine is sometimes just a little bit above 1.0: 
      <pre>Angle::arcCosine(dotProduct(v1, v2) / (v1.getMagnitude() \* v2.getMagnitude()));</pre>
    - even the mathematically valid formula like the one above may produce results which are just a little bit off due to float's accuracy and so they would cause effectively acosf() to generate NaN
  - division by zero: can cause +/-inf or NaN
  - probably others like sqrt() of the operand is smaller than 0.0f
- in order to track down these issues I have enabled the reporting of floating point exceptions when project is not compiled with --enable-release
- for the revealed exceptions I did the following:
  - added asserts in the low-level math classes when undefined values are calculated or when the objects are created with undefined or non-meaningful values (like a line with no direction or a segment where the start and end point are equal)
  - fixed this kind of usage in the higher-level objects (e.g. in Grim::Actor)
### Open items
- Is that approach helpful at all?
- Enable the reporting of floating point exceptions in all 3 games and play some more scenes in order to detect other areas where the inaccuracies of floating point operations could cause some trouble.
