### PR TITLE
Implement drawing of dynamically created layers

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -309,8 +309,6 @@ bool BitmapData::loadTile(Common::SeekableReadStream *o) {
 
 	o->seek(16, SEEK_CUR);
 	int numSubImages = o->readUint32LE();
-	if (numSubImages < 5)
-		error("Can not handle a tile with less than 5 sub images");
 
 	char **data = new char *[numSubImages];
 

--- a/engines/grim/emi/emi.h
+++ b/engines/grim/emi/emi.h
@@ -24,6 +24,7 @@
 #define EMI_ENGINE_H
 
 #include "engines/grim/grim.h"
+#include "engines/grim/emi/layer.h"
 
 namespace Grim {
 
@@ -56,8 +57,11 @@ private:
 	void drawTextObjects() override;
 	static bool compareActor(const Actor *x, const Actor *y);
 	void sortTextObjects();
+	static bool compareLayer(const Layer *x, const Layer *y);
+	void sortLayers();
 
 	Common::List<TextObject *> _textObjects;
+	Common::List<Layer *> _layers;
 
 	bool _textObjectsSortOrderInvalidated;
 	bool _sortOrderInvalidated;

--- a/engines/grim/emi/layer.h
+++ b/engines/grim/emi/layer.h
@@ -44,7 +44,7 @@ public:
 	void setFrame(int frame);
 	void setSortOrder(int order);
 	void advanceFrame(int num);
-	int getSortOrder() { return _sortOrder; }
+	int getSortOrder() const { return _sortOrder; }
 
 	void saveState(SaveGame *state);
 	void restoreState(SaveGame *state);

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -676,11 +676,13 @@ void Lua_V2::SetLayerFrame() {
 void Lua_V2::SetLayerSortOrder() {
 	lua_Object param1 = lua_getparam(1);
 	lua_Object param2 = lua_getparam(2);
-	if (lua_isuserdata(param1) && lua_tag(param1) != MKTAG('L','A','Y','R') && lua_isnumber(param2)) {
+	if (lua_isuserdata(param1) && lua_tag(param1) == MKTAG('L','A','Y','R') && lua_isnumber(param2)) {
 		int layer = (int)lua_getuserdata(param1);
 		int sortorder = (int)lua_getnumber(param2);
 		Layer *l = Layer::getPool().getObject(layer);
 		l->setSortOrder(sortorder);
+	} else {
+		warning("Lua_V2::SetLayerSortOrder: wrong parameters");
 	}
 }
 

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1137,8 +1137,8 @@ void GfxOpenGL::createBitmap(BitmapData *bitmap) {
 void GfxOpenGL::drawBitmap(const Bitmap *bitmap, int dx, int dy, uint32 layer) {
 	// The PS2 version of EMI uses a TGA for it's splash-screen
 	// avoid using the TIL-code below for that, by checking
-	// numImages here:
-	if (g_grim->getGameType() == GType_MONKEY4 && bitmap->_data->_numImages > 1) {
+	// for texture coordinates set by BitmapData::loadTile
+	if (g_grim->getGameType() == GType_MONKEY4 && bitmap->_data && bitmap->_data->_texc) {
 		glMatrixMode(GL_MODELVIEW);
 		glPushMatrix();
 		glLoadIdentity();

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1339,7 +1339,7 @@ void GfxOpenGLS::createBitmap(BitmapData *bitmap) {
 }
 
 void GfxOpenGLS::drawBitmap(const Bitmap *bitmap, int dx, int dy, uint32 layer) {
-	if (g_grim->getGameType() == GType_MONKEY4 && bitmap->_data->_numImages > 1) {
+	if (g_grim->getGameType() == GType_MONKEY4 && bitmap->_data && bitmap->_data->_texc) {
 		BitmapData *data = bitmap->_data;
 		Graphics::Shader *shader = (Graphics::Shader *)data->_userData;
 		GLuint *textures = (GLuint *)bitmap->getTexIds();

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -986,7 +986,7 @@ void GfxTinyGL::createBitmap(BitmapData *bitmap) {
 void GfxTinyGL::drawBitmap(const Bitmap *bitmap, int x, int y, uint32 layer) {
 	// PS2 EMI uses a TGA for it's splash-screen, avoid using the following
 	// code for drawing that (as it has no tiles).
-	if (g_grim->getGameType() == GType_MONKEY4 && bitmap->_data->_numImages > 1) {
+	if (g_grim->getGameType() == GType_MONKEY4 && bitmap->_data && bitmap->_data->_texc) {
 		tglEnable(TGL_BLEND);
 		tglBlendFunc(TGL_SRC_ALPHA, TGL_ONE_MINUS_SRC_ALPHA);
 		tglColor3f(1.0f, 1.0f, 1.0f);


### PR DESCRIPTION
This patch set enables the drawing of layers which are dynamically created by EMI's lua code.

* enables the illumination of the neon signs of Planet Threepwood on Jambalaya Island
* turns on water effects in the lagoon on Lucre Island
* hides the cannonball on the beach of Knuttin Atoll until it is actually landed (issue #1046)