### PR TITLE
EMI: Fix caching of local.m4b

### DIFF
--- a/engines/grim/resource.h
+++ b/engines/grim/resource.h
@@ -103,8 +103,6 @@ private:
 	mutable bool _cacheDirty;
 	mutable int32 _cacheMemorySize;
 
-	Common::Archive *_localArchive;
-
 	Common::List<EMIModel *> _emiModels;
 	Common::List<Model *> _models;
 	Common::List<CMap *> _colormaps;


### PR DESCRIPTION
Commit 2e7b6a0ec1d825526dc10cee17efd31dc8591c24 introduced the problem that _options.lua from local.m4b took precedence over _options.lua from patch.m4b in EMI.

That caused the problem that the patch from residualvm-emi-patch.m4b never got applied and so the game's integration into the preference handling of the engine was turned off (system_prefs.loadprefs was not overwritten with residualvm's version).

This patch fixes the problem by reverting some portions of the original commit but still avoids the problem that local.m4b is opened multiple times (which is very slow on on Mac).