### PR TITLE
GRIM/EMI: Add Joystick/gamepad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Alt + x     | Quit (ingame)
 Alt + enter | Switch between windowed-mode and fullscreen
 F1          | Menu
 
+### 3.4. Joystick/gamepad support ###
+
+If you want to use a joystick or gamepad for navigation, the joystick support
+of the engine needs to be enabled using one of the following two options:
+
+  * start residualvm with "--joystick" parameter
+  * add "joystick\_num=0" to the "[residualvm]" section of the configuration file
+    (see section 5.1. how to find the file)
 
 4. Running Myst III
 -------------------

--- a/backends/events/sdl/resvm-sdl-events.cpp
+++ b/backends/events/sdl/resvm-sdl-events.cpp
@@ -1,0 +1,48 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "common/scummsys.h"
+
+#if defined(SDL_BACKEND)
+
+#include "resvm-sdl-events.h"
+
+bool ResVmSdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
+	event.type = Common::EVENT_JOYBUTTON_DOWN;
+	event.joystick.button = ev.jbutton.button;
+	return true;
+}
+
+bool ResVmSdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
+	event.type = Common::EVENT_JOYBUTTON_UP;
+	event.joystick.button = ev.jbutton.button;
+	return true;
+}
+
+bool ResVmSdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
+	event.type = Common::EVENT_JOYAXIS_MOTION;
+	event.joystick.axis = ev.jaxis.axis;
+	event.joystick.position = ev.jaxis.value;
+	return true;
+}
+
+#endif

--- a/backends/events/sdl/resvm-sdl-events.h
+++ b/backends/events/sdl/resvm-sdl-events.h
@@ -1,0 +1,38 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKEND_EVENTS_RESVM_SDL
+#define BACKEND_EVENTS_RESVM_SDL
+
+#include "sdl-events.h"
+
+/**
+ * Custom event source for ResidualVM with true joystick support.
+ */
+class ResVmSdlEventSource : public SdlEventSource {
+protected:
+	bool handleJoyButtonDown(SDL_Event &ev, Common::Event &event);
+	bool handleJoyButtonUp(SDL_Event &ev, Common::Event &event);
+	bool handleJoyAxisMotion(SDL_Event &ev, Common::Event &event);
+};
+
+#endif

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -55,6 +55,7 @@ endif
 ifdef SDL_BACKEND
 MODULE_OBJS += \
 	events/sdl/sdl-events.o \
+	events/sdl/resvm-sdl-events.o \
 	graphics/sdl/sdl-graphics.o \
 	graphics/surfacesdl/surfacesdl-graphics.o \
 	mixer/doublebuffersdl/doublebuffersdl-mixer.o \

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -42,8 +42,9 @@
 #else
 #include "backends/audiocd/sdl/sdl-audiocd.h"
 #endif
-
-#include "backends/events/sdl/sdl-events.h"
+// ResidualVM:
+// #include "backends/events/sdl/sdl-events.h"
+#include "backends/events/sdl/resvm-sdl-events.h"
 #include "backends/mutex/sdl/sdl-mutex.h"
 #include "backends/timer/sdl/sdl-timer.h"
 #include "backends/graphics/surfacesdl/surfacesdl-graphics.h"
