### PR TITLE
EMI: Correct draw order of textobjects

### DIFF
--- a/engines/grim/emi/emi.cpp
+++ b/engines/grim/emi/emi.cpp
@@ -268,7 +268,14 @@ void EMIEngine::invalidateSortOrder() {
 }
 
 bool EMIEngine::compareTextLayer(const TextObject *x, const TextObject *y) {
-	return x->getLayer() < y->getLayer();
+	int xl = x->getLayer();
+	int yl = y->getLayer();
+
+	if (xl == yl) {
+		return x->getId() < y->getId();
+	} else {
+		return xl < yl;
+	}
 }
 
 bool EMIEngine::compareLayer(const Layer *x, const Layer *y) {


### PR DESCRIPTION
Instead of just ordering the textobjects by their layer, use their
creation time (indirectly provided by the pool ID which is continuously
counting up).

This ensures that if there are multiple textobjects with the same text
ID and the same layer, that the latest is drawn last and overwrites the
previous ones.

That's necessary since the LUA code will create multiple instances of
the same textobject for the color fading effect in the credits.

This fixes the issue #1155.