### PR TITLE
WIP: Multisampling for framebuffers

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -458,7 +458,11 @@ Graphics::PixelBuffer SurfaceSdlGraphicsManager::setupScreen(uint screenW, uint 
 			&& !g_engine->hasFeature(Engine::kSupportsArbitraryResolutions)
 			&& framebufferSupported) {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		_frameBuffer = new Graphics::FrameBuffer(fbW, fbH);
+		if (_antialiasing) {
+			_frameBuffer = new Graphics::MultiSampleFrameBuffer(fbW, fbH);
+		} else {
+			_frameBuffer = new Graphics::FrameBuffer(fbW, fbH);
+		}
 		_frameBuffer->attach();
 	}
 #endif

--- a/graphics/opengl/framebuffer.cpp
+++ b/graphics/opengl/framebuffer.cpp
@@ -38,7 +38,9 @@
 #define GL_STENCIL_ATTACHMENT GL_STENCIL_ATTACHMENT_EXT
 #define GL_STENCIL_INDEX8 GL_STENCIL_INDEX8_EXT
 #define GL_DEPTH24_STENCIL8 0x88F0
-#endif
+#define GL_READ_FRAMEBUFFER 0x8CA8
+#define GL_DRAW_FRAMEBUFFER 0x8CA9
+#endif // defined(GL_ARB_framebuffer_object)
 #include "backends/platform/sdl/sdl-sys.h"
 #endif // defined(SDL_BACKEND)
 
@@ -62,6 +64,11 @@ static PFNGLFRAMEBUFFERTEXTURE2DEXTPROC glFramebufferTexture2D;
 static PFNGLGENFRAMEBUFFERSEXTPROC glGenFramebuffers;
 static PFNGLGENRENDERBUFFERSEXTPROC glGenRenderbuffers;
 static PFNGLRENDERBUFFERSTORAGEEXTPROC glRenderbufferStorage;
+typedef void (* PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
+static PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisample;
+typedef void (* PFNGLBLITFRAMEBUFFEREXTPROC) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+static PFNGLBLITFRAMEBUFFEREXTPROC glBlitFramebuffer;
+
 
 static void grabFramebufferObjectPointers() {
 	if (framebuffer_object_functions)
@@ -75,6 +82,8 @@ static void grabFramebufferObjectPointers() {
 	// We're casting from an object pointer to a function pointer, the
 	// sizes need to be the same for this to work.
 	assert(sizeof(u.obj_ptr) == sizeof(u.func_ptr));
+	u.obj_ptr = SDL_GL_GetProcAddress("glBlitFramebuffer");
+	glBlitFramebuffer = (PFNGLBLITFRAMEBUFFEREXTPROC)u.func_ptr;
 	u.obj_ptr = SDL_GL_GetProcAddress("glBindFramebuffer");
 	glBindFramebuffer = (PFNGLBINDFRAMEBUFFEREXTPROC)u.func_ptr;
 	u.obj_ptr = SDL_GL_GetProcAddress("glBindRenderbuffer");
@@ -95,6 +104,8 @@ static void grabFramebufferObjectPointers() {
 	glGenRenderbuffers = (PFNGLGENRENDERBUFFERSEXTPROC)u.func_ptr;
 	u.obj_ptr = SDL_GL_GetProcAddress("glRenderbufferStorage");
 	glRenderbufferStorage = (PFNGLRENDERBUFFERSTORAGEEXTPROC)u.func_ptr;
+	u.obj_ptr = SDL_GL_GetProcAddress("glRenderbufferStorageMultisample");
+	glRenderbufferStorageMultisample = (PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC)u.func_ptr;
 }
 #endif // defined(SDL_BACKEND) && !defined(USE_GLEW)
 

--- a/graphics/opengl/framebuffer.cpp
+++ b/graphics/opengl/framebuffer.cpp
@@ -96,7 +96,7 @@ static void grabFramebufferObjectPointers() {
 	u.obj_ptr = SDL_GL_GetProcAddress("glRenderbufferStorage");
 	glRenderbufferStorage = (PFNGLRENDERBUFFERSTORAGEEXTPROC)u.func_ptr;
 }
-#endif // defined(SDL_BACKEND) && !defined(USE_OPENGL_SHADERS)
+#endif // defined(SDL_BACKEND) && !defined(USE_GLEW)
 
 
 
@@ -178,6 +178,67 @@ void FrameBuffer::attach() {
 void FrameBuffer::detach() {
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
+
+#if defined(SDL_BACKEND) && !defined(AMIGAOS)
+MultiSampleFrameBuffer::MultiSampleFrameBuffer(uint width, uint height)
+	: FrameBuffer(width,height) {
+	if (!Graphics::isExtensionSupported("GL_EXT_framebuffer_multisample")) {
+		error("GL_EXT_framebuffer_multisample extension is not supported!");
+	}
+	if (!Graphics::isExtensionSupported("GL_EXT_framebuffer_blit")) {
+		error("GL_EXT_framebuffer_blit extension is not supported!");
+	}
+	init();
+}
+
+MultiSampleFrameBuffer::~MultiSampleFrameBuffer() {
+	glDeleteRenderbuffers(1, &_msColorId);
+	glDeleteRenderbuffers(1, &_msDepthId);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glDeleteFramebuffers(1, &_msFrameBufferId);
+}
+
+//TODO: fallback to fewer samples
+void MultiSampleFrameBuffer::init() {
+	glGenFramebuffers(1, &_msFrameBufferId);
+	glBindFramebuffer(GL_FRAMEBUFFER, _msFrameBufferId);
+
+	glGenRenderbuffers(1, &_msColorId);
+	glBindRenderbuffer(GL_RENDERBUFFER, _msColorId);
+	glRenderbufferStorageMultisample(GL_RENDERBUFFER, 8, GL_RGBA8, getTexWidth(), getTexHeight());
+
+	glGenRenderbuffers(1, &_msDepthId);
+	glBindRenderbuffer(GL_RENDERBUFFER, _msDepthId);
+	glRenderbufferStorageMultisample(GL_RENDERBUFFER, 8, GL_DEPTH24_STENCIL8, getTexWidth(), getTexHeight());
+
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, _msColorId);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _msDepthId);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _msDepthId);
+
+	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	if (status != GL_FRAMEBUFFER_COMPLETE)
+		error("Framebuffer is not complete! status: %d", status);
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void MultiSampleFrameBuffer::attach() {
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, getFrameBufferName());
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _msFrameBufferId);
+	glViewport(0,0, getWidth(), getHeight());
+
+	glClearColor(0, 0, 0, 1.0f);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+}
+
+void MultiSampleFrameBuffer::detach() {
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, _msFrameBufferId);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, getFrameBufferName());
+	glBlitFramebuffer(0, 0, getWidth(), getHeight(), 0, 0, getWidth(), getHeight(), GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+#endif // defined(SDL_BACKEND) && !defined(AMIGAOS)
 
 }
 

