### PR TITLE
EMI: Relax height check for bridges between sectors

### DIFF
--- a/engines/grim/sector.cpp
+++ b/engines/grim/sector.cpp
@@ -391,8 +391,18 @@ Common::List<Math::Line3d> Sector::getBridgesTo(Sector *sector) const {
 	it = bridges.begin();
 	while (it != bridges.end()) {
 		if (g_grim->getGameType() == GType_MONKEY4) {
-			if (fabs(getProjectionToPlane((*it).begin()).y() - sector->getProjectionToPlane((*it).begin()).y()) > 0.01f ||
-					fabs(getProjectionToPlane((*it).end()).y() - sector->getProjectionToPlane((*it).end()).y()) > 0.01f) {
+			// Set pac contains sectors which are not parallel to any
+			// other sector or share any edge. Since one sector isn't
+			// a plane, finding the intersections in 3D would be complicated.
+			//
+			// Checking for bridges using a projection in 2D and having a height
+			// threshold to avoid that characters jump from lower to higher floors
+			// seems to be a good compromise.
+			//
+			// The value of at least 0.1 was chosen to fix a path finding issue
+			// in set pac when guybrush tried to reach the pile of rocks.
+			if (fabs(getProjectionToPlane((*it).begin()).y() - sector->getProjectionToPlane((*it).begin()).y()) > 0.1f ||
+					fabs(getProjectionToPlane((*it).end()).y() - sector->getProjectionToPlane((*it).end()).y()) > 0.1f) {
 				it = bridges.erase(it);
 				continue;
 			}


### PR DESCRIPTION
- fixes a path finding issue (#992)