### PR TITLE
COMMON: Use c++11 foreach if available

### DIFF
--- a/common/foreach.h
+++ b/common/foreach.h
@@ -25,6 +25,8 @@
 
 #include "common/scummsys.h"
 
+#if __cplusplus < 201103L
+
 namespace Common {
 
 class _Foreach_Container_Base_ {
@@ -65,5 +67,11 @@ for (const Common::_Foreach_Container_Base_ &_FOREACH_CONTAINER_ = Common::_Crea
 	Common::_Get_Foreach_Container_(&_FOREACH_CONTAINER_, container)->next()) \
 	for (var = *Common::_Get_Foreach_Container_(&_FOREACH_CONTAINER_, container)->i;\
 		_FOREACH_CONTAINER_.brk > 0; --_FOREACH_CONTAINER_.brk)
+
+#else
+
+#define foreach(var, container) for (var : container)
+
+#endif
 
 #endif


### PR DESCRIPTION
I'm not sure this is the best way to do the check, but it works pretty well it seems. I decided to do this as coverity doesn't like our foreach macros.

I haven't actually tested this in game (as I don't actually have the game files with me right now), but it compiles so I'd guess it works.
