### PR TITLE
RFC Enable GRIM glsl lighting

### DIFF
--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1112,8 +1112,8 @@ void GfxOpenGLS::setupLight(Grim::Light *light, int lightId) {
 		lightPos = Math::Vector4d(-light->_dir.x(), -light->_dir.y(), -light->_dir.z(), 0.0f);
 		lightDir = Math::Vector4d(0.0f, 0.0f, 0.0f, -1.0f);
 	} else if (light->_type == Grim::Light::Spot) {
-		float cosPenumbra = cos(light->_penumbraangle);
-		float cosUmbra = cos(light->_umbraangle);
+		float cosPenumbra = cosf(light->_penumbraangle * M_PI / 180.0f);
+		float cosUmbra = cosf(light->_umbraangle * M_PI / 180.0f);
 		lightPos = Math::Vector4d(light->_pos.x(), light->_pos.y(), light->_pos.z(), 1.0f);
 		lightDir = Math::Vector4d(light->_dir.x(), light->_dir.y(), light->_dir.z(), 1.0f);
 		lightParams = Math::Vector4d(light->_falloffNear, light->_falloffFar, cosPenumbra, cosUmbra);

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1094,10 +1094,10 @@ void GfxOpenGLS::setupLight(Grim::Light *light, int lightId) {
 	} else {
 		intensity /= 15.0f;
 	}
-	lightColor.x() = (float)light->_color.getRed() * intensity;
-	lightColor.y() = (float)light->_color.getGreen() * intensity;
-	lightColor.z() = (float)light->_color.getBlue() * intensity;
-	lightColor.w() = 1.0f;
+	lightColor.x() = (float)light->_color.getRed();
+	lightColor.y() = (float)light->_color.getGreen();
+	lightColor.z() = (float)light->_color.getBlue();
+	lightColor.w() = intensity;
 
 	if (light->_type == Grim::Light::Omni) {
 		lightPos = Math::Vector4d(light->_pos.x(), light->_pos.y(), light->_pos.z(), 1.0f);

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -779,10 +779,8 @@ void GfxOpenGLS::startActorDraw(const Actor *actor) {
 			uniform = Common::String::format("lights[%u]._color", i);
 			_actorProgram->setUniform(uniform.c_str(), l._color);
 
-			if (g_grim->getGameType() == GType_MONKEY4) {
-				uniform = Common::String::format("lights[%u]._params", i);
-				_actorProgram->setUniform(uniform.c_str(), l._params);
-			}
+			uniform = Common::String::format("lights[%u]._params", i);
+			_actorProgram->setUniform(uniform.c_str(), l._params);
 		}
 	}
 }

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -717,14 +717,11 @@ void GfxOpenGLS::startActorDraw(const Actor *actor) {
 		modelMatrix.transpose();
 		modelMatrix.setPosition(pos);
 		modelMatrix.transpose();
-		_mvpMatrix = _viewMatrix * modelMatrix;
-		_mvpMatrix.transpose();
 
 		_actorProgram->setUniform("modelMatrix", modelMatrix);
 		_actorProgram->setUniform("viewMatrix", _viewMatrix);
 		_actorProgram->setUniform("projMatrix", _projMatrix);
 		_actorProgram->setUniform("extraMatrix", extraMatrix);
-		_actorProgram->setUniform("mvpMatrix", _mvpMatrix);
 		_actorProgram->setUniform("tex", 0);
 		_actorProgram->setUniform("texZBuf", 1);
 		_actorProgram->setUniform("hasZBuffer", hasZBuffer);

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1093,19 +1093,16 @@ void GfxOpenGLS::setupLight(Grim::Light *light, int lightId) {
 	Math::Vector4d &lightDir    = _lights[lightId]._direction;
 	Math::Vector4d &lightParams = _lights[lightId]._params;
 
+	float intensity = light->_intensity;
 	if (g_grim->getGameType() == GType_MONKEY4) {
-		float intensity = light->_intensity;
-		lightColor.x() = ((float)light->_color.getRed() / 255.0f) * intensity;
-		lightColor.y() = ((float)light->_color.getGreen() / 255.0f) * intensity;
-		lightColor.z() = ((float)light->_color.getBlue() / 255.0f) * intensity;
-		lightColor.w() = 1.0f;
+		intensity /= 255.0f;
 	} else {
-		float intensity = light->_intensity / 1.3f;
-		lightColor.x() = ((float)light->_color.getRed() / 15.0f) * intensity;
-		lightColor.y() = ((float)light->_color.getGreen() / 15.0f) * intensity;
-		lightColor.z() = ((float)light->_color.getBlue() / 15.0f) * intensity;
-		lightColor.w() = 1.0f;
+		intensity /= 15.0f;
 	}
+	lightColor.x() = (float)light->_color.getRed() * intensity;
+	lightColor.y() = (float)light->_color.getGreen() * intensity;
+	lightColor.z() = (float)light->_color.getBlue() * intensity;
+	lightColor.w() = 1.0f;
 
 	if (light->_type == Grim::Light::Omni) {
 		lightPos = Math::Vector4d(light->_pos.x(), light->_pos.y(), light->_pos.z(), 1.0f);

--- a/engines/grim/shaders/emi_actor.vertex
+++ b/engines/grim/shaders/emi_actor.vertex
@@ -84,40 +84,43 @@ void main()
 	}
 
 	if (lightsEnabled) {
-		vec3 light = vec3(0,0,0);
-		vec3 normalEye = (normalMatrix * vec4(normal, 1.0)).xyz;
+		vec3 light = vec3(0.0, 0.0, 0.0);
+		vec3 normalEye = normalize((normalMatrix * vec4(normal, 1.0)).xyz);
 
 		for (int i = 0; i < maxLights; ++i) {
-			if (lights[i]._color.w != 0.0) { // Enabled?
-				vec3 color = lights[i]._color.xyz;
-				if (lights[i]._position.w == 1.0) { // Omnidirectional or spotlight
-					vec3 vertexToLight = lights[i]._position.xyz - pos.xyz;
+			float intensity = lights[i]._color.w;
+			float light_type = lights[i]._position.w;
+			if (light_type >= 0.0) { // Not ambient
+				vec3 vertexToLight;
+				if (light_type > 0.0) { // positional light
 					float falloffNear = lights[i]._params.x;
-					float falloffFar = lights[i]._params.y;
+					float falloffFar = max(falloffNear, lights[i]._params.y);
+					vertexToLight = lights[i]._position.xyz - pos.xyz;
 					float dist = length(vertexToLight);
-
-					float attn = clamp(1.0 - (dist - falloffNear) / max(0.001, falloffFar - falloffNear), 0.0, 1.0);
-					color *= attn;
-
-					vertexToLight = normalize(vertexToLight);
-					float incidence = max(0.0, dot(normalEye, vertexToLight));
-					color *= incidence;
-
-					if (lights[i]._direction.w != -1.0) { // Spotlight
-						float cosAngle = max(0.0, dot(lights[i]._direction.xyz, vertexToLight));
-						float cosPenumbra = lights[i]._params.z;
-						float cosUmbra = lights[i]._params.w;
-						float cone = clamp((cosAngle - cosPenumbra) / max(0.001, cosUmbra - cosPenumbra), 0.0, 1.0);
-						color *= cone;
+					if (falloffFar == falloffNear) {
+						intensity = 0.0;
+					} else {
+						intensity *= clamp(1.0 - (dist - falloffNear) / (falloffFar - falloffNear), 0.0, 1.0);
 					}
-				} else if (lights[i]._direction.w == -1.0) { // Ambient or directional
-					if (lights[i]._position.w != -1.0) { // Directional
-						float incidence = max(0.0, dot(normalEye, -lights[i]._position.xyz));
-						color *= incidence;
+					if (lights[i]._direction.w > -1.0) { // Spotlight
+						// See DirectX spotlight documentation
+						float cosAngle = -dot(normalize(vertexToLight), normalize(lights[i]._direction.xyz)); // rho
+						float cosPenumbra = clamp(lights[i]._params.w, 0.0, 1.0); // cos(theta / 2)
+						float cosUmbra = clamp(lights[i]._params.z, 0.0, cosPenumbra); // cos(phi / 2)
+						if (cosAngle <= cosPenumbra) {
+							if (cosAngle < cosUmbra || cosPenumbra == cosUmbra) {
+								intensity = 0.0;
+							} else {
+								intensity *= (cosAngle - cosUmbra) / (cosPenumbra - cosUmbra);
+							}
+						}
 					}
+				} else { // directional light
+					vertexToLight = -lights[i]._position.xyz;
 				}
-				light += color;
+				intensity *= max(0.0, dot(normalEye, normalize(vertexToLight)));
 			}
+			light += lights[i]._color.xyz * intensity;
 		}
 
 		if (!hasAmbient)

--- a/engines/grim/shaders/emi_actor.vertex
+++ b/engines/grim/shaders/emi_actor.vertex
@@ -73,7 +73,11 @@ void main()
 
 	gl_Position = projectedPos;
 
-	Color = color;
+	if (shadow._active) {
+		Color = vec4(shadow._color, 1.0);
+	} else {
+		Color = color;
+	}
 	if (!useVertexAlpha)
 		Color.a = 1.0;
 	Color *= uniformColor;

--- a/engines/grim/shaders/grim_actor.vertex
+++ b/engines/grim/shaders/grim_actor.vertex
@@ -1,18 +1,3 @@
-struct Light {
-	vec4 _position;
-	vec4 _direction;
-	vec4 _color;
-};
-
-struct shadow_info {
-	bool _active;
-	vec3 _color;
-	vec3 _light;
-	vec3 _point;
-	vec3 _normal;
-};
-
-const int maxLights = 8;
 const float DIFFUSE_FACTOR = 0.8;
 
 in vec3 position;
@@ -24,11 +9,27 @@ uniform highp mat4 modelMatrix;
 uniform highp mat4 viewMatrix;
 uniform highp mat4 projMatrix;
 uniform highp mat4 extraMatrix;
-uniform highp vec2 texScale;
 uniform bool textured;
-uniform Light lights[maxLights];
-uniform shadow_info shadow;
 uniform bool lightsEnabled;
+uniform highp vec2 texScale;
+
+struct Light {
+	vec4 _position;
+	vec4 _direction;
+	vec4 _color;
+};
+const int maxLights = 8;
+uniform Light lights[maxLights];
+
+struct shadow_info {
+	bool _active;
+	vec3 _color;
+	vec3 _light;
+	vec3 _point;
+	vec3 _normal;
+};
+
+uniform shadow_info shadow;
 
 out vec2 Texcoord;
 out vec4 Color;

--- a/engines/grim/shaders/grim_actor.vertex
+++ b/engines/grim/shaders/grim_actor.vertex
@@ -1,4 +1,4 @@
-struct light {
+struct Light {
 	vec4 _position;
 	vec4 _direction;
 	vec4 _color;
@@ -26,7 +26,7 @@ uniform highp mat4 projMatrix;
 uniform highp mat4 extraMatrix;
 uniform highp vec2 texScale;
 uniform bool textured;
-uniform light lights[maxLights];
+uniform Light lights[maxLights];
 uniform shadow_info shadow;
 uniform bool lightsEnabled;
 

--- a/engines/grim/shaders/grim_actor.vertex
+++ b/engines/grim/shaders/grim_actor.vertex
@@ -17,6 +17,7 @@ struct Light {
 	vec4 _position;
 	vec4 _direction;
 	vec4 _color;
+	vec4 _params;
 };
 const int maxLights = 8;
 uniform Light lights[maxLights];

--- a/engines/grim/shaders/grim_actor.vertex
+++ b/engines/grim/shaders/grim_actor.vertex
@@ -1,4 +1,6 @@
-const float DIFFUSE_FACTOR = 0.8;
+const float CONSTANT_ATTENUATION = 0.0;
+const float LINEAR_ATTENUATION = 0.0;
+const float QUADRATIC_ATTENUATION = 1.0;
 
 in vec3 position;
 in vec2 texcoord;
@@ -37,11 +39,7 @@ out vec4 Color;
 
 void main()
 {
-	vec4 pos = vec4(position, 1.0);
-
-	pos = modelMatrix *
-	      extraMatrix *
-	      pos;
+	vec4 pos = modelMatrix * extraMatrix * vec4(position, 1.0);
 
 	// See http://en.wikipedia.org/wiki/Line-plane_intersection
 	if (shadow._active) {
@@ -52,7 +50,8 @@ void main()
 		pos = vec4(p, 1.0);
 	}
 
-	gl_Position = projMatrix * viewMatrix * pos;
+	vec4 positionView = viewMatrix * pos;
+	gl_Position = projMatrix * positionView;
 
 	if (textured) {
 		Texcoord = vec2(0.0, 1.0) + (texcoord / texScale);
@@ -60,37 +59,39 @@ void main()
 		Texcoord = vec2(0.0, 0.0);
 	}
 
-/*
-	if (lightsEnabled) {
-		vec3 normal_eye = normalize((mvpMatrix * extraMatrix * vec4(normal, 0.0))).xyz;
+	if (shadow._active) {
+		Color = vec4(shadow._color, 1.0);
+	} else if (lightsEnabled) {
 		vec3 light = vec3(0.0, 0.0, 0.0);
+		vec3 normalEye = normalize((viewMatrix * (modelMatrix * extraMatrix * vec4(normal, 0.0))).xyz);
+
 		for (int i = 0; i < maxLights; ++i) {
-			if (lights[i]._color.w != 0.0) {
-				vec3 faceToLight = normalize(lights[i]._position - pos).xyz;
-				if (lights[i]._position.w == 1.0) {
-					float incidence = dot(normal_eye, faceToLight);
-					if (incidence > 0.0) {
-						if (lights[i]._direction.w == -1.0) {
-							light += incidence * DIFFUSE_FACTOR * lights[i]._color.rgb;
-						} else {
-							vec3 lightDir = normalize(lights[i]._direction.xyz);
-							float cos_angle = dot(lightDir, faceToLight);
-							float incidence2 = max(-cos_angle, 0.0);
-							light += incidence2 * DIFFUSE_FACTOR * lights[i]._color.rgb;
+			float intensity = lights[i]._color.w;
+			float light_type = lights[i]._position.w;
+			if (light_type >= 0.0) { // Not ambient
+				vec3 vertexToLight = lights[i]._position.xyz;
+				if (light_type > 0.0) { // positional light
+					vertexToLight -= positionView.xyz;
+					float dist = length(vertexToLight);
+					intensity /= CONSTANT_ATTENUATION + dist * (LINEAR_ATTENUATION + dist * QUADRATIC_ATTENUATION);
+					if (lights[i]._direction.w > -1.0) { // Spotlight
+						// See DirectX spotlight documentation
+						float cosAngle = -dot(normalize(vertexToLight), normalize(lights[i]._direction.xyz)); // rho
+						float cosPenumbra = clamp(lights[i]._params.w, 0.0, 1.0); // cos(theta / 2)
+						float cosUmbra = clamp(lights[i]._params.z, 0.0, cosPenumbra); // cos(phi / 2)
+						if (cosAngle <= cosPenumbra) {
+							if (cosAngle < cosUmbra || cosPenumbra == cosUmbra) {
+								intensity = 0.0;
+							} else {
+								intensity *= (cosAngle - cosUmbra) / (cosPenumbra - cosUmbra);
+							}
 						}
 					}
-				} else {
-					vec3 lightDir = normalize(lights[i]._position.xyz);
-					float incidence = dot(lightDir, faceToLight);
-					light += max(-incidence, 0.0) * DIFFUSE_FACTOR * lights[i]._color.rgb;
 				}
+				intensity *= max(0.0, dot(normalEye, normalize(vertexToLight)));
 			}
+			light += lights[i]._color.xyz * intensity;
 		}
-		Color = color * vec4(light, 1.0);
-	} else */ {
-		Color = color;
-		if (shadow._active) {
-			Color = vec4(shadow._color, 1.0);
-		}
+		Color = clamp(vec4(color.xyz * light, color.w), 0.0, 1.0);
 	}
 }


### PR DESCRIPTION
This patch set enables lighting code in actor vertex shader.
This is my first stab at shaders, so please carefully review and tell me what I'm doing wrong.
I tried to change as little CPU as possible, because I'm afraid of all the special-casing for GRIM vs. EMI.
I did move attenuation computation to shader, though, which required me to update EMI shader. Was this a good idea ? My idea is that shader needs to multiply color with per-vertex intensity anyway, so rather than starting at intensity 1.0 and reducing it with normal-to-light, distance and cone attenuation, I should be able to just start at intensity and do the same for the same cost. I also tried to code the shader defensively whenever a divide-by-zero is possible, although I would tend to trust game data.