### PR TITLE
EMI: Fix lighting to overworld actors

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1709,7 +1709,7 @@ void Actor::draw() {
 	// FIXME: if isAttached(), factor in the joint rotation as well.
 	const Math::Vector3d &absPos = getWorldPos();
 	if (!_costumeStack.empty()) {
-		g_grim->getCurrSet()->setupLights(absPos);
+		g_grim->getCurrSet()->setupLights(absPos, _inOverworld);
 		if (g_grim->getGameType() == GType_GRIM) {
 			Costume *costume = _costumeStack.back();
 			drawCostume(costume);

--- a/engines/grim/emi/modelemi.cpp
+++ b/engines/grim/emi/modelemi.cpp
@@ -320,7 +320,9 @@ void EMIModel::updateLighting(const Math::Matrix4 &modelToWorld) {
 	Common::Array<Grim::Light *> activeLights;
 	bool hasAmbient = false;
 
-	foreach(Light *l, g_grim->getCurrSet()->getLights()) {
+	Actor *actor = _costume->getOwner();
+
+	foreach(Light *l, g_grim->getCurrSet()->getLights(actor->isInOverworld())) {
 		if (l->_enabled) {
 			activeLights.push_back(l);
 			if (l->_type == Light::Ambient)

--- a/engines/grim/set.h
+++ b/engines/grim/set.h
@@ -51,6 +51,7 @@ public:
 
 	void loadText(TextSplitter &ts);
 	void loadBinary(Common::SeekableReadStream *data);
+	void setupOverworldLights();
 
 	void saveState(SaveGame *savedState) const;
 	bool restoreState(SaveGame *savedState);
@@ -63,7 +64,7 @@ public:
 	void drawBitmaps(ObjectState::Position stage);
 	void setupCamera();
 
-	void setupLights(const Math::Vector3d &pos);
+	void setupLights(const Math::Vector3d &pos, bool inOverworld);
 
 	void setSoundPosition(const char *soundName, const Math::Vector3d &pos);
 	void setSoundPosition(const char *soundName, const Math::Vector3d &pos, int minVol, int maxVol);
@@ -143,7 +144,7 @@ public:
 	};
 
 	Setup *getCurrSetup() { return _currSetup; }
-	const Common::List<Light *> &getLights() { return _lightsList; }
+	const Common::List<Light *> &getLights(bool inOverworld) { return (inOverworld ? _overworldLightsList : _lightsList); }
 	const Math::Frustum &getFrustum() { return _frustum; }
 
 	int getShadowCount() const { return _numShadows; }
@@ -160,6 +161,7 @@ private:
 	Sector **_sectors;
 	Light *_lights;
 	Common::List<Light *> _lightsList;
+	Common::List<Light *> _overworldLightsList;
 	Setup *_setups;
 	SetShadow *_shadows;
 


### PR DESCRIPTION
Overworld actors, e.g. the load/save menu should not use
lighting based on the lights of the current scene. This
fixes the bug that the screenshots of the load menu
were dimmed to various levels depending on the current scene.

The bug fix is implemented for OpenGL, TinyGL and OpenGL Shaders.

Since the display of the overworld actors does not work with OpenGL Shaders, the bug fix could not be verified for this renderer.
