### PR TITLE
EMI: Fix stuck dart players

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -87,7 +87,7 @@ Actor::Actor() :
 		_pitch(0), _yaw(0), _roll(0), _walkRate(0.3f),
 		_turnRateMultiplier(0.f), _talkAnim(0),
 		_reflectionAngle(80), _scale(1.f), _timeScale(1.f),
-		_visible(true), _lipSync(nullptr), _turning(false), _walking(false),
+		_visible(true), _lipSync(nullptr), _turning(false), _singleTurning(false), _walking(false),
 		_walkedLast(false), _walkedCur(false),
 		_collisionMode(CollisionOff), _collisionScale(1.f),
 		_lastTurnDir(0), _currTurnDir(0),
@@ -184,6 +184,7 @@ void Actor::saveState(SaveGame *savedState) const {
 	}
 
 	savedState->writeBool(_turning);
+	savedState->writeBool(_singleTurning);
 	savedState->writeFloat(_moveYaw.getDegrees());
 	savedState->writeFloat(_movePitch.getDegrees());
 	savedState->writeFloat(_moveRoll.getDegrees());
@@ -349,6 +350,9 @@ bool Actor::restoreState(SaveGame *savedState) {
 	}
 
 	_turning = savedState->readBool();
+	if (savedState->saveMinorVersion() > 25) {
+		_singleTurning = savedState->readBool();
+	}
 	_moveYaw = savedState->readFloat();
 	if (savedState->saveMinorVersion() > 6) {
 		_movePitch = savedState->readFloat();
@@ -580,6 +584,7 @@ bool Actor::singleTurnTo(const Math::Vector3d &pos) {
 	_moveYaw = _yaw;
 	_movePitch = _pitch;
 	_moveRoll = _roll;
+	_singleTurning = !done;
 
 	return done;
 }
@@ -756,6 +761,9 @@ bool Actor::isWalking() const {
 }
 
 bool Actor::isTurning() const {
+	if (g_grim->getGameType() == GType_MONKEY4)
+		if (_singleTurning)
+			return true;
 	if (_turning)
 		return true;
 

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -611,6 +611,7 @@ private:
 
 	// Variables for gradual turning
 	bool _turning;
+	bool _singleTurning;
 	// NOTE: The movement direction is separate from the direction
 	// the actor's model is facing. The model's direction is gradually
 	// updated to match the movement direction. This produces a smooth

--- a/engines/grim/savegame.cpp
+++ b/engines/grim/savegame.cpp
@@ -35,7 +35,7 @@ namespace Grim {
 #define SAVEGAME_FOOTERTAG  'ESAV'
 
 uint SaveGame::SAVEGAME_MAJOR_VERSION = 22;
-uint SaveGame::SAVEGAME_MINOR_VERSION = 25;
+uint SaveGame::SAVEGAME_MINOR_VERSION = 26;
 
 SaveGame *SaveGame::openForLoading(const Common::String &filename) {
 	Common::InSaveFile *inSaveFile = g_system->getSavefileManager()->openForLoading(filename);


### PR DESCRIPTION
TurnActorTo is mapped to Actor::singleTurnTo() which only
turns the actor according to its turn rate a small amount.

If the the turn could not be completed, TurnActorTo returns
false.

In EMI, all LUA calls to TurnActorTo are repeated until the
actor does eventually look into the correct direction.

However, for parallel running LUA threads calls to IsActorTurning
would return false during such a "LUA-controlled" turn.

In the scene with the dart players, the LUA code for the dialog
waits for the dart player to stop moving (and turning) by repeatedly
calling IsActorTurning. Since that function returns false
even if the players are still turning towards the dart board, the
dialog code starts and starts a parallel LUA thread to use
TurnActorTo to make the dart players looking at Guybrush.

This means, that eventually for each dart player, two LUA
threads with contradicting TurnActorTo directions will run forever
since in none of the threads the final direction is ever reached.

To fix that, a new actor state variable _singleTurning is introduced.
It is set to true if an Actior::singleTurnTo() call indicates that
the turn is not complete. It is set to false once the turning has
fininshed.

Since all TurnActorTo calls EMI are repeated until the function returns
false, it is safe to use that variable to indicate a "LUA-controlled"
turning is in progress.

In GRIM, that's not the case and so isTurning() is only changed for EMI.

This fixes issue #1034.
