### PR TITLE
GRIM: SHADERS: Enable GL_BLEND when texture has transparency.

### DIFF
--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1203,7 +1203,7 @@ void GfxOpenGLS::selectTexture(const Texture *texture) {
 	GLuint *textures = (GLuint *)texture->_texture;
 	glBindTexture(GL_TEXTURE_2D, textures[0]);
 
-	if (texture->_hasAlpha && g_grim->getGameType() == GType_MONKEY4) {
+	if (texture->_hasAlpha) {
 		glEnable(GL_BLEND);
 	}
 


### PR DESCRIPTION
Fixes, likely among others, the tie rope in set "al".