### PR TITLE
EMI: Keep time of chores and animations in sync

### DIFF
--- a/engines/grim/emi/animationemi.h
+++ b/engines/grim/emi/animationemi.h
@@ -99,7 +99,7 @@ private:
 	bool _looping;
 	bool _active;
 	bool _paused;
-	uint _time;
+	int _time;
 	float _fade;
 	float _startFade;
 	Animation::FadeMode _fadeMode;


### PR DESCRIPTION
Both the animation components/tracks and the chores itself keep track of
the current time independently:

animation component:
- AnimationStateEmi::_time
- initialized with 0
- after the first update() call, _time is advanced by the frametime

chores:
- Costume::_currTime
- initialized with -1
- during the first update() call, _currTime is set first to 0
- during the next update() call, _currTime is advanced by the frametime

EMICostume::update() updates first the chore and then all components
with the same frame time. This has the effect, that the internal time
base of the chore and the animation has always an initial offset (the
value of the frametime of the first update() call).

For some costumes, the chore will pause the animation by setting the
according key for that animation at the end of the animation. However,
since the animation component has a different time base, it has already
reached that point and may have already disabled itself entirely
(instead of just being paused by the chore).

This bug fix avoids setting _currTime to 0 in the first update() call of
the chore but just sets it to the frametime. Any consecutive update()
call will advance the time by the frametime. This will keep the two
time bases of the chore and the animation component in sync.

This fixes #1048.