### PR TITLE
DEVTOOLS: Allways enable langauge extentions for MSVC

### DIFF
--- a/devtools/create_project/config.h
+++ b/devtools/create_project/config.h
@@ -29,7 +29,7 @@
 #define REVISION_DEFINE "SCUMMVM_INTERNAL_REVISION"
 #define FIRST_ENGINE "grim"               // Name of the engine which should be sorted as first element
 
-#define ENABLE_LANGUAGE_EXTENSIONS "grim,myst3"    // Comma separated list of projects that need language extensions
+#define ENABLE_LANGUAGE_EXTENSIONS ""    // Comma separated list of projects that need language extensions, not used by ResidualVM
 #define DISABLE_EDIT_AND_CONTINUE ""     // Comma separated list of projects that need Edit&Continue to be disabled for co-routine support (the main project is automatically added)
 
 //#define ADDITIONAL_LIBRARY ""            // Add a single library to the list of externally linked libraries

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -269,7 +269,7 @@ void MSBuildProvider::writeReferences(const BuildSetup &setup, std::ofstream &ou
 void MSBuildProvider::outputProjectSettings(std::ofstream &project, const std::string &name, const BuildSetup &setup, bool isRelease, bool isWin32, std::string configuration) {
 	// Check for project-specific warnings:
 	std::map<std::string, StringList>::iterator warningsIterator = _projectWarnings.find(name);
-	bool enableLanguageExtensions = find(_enableLanguageExtensions.begin(), _enableLanguageExtensions.end(), name) != _enableLanguageExtensions.end();
+	bool enableLanguageExtensions = true; // ResidualVM
 	bool disableEditAndContinue = find(_disableEditAndContinue.begin(), _disableEditAndContinue.end(), name) != _disableEditAndContinue.end();
 
 	// Nothing to add here, move along!

--- a/devtools/create_project/visualstudio.cpp
+++ b/devtools/create_project/visualstudio.cpp
@@ -101,7 +101,7 @@ void VisualStudioProvider::createProjectFile(const std::string &name, const std:
 		outputConfiguration(project, setup, libraries, "Release", "x64", "64", false);
 
 	} else {
-		bool enableLanguageExtensions = find(_enableLanguageExtensions.begin(), _enableLanguageExtensions.end(), name) != _enableLanguageExtensions.end();
+		bool enableLanguageExtensions = true; // ResidualVM
 		bool disableEditAndContinue = find(_disableEditAndContinue.begin(), _disableEditAndContinue.end(), name) != _disableEditAndContinue.end();
 
 		std::string warnings = "";


### PR DESCRIPTION
Since all our projects use OpenGL, we always need language extensions to be enabled.

My motivation here is that I can have one build of create_project that I don't need to update when new engines are in development.