### PR TITLE
GRIM/EMI: Re-use TextObjects with the same textID and layer

### DIFF
--- a/engines/grim/lua.h
+++ b/engines/grim/lua.h
@@ -165,6 +165,7 @@ private:
 	int _translationMode;
 	unsigned int _frameTimeCollection;
 
+public:
 	int refSystemTable;
 	int refTypeOverride;
 	int refOldConcatFallback;

--- a/engines/grim/lua_v1_text.cpp
+++ b/engines/grim/lua_v1_text.cpp
@@ -107,12 +107,35 @@ void Lua_V1::MakeTextObject() {
 	if (!lua_isstring(textObj)) {
 		return;
 	}
-
-	TextObject *textObject = new TextObject();
-	const char *line = lua_getstring(textObj);
-
-	textObject->setDefaults(&g_grim->_blastTextDefaults);
 	lua_Object tableObj = lua_getparam(2);
+
+	int layer = 0;
+	if (lua_istable(tableObj)) {
+		lua_Object keyObj;
+		lua_pushobject(tableObj);
+		lua_pushobject(lua_getref(refTextObjectLayer));
+		keyObj = lua_gettable();
+		if (keyObj) {
+			if (lua_isnumber(keyObj)) {
+				layer = lua_getnumber(keyObj);
+			}
+		}
+	}
+
+	// Re-use text object if the Id and the layer match
+	TextObject *textObject = nullptr;
+	const char *line = lua_getstring(textObj);
+	foreach (TextObject *t, TextObject::getPool()) {
+		if (t->getName().equals(line) && t->getLayer() == layer) {
+			textObject = t;
+			break;
+		}
+	}
+	if (textObject == nullptr) {
+		textObject = new TextObject();
+		textObject->setDefaults(&g_grim->_blastTextDefaults);
+	}
+
 	if (lua_istable(tableObj))
 		setTextObjectParams(textObject, tableObj);
 


### PR DESCRIPTION
Re-use existing TextObjects in MakeTextObjects() in order
to avoid a massive duplications in case the LUA code
calls MakeTextObject multiple times for the same text
but with a different color.

Note:
In EMI, the menus are using 2 TextObjects with the same textID
with different colors but with a different layer.

This fixes the issue that in the credits of EMI the colors
were off (issue #1155)  since there were multiple TextObjects for the same
textID but each with a different color (one per fade step). 