### PR TITLE
GRIM/EMI: Add nullptr checks to avoid segfaults on cleanup

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -232,7 +232,7 @@ BitmapData::~BitmapData() {
 }
 
 void BitmapData::freeData() {
-	if (!_keepData) {
+	if (!_keepData && _data) {
 		for (int i = 0; i < _numImages; ++i) {
 			_data[i].free();
 		}

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1218,9 +1218,10 @@ void GfxOpenGLS::selectTexture(const Texture *texture) {
 
 void GfxOpenGLS::destroyTexture(Texture *texture) {
 	GLuint *textures = static_cast<GLuint *>(texture->_texture);
-	glDeleteTextures(1, textures);
-
-	delete[] textures;
+	if (textures) {
+		glDeleteTextures(1, textures);
+		delete[] textures;
+	}
 }
 
 void GfxOpenGLS::createBitmap(BitmapData *bitmap) {

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -1247,8 +1247,11 @@ void GfxTinyGL::selectTexture(const Texture *texture) {
 }
 
 void GfxTinyGL::destroyTexture(Texture *texture) {
-	tglDeleteTextures(1, (TGLuint *)texture->_texture);
-	delete[] (TGLuint *)texture->_texture;
+	TGLuint *textures = (TGLuint *)texture->_texture;
+	if (textures) {
+		tglDeleteTextures(1, textures);
+		delete[] textures;
+	}
 }
 
 void GfxTinyGL::prepareMovieFrame(Graphics::Surface *frame) {


### PR DESCRIPTION
Add some nullptr checks to avoid segfaults on cleanup.vu 