### PR TITLE
GRIM/EMI: Handle special case in Actor::walkForward()

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -800,6 +800,13 @@ void Actor::walkForward() {
 	if ((dist > 0 && dist > _walkRate / 5.f) || (dist < 0 && dist < _walkRate / 5.f))
 		dist = _walkRate / 5.f;
 
+	// Handle special case where actor is trying to walk but _walkRate is
+	// currently set to 0.0f by _walkChore to simulate roboter-like walk style:
+	// set _walkedCur to true to keep _walkChore playing in Actor::update()
+	if (_walkRate == 0.0f) {
+		_walkedCur = true;
+	}
+
 	_walking = false;
 
 	if (!_followBoxes) {


### PR DESCRIPTION
The walk chore of the monkey bot is simulating
a robotor-like walking style by setting _walkRate to
0.0f repeatedly. This prohibits walking forward
which results in stopping the walk chore eventually.

To avoid the walk chore in this case to stop, assume that
the actor has walked when calling Actor::walkForward() with
a _walkRate of 0.0f.

This fixes #1112.