@@ -156,7 +157,7 @@ void OSystem_SDL::initBackend() {
 	// Create the default event source, in case a custom backend
 	// manager didn't provide one yet.
 	if (_eventSource == 0)
-		_eventSource = new SdlEventSource();
+		_eventSource = new ResVmSdlEventSource(); // ResidualVm: was SdlEventSource
 
 	if (_graphicsManager == 0) {
 		if (_graphicsManager == 0) {

--- a/common/events.h
+++ b/common/events.h
@@ -87,7 +87,28 @@ enum EventType {
 	,
 	EVENT_VIRTUAL_KEYBOARD = 20
 #endif
+/* START of ResidualVM-specific code */
+	,
+	EVENT_JOYAXIS_MOTION = 23,
+	EVENT_JOYBUTTON_DOWN = 24,
+	EVENT_JOYBUTTON_UP = 25
 };
+
+const int16 JOYAXIS_MIN = -32768;
+const int16 JOYAXIS_MAX = 32767;
+
+/**
+ * Data structure for joystick events
+ */
+struct JoystickState {
+	/** The axis for EVENT_JOYAXIS_MOTION events */
+	byte axis;
+	/** The new axis position for EVENT_JOYAXIS_MOTION events */
+	int16 position;
+	/** The button index for EVENT_JOYBUTTON_DOWN/UP events */
+	byte button;
+};
+/* END of ResidualVM-specific code */
 
 typedef uint32 CustomEventType;
 /**
@@ -126,6 +147,14 @@ struct Event {
 	 * This field is ResidualVM specific
 	 */
 	Common::Point relMouse;
+
+	/**
+	 * Joystick data; only valid for joystick events (EVENT_JOYAXIS_MOTION,
+	 * EVENT_JOYBUTTON_DOWN and EVENT_JOYBUTTON_UP).
+	 *
+	 * This field is ResidualVM specific
+	 */
+	JoystickState joystick;
 
 	Event() : type(EVENT_INVALID), synthetic(false) {
 #ifdef ENABLE_KEYMAPPER

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -119,6 +119,10 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 		_controlsEnabled[i] = false;
 		_controlsState[i] = false;
 	}
+	_joyAxisPosition = new float[NUM_JOY_AXES];
+	for (int i = 0; i < NUM_JOY_AXES; i++) {
+		_joyAxisPosition[i] = 0;
+	}
 	_speechMode = TextAndVoice;
 	_textSpeed = 7;
 	_mode = _previousMode = NormalMode;
@@ -171,6 +175,7 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 GrimEngine::~GrimEngine() {
 	delete[] _controlsEnabled;
 	delete[] _controlsState;
+	delete[] _joyAxisPosition;
 
 	clearPools();
 
@@ -816,6 +821,10 @@ void GrimEngine::mainLoop() {
 					}
 				}
 			}
+			if (type == Common::EVENT_JOYAXIS_MOTION)
+				handleJoyAxis(event.joystick.axis, event.joystick.position);
+			if (type == Common::EVENT_JOYBUTTON_DOWN || type == Common::EVENT_JOYBUTTON_UP)
+				handleJoyButton(type, event.joystick.button);
 		}
 
 		if (_mode != PauseMode) {
@@ -1250,6 +1259,10 @@ void GrimEngine::setTextSpeed(int speed) {
 }
 
 float GrimEngine::getControlAxis(int num) {
+	int idx = num - KEYCODE_AXIS_JOY1_X;
+	if (idx >= 0 && idx < NUM_JOY_AXES) {
+		return _joyAxisPosition[idx];
+	}
 	return 0;
 }
 

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -193,6 +193,8 @@ protected:
 
 	void handleControls(Common::EventType type, const Common::KeyState &key);
 	void handleChars(Common::EventType type, const Common::KeyState &key);
+	void handleJoyAxis(byte axis, int16 position);
+	void handleJoyButton(Common::EventType type, byte button);
 	void handleExit();
 	void handlePause();
 	void handleUserPaint();
@@ -243,6 +245,7 @@ protected:
 
 	bool *_controlsEnabled;
 	bool *_controlsState;
+	float *_joyAxisPosition;
 
 	bool _changeHardwareState;
 	bool _changeFullscreenState;
@@ -335,6 +338,9 @@ enum {
 	KEYCODE_AXIS_MOUSE_Z,
 	KEYCODE_EXTRA_LAST
 };
+
+#define NUM_JOY_AXES (KEYCODE_AXIS_JOY1_V - KEYCODE_AXIS_JOY1_X + 1)
+#define NUM_JOY_BUTTONS (KEYCODE_JOY1_B20 - KEYCODE_JOY1_B1 + 1)
 
 extern const ControlDescriptor controls[];
 


### PR DESCRIPTION
This commit adds true joystick/gamepad support to the Grim/Emi engine. I have rebased the commits from #721 and made some minor modifications (comments, support for EMI, ...).

As inherited from ScummVM, the joystick support has to be enabled globally either with the "--joystick" command line option or by adding "joystick_num=0" to the [residualvm] section of ~/.residualvmrc.

Tested with X-Box 360 controller in EMI and GRIM.