### PR TITLE
EMI: Check bit in mesh face flags to disable lighting

### DIFF
--- a/engines/grim/emi/modelemi.h
+++ b/engines/grim/emi/modelemi.h
@@ -64,6 +64,7 @@ public:
 	EMIModel *_parent;
 
 	enum MeshFaceFlags {
+		kNoLighting = 0x20, // guessed, but distinctive for screen actors
 		kAlphaBlend = 0x10000,
 		kUnknownBlend = 0x40000 // used only in intro screen actors
 	};

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -763,6 +763,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 	if (model->_meshAlphaMode == Actor::AlphaReplace) {
 		alpha *= model->_meshAlpha;
 	}
+	Math::Vector3d noLighting(1.f, 1.f, 1.f);
 	for (uint j = 0; j < face->_faceLength * 3; j++) {
 		int index = indices[j];
 
@@ -770,7 +771,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 			if (face->_hasTexture) {
 				glTexCoord2f(model->_texVerts[index].getX(), model->_texVerts[index].getY());
 			}
-			Math::Vector3d lighting = model->_lighting[index];
+			Math::Vector3d lighting = (face->_flags & EMIMeshFace::kNoLighting) ? noLighting : model->_lighting[index];
 			byte r = (byte)(model->_colorMap[index].r * lighting.x());
 			byte g = (byte)(model->_colorMap[index].g * lighting.y());
 			byte b = (byte)(model->_colorMap[index].b * lighting.z());

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -937,7 +937,7 @@ void GfxOpenGLS::drawEMIModelFace(const EMIModel* model, const EMIMeshFace* face
 	mud->_shader->use();
 	bool textured = face->_hasTexture && !_currentShadowArray;
 	mud->_shader->setUniform("textured", textured ? GL_TRUE : GL_FALSE);
-	mud->_shader->setUniform("lightsEnabled", _lightsEnabled);
+	mud->_shader->setUniform("lightsEnabled", (face->_flags & EMIMeshFace::kNoLighting) ? false : _lightsEnabled);
 	mud->_shader->setUniform("swapRandB", _selectedTexture->_colorFormat == BM_BGRA || _selectedTexture->_colorFormat == BM_BGR888);
 	mud->_shader->setUniform("useVertexAlpha", _selectedTexture->_colorFormat == BM_BGRA);
 	mud->_shader->setUniform1f("meshAlpha", (model->_meshAlphaMode == Actor::AlphaReplace) ? model->_meshAlpha : 1.0f);

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -690,6 +690,7 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 	if (model->_meshAlphaMode == Actor::AlphaReplace) {
 		alpha *= model->_meshAlpha;
 	}
+	Math::Vector3d noLighting(1.f, 1.f, 1.f);
 	for (uint j = 0; j < face->_faceLength * 3; j++) {
 		int index = indices[j];
 		if (!_currentShadowArray) {
@@ -697,7 +698,7 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 				tglTexCoord2f(model->_texVerts[index].getX(), model->_texVerts[index].getY());
 			}
 
-			Math::Vector3d lighting = model->_lighting[index];
+			Math::Vector3d lighting = (face->_flags & EMIMeshFace::kNoLighting) ? noLighting : model->_lighting[index];
 			byte r = (byte)(model->_colorMap[index].r * lighting.x());
 			byte g = (byte)(model->_colorMap[index].g * lighting.y());
 			byte b = (byte)(model->_colorMap[index].b * lighting.z());


### PR DESCRIPTION
Use bit 0x20 in the mesh face flags to disable ligthing. This fixes the problem that once a previous screen is used as texture (e.g. in the intro or for the transition effects in set kab when walking eastwards or westwards), it is shown too dark due to the applied static lighting for overworld actors. When drawing the according faces for these actors, lighting should be disabled.

This commit fixes issue #1045.

Additionally, it fixes the same problem in the intro: the transition effects are too dark, too.

Note: using bit 0x20 is just a guess, but this bit is distinctive for the affected costumes/meshes. Alternatively, we could just use "kUnknownBlend" bit which would also fit.
