### PR TITLE
EMI: Flip y coordinate when creating screenshot textures

### DIFF
--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -2057,8 +2057,10 @@ Bitmap *GfxOpenGLS::getScreenshot(int w, int h, bool useStored) {
 		char *buffer = new char[_screenWidth * _screenHeight * 4];
 
 		glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
-		memcpy(src.getRawBuffer(), buffer, _screenWidth * _screenHeight * 4);
-
+		byte *rawBuf = src.getRawBuffer();
+		for (int i = 0; i < _screenHeight; i++) {
+			memcpy(&(rawBuf[(_screenHeight - i - 1) * _screenWidth * 4]), &buffer[4 * _screenWidth * i], _screenWidth * 4);
+		}
 		delete[] buffer;
 	} else
 #endif


### PR DESCRIPTION
With OpenGL the created textures were mirrored in y direction
because OpenGL uses a different coordinate system where (0, 0)
is the bottom left corner.

This fixes the problem that the savegame screenshots are upside-down when using the OpenGLS renderer.