--- a/graphics/opengl/framebuffer.h
+++ b/graphics/opengl/framebuffer.h
@@ -33,22 +33,42 @@ public:
 	FrameBuffer(uint width, uint height);
 	FrameBuffer(GLuint texture_name, uint width, uint height, uint texture_width, uint texture_height);
 #ifdef AMIGAOS
-	~FrameBuffer() {}
+	virtual ~FrameBuffer() {}
 
 	void attach() {}
 	void detach() {}
 #else
-	~FrameBuffer();
+	virtual ~FrameBuffer();
 
-	void attach();
-	void detach();
+	virtual void attach();
+	virtual void detach();
 #endif
+
+protected:
+	GLuint getFrameBufferName() const { return _frameBuffer; }
 
 private:
 	void init();
 	GLuint _renderBuffers[2];
 	GLuint _frameBuffer;
 };
+
+#if defined(SDL_BACKEND) && !defined(AMIGAOS)
+class MultiSampleFrameBuffer : public FrameBuffer {
+public:
+	MultiSampleFrameBuffer(uint width, uint height);
+	~MultiSampleFrameBuffer();
+
+	virtual void attach();
+	virtual void detach();
+
+private:
+	void init();
+	GLuint _msFrameBufferId;
+	GLuint _msColorId;
+	GLuint _msDepthId;
+};
+#endif
 
 }
 


### PR DESCRIPTION
I wrote code to enable multisampling for fullscreen framebuffers.
Is there interest in merging this?
I only tested with the shader renderer for now.
This is an OpenGL-only feature, to restore anti-aliasing for people who force it on in their drivers.

Before: https://www.dropbox.com/s/6933731ffq4scu7/without_multisampling.png?dl=0
After: https://www.dropbox.com/s/3iwsxt8kw9gpg5a/with_multisampling.png?dl=0

Known issues:
- [x] Probably linking issues on Windows
- [x] No fallback for Amiga
- [ ] No fallback or error checking in general.
- [x] ADDED: `GfxOpenGLShaders::storeDisplay` is broken (cannot `glReadPixels` from a MS framebuffer