### PR TITLE
EMI: Allow saving in-game on the PS2 version

### DIFF
--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -599,7 +599,10 @@ SaveStateList GrimMetaEngine::listSaves(const char *target) const {
 		if (slotNum >= 0) {
 			SaveGame *savedState = SaveGame::openForLoading(*file);
 			if (savedState && savedState->isCompatible()) {
-				savedState->beginSection('SUBS');
+				if (targetString.hasPrefix("monkey4-ps2"))
+					savedState->beginSection('PS2S');
+				else
+					savedState->beginSection('SUBS');
 				strSize = savedState->readLESint32();
 				savedState->read(str, strSize);
 				savedState->endSection();

--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -583,6 +583,9 @@ SaveStateList GrimMetaEngine::listSaves(const char *target) const {
 	Common::StringArray filenames;
 	Common::String targetString(target);
 	Common::String pattern = targetString.hasPrefix("monkey4") ? "efmi*.gsv" : "grim*.gsv";
+	
+	if (targetString.hasPrefix("monkey4-ps2"))
+		pattern = "efmi*.ps2";
 
 	filenames = saveFileMan->listSavefiles(pattern);
 

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -477,14 +477,19 @@ void Lua_V2::ThumbnailFromFile() {
 		return;
 	}
 	int index = (int)lua_getnumber(texIdObj);
-	const char *filename = lua_getstring(filenameObj);
+	Common::String filename(lua_getstring(filenameObj));
+	
+	if (g_grim->getGameType() == GType_MONKEY4 &&
+		g_grim->getGamePlatform() == Common::kPlatformPS2) {
+		filename += ".gsv";
+	}
 
 	int width = 256, height = 128;
 
 	SaveGame *savedState = SaveGame::openForLoading(filename);
 	if (!savedState || !savedState->isCompatible()) {
 		delete savedState;
-		warning("Lua_V2::ThumbnailFromFile: savegame %s not compatible", filename);
+		warning("Lua_V2::ThumbnailFromFile: savegame %s not compatible", filename.c_str());
 		lua_pushnil();
 		return;
 	}
@@ -503,7 +508,7 @@ void Lua_V2::ThumbnailFromFile() {
 	Bitmap *screenshot = new Bitmap(buf, width, height, "screenshot");
 	if (!screenshot) {
 		lua_pushnil();
-		warning("Lua_V2::ThumbnailFromFile: Could not restore screenshot from file %s", filename);
+		warning("Lua_V2::ThumbnailFromFile: Could not restore screenshot from file %s", filename.c_str());
 		delete screenshot;
 		delete[] data;
 		delete savedState;

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -481,7 +481,7 @@ void Lua_V2::ThumbnailFromFile() {
 	
 	if (g_grim->getGameType() == GType_MONKEY4 &&
 		g_grim->getGamePlatform() == Common::kPlatformPS2) {
-		filename += ".gsv";
+		filename += ".ps2";
 	}
 
 	int width = 256, height = 128;

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -522,8 +522,10 @@ void Lua_V2::ThumbnailFromFile() {
 
 void Lua_V2::GetMemoryCardId() {
 	// 0 - No mem card
-	lua_pushnumber(0);
-	warning("GetMemoryCardId: Currently just returning 0");
+	// 1 - Not formatted
+	// 2 - Not enough space
+	// 3 - Error occured
+	lua_pushnumber(4);
 }
 
 void Lua_V2::SetReplayMode() {

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -417,7 +417,11 @@ void GrimEngine::playAspyrLogo() {
 Common::Error GrimEngine::loadGameState(int slot) {
 	assert(slot >= 0);
 	if (getGameType() == GType_MONKEY4) {
-		_savegameFileName = Common::String::format("efmi%03d.gsv", slot);
+		if (getGamePlatform() == Common::kPlatformPS2) {
+			_savegameFileName = Common::String::format("efmi%03d.ps2", slot);
+		} else {
+			_savegameFileName = Common::String::format("efmi%03d.gsv", slot);
+		}
 	} else {
 		_savegameFileName = Common::String::format("grim%02d.gsv", slot);
 	}

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -497,14 +497,9 @@ void Lua_V1::GetSpeechMode() {
 }
 
 void Lua_V1::GetDiskFreeSpace() {
-	if (g_grim->getGameType() == GType_MONKEY4 &&
-		g_grim->getGamePlatform() == Common::kPlatformPS2) {
-		//wants more than 600 KB
-		lua_pushnumber(700);
-	} else {
-	// amount of free space in MB, used for creating saves
-		lua_pushnumber(50);
-	}
+	//the ps2 version of emi wants more than 600 KB
+	//grim: amount of free space in MB, used for creating saves
+	lua_pushnumber(700);
 }
 
 void Lua_V1::GetCurrentScript() {

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -497,8 +497,14 @@ void Lua_V1::GetSpeechMode() {
 }
 
 void Lua_V1::GetDiskFreeSpace() {
+	if (g_grim->getGameType() == GType_MONKEY4 &&
+		g_grim->getGamePlatform() == Common::kPlatformPS2) {
+		//wants more than 600 KB
+		lua_pushnumber(700);
+	} else {
 	// amount of free space in MB, used for creating saves
-	lua_pushnumber(50);
+		lua_pushnumber(50);
+	}
 }
 
 void Lua_V1::GetCurrentScript() {

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -576,7 +576,7 @@ void Lua_V1::GetSaveGameData() {
 	Common::String filename(lua_getstring(param));
 	if (g_grim->getGameType() == GType_MONKEY4 &&
 		g_grim->getGamePlatform() == Common::kPlatformPS2) {
-		filename += ".gsv";
+		filename += ".ps2";
 	}
 	SaveGame *savedState = SaveGame::openForLoading(filename);
 	lua_Object result = lua_createtable();
@@ -631,7 +631,7 @@ void Lua_V1::Load() {
 		Common::String fileName(lua_getstring(fileNameObj));
 		if (g_grim->getGameType() == GType_MONKEY4 &&
 			g_grim->getGamePlatform() == Common::kPlatformPS2) {
-			fileName += ".gsv";
+			fileName += ".ps2";
 		}
 		g_grim->loadGame(fileName);
 	} else {
@@ -648,7 +648,7 @@ void Lua_V1::Save() {
 		Common::String fileName(lua_getstring(fileNameObj));
 		if (g_grim->getGameType() == GType_MONKEY4 &&
 			g_grim->getGamePlatform() == Common::kPlatformPS2) {
-			fileName += ".gsv";
+			fileName += ".ps2";
 		}
 		g_grim->saveGame(fileName);
 	} else {

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -578,7 +578,11 @@ void Lua_V1::GetSaveGameData() {
 	lua_Object param = lua_getparam(1);
 	if (!lua_isstring(param))
 		return;
-	const char *filename = lua_getstring(param);
+	Common::String filename(lua_getstring(param));
+	if (g_grim->getGameType() == GType_MONKEY4 &&
+		g_grim->getGamePlatform() == Common::kPlatformPS2) {
+		filename += ".gsv";
+	}
 	SaveGame *savedState = SaveGame::openForLoading(filename);
 	lua_Object result = lua_createtable();
 
@@ -590,10 +594,10 @@ void Lua_V1::GetSaveGameData() {
 		lua_pushobject(result);
 
 		if (!savedState) {
-			warning("Savegame %s is invalid", filename);
+			warning("Savegame %s is invalid", filename.c_str());
 		} else {
 			warning("Savegame %s is incompatible with this ResidualVM build. Save version: %d.%d; current version: %d.%d",
-					filename, savedState->saveMajorVersion(), savedState->saveMinorVersion(),
+					filename.c_str(), savedState->saveMajorVersion(), savedState->saveMinorVersion(),
 					SaveGame::SAVEGAME_MAJOR_VERSION, SaveGame::SAVEGAME_MINOR_VERSION);
 		}
 		delete savedState;
@@ -625,11 +629,16 @@ void Lua_V1::GetSaveGameData() {
 }
 
 void Lua_V1::Load() {
-	lua_Object fileName = lua_getparam(1);
-	if (lua_isnil(fileName)) {
+	lua_Object fileNameObj = lua_getparam(1);
+	if (lua_isnil(fileNameObj)) {
 		g_grim->loadGame("");
-	} else if (lua_isstring(fileName)) {
-		g_grim->loadGame(lua_getstring(fileName));
+	} else if (lua_isstring(fileNameObj)) {
+		Common::String fileName(lua_getstring(fileNameObj));
+		if (g_grim->getGameType() == GType_MONKEY4 &&
+			g_grim->getGamePlatform() == Common::kPlatformPS2) {
+			fileName += ".gsv";
+		}
+		g_grim->loadGame(fileName);
 	} else {
 		warning("Load() fileName is wrong");
 		return;
@@ -637,11 +646,16 @@ void Lua_V1::Load() {
 }
 
 void Lua_V1::Save() {
-	lua_Object fileName = lua_getparam(1);
-	if (lua_isnil(fileName)) {
+	lua_Object fileNameObj = lua_getparam(1);
+	if (lua_isnil(fileNameObj)) {
 		g_grim->saveGame("");
-	} else if (lua_isstring(fileName)) {
-		g_grim->saveGame(lua_getstring(fileName));
+	} else if (lua_isstring(fileNameObj)) {
+		Common::String fileName(lua_getstring(fileNameObj));
+		if (g_grim->getGameType() == GType_MONKEY4 &&
+			g_grim->getGamePlatform() == Common::kPlatformPS2) {
+			fileName += ".gsv";
+		}
+		g_grim->saveGame(fileName);
 	} else {
 		warning("Save() fileName is wrong");
 		return;


### PR DESCRIPTION
Change the memory card id and the reported free space so that the game is able to save.

There are some remaining issues:

* When finished loading a game, the game displays “Save Successful.” This seems to be just a visual bug.

* The game saves without *.gsv file extensions, resulting in filenames such as “efmi000”.  This prevents loading one of these saves from ResidualVM’s menus.

* Save thumbnails are displayed incorrectly.