### PR TITLE
EMI: Start animation when "Loop" key is set

### DIFF
--- a/engines/grim/emi/costume/emianim_component.cpp
+++ b/engines/grim/emi/costume/emianim_component.cpp
@@ -69,6 +69,7 @@ void EMIAnimComponent::setKey(int f) {
 		break;
 	case 3: // Loop
 		_animState->setLooping(true);
+		_animState->play();
 		break;
 	case 4: // No loop
 		_animState->setLooping(false);


### PR DESCRIPTION
This fixes the problem if the costume uses only key 3 ("Loop") but not
key 1 ("Play") for an animation. This happens e.g. for Pegnose's "run" chore (issue #1169).

