### PR TITLE
EMI: Implement mesh-specific alpha values

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1446,6 +1446,47 @@ float Actor::getLookAtRate() const {
 	return getCurrentCostume()->getLookAtRate();
 }
 
+EMIModel *Actor::findModelWithMesh(const Common::String &mesh) {
+	for (Common::List<Costume *>::iterator i = _costumeStack.begin(); i != _costumeStack.end(); ++i) {
+		EMICostume *costume = static_cast<EMICostume *>(*i);
+		if (!costume) {
+			continue;
+		}
+		for (int j = 0; j < costume->getNumChores(); j++) {
+			EMIModel *model = costume->getEMIModel(j);
+			if (!model) {
+				continue;
+			}
+			if (mesh == model->_meshName) {
+				return model;
+			}
+		}
+	}
+	return nullptr;
+}
+
+void Actor::setGlobalAlpha(float alpha, const Common::String &mesh) {
+	if (mesh.empty()) {
+		_globalAlpha = alpha;
+	} else {
+		EMIModel *model = findModelWithMesh(mesh);
+		if (model != nullptr) {
+			model->_meshAlpha = alpha;
+		}
+	}
+}
+
+void Actor::setAlphaMode(AlphaMode mode, const Common::String &mesh) {
+	if (mesh.empty()) {
+		_alphaMode = mode;
+	} else {
+		EMIModel *model = findModelWithMesh(mesh);
+		if (model != nullptr) {
+			model->_meshAlphaMode = mode;
+		}
+	}
+}
+
 Costume *Actor::findCostume(const Common::String &n) {
 	for (Common::List<Costume *>::iterator i = _costumeStack.begin(); i != _costumeStack.end(); ++i) {
 		if ((*i)->getFilename().compareToIgnoreCase(n) == 0)

--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -41,6 +41,7 @@ class Set;
 class Material;
 struct SetShadow;
 struct Joint;
+class EMIModel;
 
 struct Plane {
 	Common::String setName;
@@ -538,8 +539,8 @@ public:
 	float getGlobalAlpha() const { return _globalAlpha; }
 	AlphaMode getAlphaMode() const { return _alphaMode; }
 	float getEffectiveAlpha() const { return _alphaMode != AlphaOff ? _globalAlpha : 1.f; }
-	void setGlobalAlpha(float alpha) { _globalAlpha = alpha; }
-	void setAlphaMode(AlphaMode mode) { _alphaMode = mode; }
+	void setGlobalAlpha(float alpha, const Common::String &mesh);
+	void setAlphaMode(AlphaMode mode, const Common::String &mesh);
 
 	int getSortOrder() const;
 	void setSortOrder(const int order);
@@ -587,6 +588,7 @@ private:
 	void calculateOrientation(const Math::Vector3d &pos, Math::Angle *pitch, Math::Angle *yaw, Math::Angle *roll);
 
 	bool getSphereInfo(bool adjustZ, float &size, Math::Vector3d &pos) const;
+	EMIModel *findModelWithMesh(const Common::String &mesh);
 
 	Common::String _name;
 	Common::String _setName;    // The actual current set

--- a/engines/grim/emi/costumeemi.cpp
+++ b/engines/grim/emi/costumeemi.cpp
@@ -315,4 +315,19 @@ EMIModel *EMICostume::getEMIModel() const {
 	return _wearChore->getMesh()->_obj;
 }
 
+EMIModel *EMICostume::getEMIModel(int num) const {
+	if (num >= _numChores) {
+		return nullptr;
+	}
+	EMIChore *chore = static_cast<EMIChore *>(_chores[num]);
+	if (chore == nullptr) {
+		return nullptr;
+	}
+	EMIMeshComponent *mesh = chore->getMesh();
+	if (mesh == nullptr) {
+		return nullptr;
+	}
+	return mesh->_obj;
+}
+
 } // end of namespace Grim

--- a/engines/grim/emi/costumeemi.h
+++ b/engines/grim/emi/costumeemi.h
@@ -60,6 +60,7 @@ public:
 	void setHeadLimits(float yawRange, float maxPitch, float minPitch);
 
 	EMIModel *getEMIModel() const;
+	EMIModel *getEMIModel(int num) const;
 public:
 	EMIChore *_wearChore;
 	EMISkelComponent *_emiSkel;

--- a/engines/grim/emi/lua_v2_actor.cpp
+++ b/engines/grim/emi/lua_v2_actor.cpp
@@ -76,7 +76,7 @@ void Lua_V2::SetActorLocalAlpha() {
 void Lua_V2::SetActorGlobalAlpha() {
 	lua_Object actorObj = lua_getparam(1);
 	lua_Object alphaObj = lua_getparam(2);
-//  lua_Object meshObj = lua_getparam(3);
+	lua_Object meshObj = lua_getparam(3);
 
 	if (!lua_isuserdata(actorObj) || lua_tag(actorObj) != MKTAG('A','C','T','R'))
 		return;
@@ -88,13 +88,17 @@ void Lua_V2::SetActorGlobalAlpha() {
 	if (!lua_isnumber(alphaObj))
 		return;
 
+	const char *mesh = nullptr;
+	if (lua_isstring(meshObj)) {
+		mesh = lua_getstring(meshObj);
+	}
 	float alpha = lua_getnumber(alphaObj);
 	if (alpha == Actor::AlphaOff ||
 	    alpha == Actor::AlphaReplace ||
 	    alpha == Actor::AlphaModulate) {
-			actor->setAlphaMode((Actor::AlphaMode) (int) alpha);
+			actor->setAlphaMode((Actor::AlphaMode) (int) alpha, mesh);
 	} else {
-		actor->setGlobalAlpha(alpha);
+		actor->setGlobalAlpha(alpha, mesh);
 	}
 }
 

--- a/engines/grim/emi/modelemi.cpp
+++ b/engines/grim/emi/modelemi.cpp
@@ -105,6 +105,12 @@ void EMIModel::loadMesh(Common::SeekableReadStream *data) {
 
 	char f[4];
 	data->read(f, 4);
+	for (uint l = 0; l < nameString.size(); ++l) {
+		if (nameString[l] == '\\') {
+			nameString.setChar('/', l);
+		}
+	}
+	_meshName = nameString;
 	_radius = get_float(f);
 	_center->readFromStream(data);
 
@@ -424,6 +430,8 @@ Math::AABB EMIModel::calculateWorldBounds(const Math::Matrix4 &matrix) const {
 
 EMIModel::EMIModel(const Common::String &filename, Common::SeekableReadStream *data, EMICostume *costume) :
 		_fname(filename), _costume(costume) {
+	_meshAlphaMode = Actor::AlphaOff;
+	_meshAlpha = 1.0;
 	_numVertices = 0;
 	_vertices = nullptr;
 	_drawVertices = nullptr;

--- a/engines/grim/emi/modelemi.h
+++ b/engines/grim/emi/modelemi.h
@@ -24,6 +24,7 @@
 #define GRIM_MODELEMI_H
 
 #include "engines/grim/object.h"
+#include "engines/grim/actor.h"
 #include "math/matrix4.h"
 #include "math/vector2d.h"
 #include "math/vector3d.h"
@@ -84,6 +85,9 @@ public:
 		// There are more flags, but their purpose is currently unknown.
 	};
 
+	Common::String _meshName;
+	Actor::AlphaMode _meshAlphaMode;
+	float _meshAlpha;
 	int _numVertices;
 	Math::Vector3d *_vertices;
 	Math::Vector3d *_drawVertices;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -759,6 +759,10 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 		glEnable(GL_BLEND);
 
 	glBegin(GL_TRIANGLES);
+	float alpha = _alpha;
+	if (model->_meshAlphaMode == Actor::AlphaReplace) {
+		alpha *= model->_meshAlpha;
+	}
 	for (uint j = 0; j < face->_faceLength * 3; j++) {
 		int index = indices[j];
 
@@ -770,7 +774,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 			byte r = (byte)(model->_colorMap[index].r * lighting.x());
 			byte g = (byte)(model->_colorMap[index].g * lighting.y());
 			byte b = (byte)(model->_colorMap[index].b * lighting.z());
-			byte a = (int)(model->_colorMap[index].a * _alpha * _currentActor->getLocalAlpha(index));
+			byte a = (int)(model->_colorMap[index].a * alpha * _currentActor->getLocalAlpha(index));
 			glColor4ub(r, g, b, a);
 		}
 

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -708,6 +708,7 @@ void GfxOpenGLS::startActorDraw(const Actor *actor) {
 		_actorProgram->setUniform("useVertexAlpha", GL_FALSE);
 		_actorProgram->setUniform("uniformColor", color);
 		_actorProgram->setUniform1f("alphaRef", 0.0f);
+		_actorProgram->setUniform1f("meshAlpha", 1.0f);
 	} else {
 		Math::Matrix4 modelMatrix = quat.toMatrix();
 		bool hasZBuffer = g_grim->getCurrSet()->getCurrSetup()->_bkgndZBm;
@@ -939,6 +940,7 @@ void GfxOpenGLS::drawEMIModelFace(const EMIModel* model, const EMIMeshFace* face
 	mud->_shader->setUniform("lightsEnabled", _lightsEnabled);
 	mud->_shader->setUniform("swapRandB", _selectedTexture->_colorFormat == BM_BGRA || _selectedTexture->_colorFormat == BM_BGR888);
 	mud->_shader->setUniform("useVertexAlpha", _selectedTexture->_colorFormat == BM_BGRA);
+	mud->_shader->setUniform1f("meshAlpha", (model->_meshAlphaMode == Actor::AlphaReplace) ? model->_meshAlpha : 1.0f);
 
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, face->_indicesEBO);
 

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -686,6 +686,10 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 		tglEnable(TGL_BLEND);
 
 	tglBegin(TGL_TRIANGLES);
+	float alpha = _alpha;
+	if (model->_meshAlphaMode == Actor::AlphaReplace) {
+		alpha *= model->_meshAlpha;
+	}
 	for (uint j = 0; j < face->_faceLength * 3; j++) {
 		int index = indices[j];
 		if (!_currentShadowArray) {
@@ -697,7 +701,7 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 			byte r = (byte)(model->_colorMap[index].r * lighting.x());
 			byte g = (byte)(model->_colorMap[index].g * lighting.y());
 			byte b = (byte)(model->_colorMap[index].b * lighting.z());
-			byte a = (int)(model->_colorMap[index].a * _alpha * _currentActor->getLocalAlpha(index));
+			byte a = (int)(model->_colorMap[index].a * alpha * _currentActor->getLocalAlpha(index));
 			tglColor4ub(r, g, b, a);
 		}
 

--- a/engines/grim/shaders/emi_actor.fragment
+++ b/engines/grim/shaders/emi_actor.fragment
@@ -5,6 +5,7 @@ uniform sampler2D tex;
 uniform bool textured;
 uniform bool swapRandB;
 uniform float alphaRef;
+uniform float meshAlpha;
 
 OUTPUT
 
@@ -18,6 +19,7 @@ void main()
 			texColor.rb = texColor.br;
 #endif
 		outColor.rgba *= texColor.rgba;
+		outColor.a *= meshAlpha;
 		if (outColor.a < alphaRef)
 			discard;
 	}


### PR DESCRIPTION
* if Lua_V2::SetActorGlobalAlpha() is called with a mesh name,
  set a mesh-specific alpha value / mode
* use this alpha value in drawEMIModelFace()
* this commit fixes the problem that the whole actor vanishs in some scenes
   * issue #896: when entering or leaving the porch of the of LUA bar 
   * issue #1151: when jumping out/in the bank window)
* instead of fading the actor in or out, only his shadow is faded correctly
* implemented for all 3 graphic drivers

