### PR TITLE
GRAPHICS: Reset GL's current color in drawDimPlane()

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -2015,12 +2015,15 @@ void GfxOpenGL::drawDimPlane() {
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	glColor4f(0.0f, 0.0f, 0.0f, _dimLevel);
+
 	glBegin(GL_QUADS);
 	glVertex2f(0, 0);
 	glVertex2f(1.0, 0);
 	glVertex2f(1.0, 1.0);
 	glVertex2f(0, 1.0);
 	glEnd();
+
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	glDisable(GL_BLEND);
 	glDepthMask(GL_TRUE);

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -1424,12 +1424,15 @@ void GfxTinyGL::drawDimPlane() {
 	tglBlendFunc(TGL_SRC_ALPHA, TGL_ONE_MINUS_SRC_ALPHA);
 
 	tglColor4f(0.0f, 0.0f, 0.0f, _dimLevel);
+
 	tglBegin(TGL_QUADS);
 	tglVertex2f(-1, -1);
 	tglVertex2f(1.0, -1);
 	tglVertex2f(1.0, 1.0);
 	tglVertex2f(-1, 1.0);
 	tglEnd();
+
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	tglDisable(TGL_BLEND);
 	tglDepthMask(TGL_TRUE);


### PR DESCRIPTION
Per convention, in residualvm the default GL current color
should be (1.0f, 1.0f, 1.0f). If a function changes the color,
it is required to reset it before returning.

This fixes the issue that some videos were not correctly displayed
until the next glColor call (e.g. when drawing the sub-titles) was
issued.

This fixes issue #1099 (some videos show only a black screen).
