### PR TITLE
GRIM: Fix deleting material when it is still needed

### DIFF
--- a/engines/grim/costume/material_component.cpp
+++ b/engines/grim/costume/material_component.cpp
@@ -50,6 +50,7 @@ void MaterialComponent::init() {
 			for (int i = 0; i < model->_numMaterials; ++i) {
 				if (_name.compareToIgnoreCase(model->_materials[i]->getFilename()) == 0) {
 					_mat = model->_materials[i];
+					_mat->reference();
 					return;
 				}
 			}

--- a/engines/grim/model.cpp
+++ b/engines/grim/model.cpp
@@ -90,7 +90,7 @@ Model::Model(const Common::String &filename, Common::SeekableReadStream *data, C
 Model::~Model() {
 	for (int i = 0; i < _numMaterials; ++i) {
 		if (!_materialsShared[i]) {
-			delete _materials[i];
+			_materials[i]->dereference();
 		}
 	}
 	delete[] _materials;
@@ -247,6 +247,7 @@ void Model::loadMaterial(int index, CMap *cmap) {
 			_materials[index] = mat;
 		} else {
 			_materials[index] = g_resourceloader->loadMaterial(_materialNames[index], cmap, false);
+			_materials[index]->reference();
 		}
 		_materialsShared[index] = false;
 	}


### PR DESCRIPTION
This fixes part of #1140. I had thought that the two issues in that issue were related. One, the changing colour, and two the save games breaking. This fixes the save games, but not the colour changing. It at least makes it easier to debug the colour changing.

I have not taken the time to go though the code to see if they affects anything else, and I think we don't generally call reference and dereference directly, but I figured I'd post this anyway. 
