### PR TITLE
TRANSLATION: Support for both (ScummVM) inherited and (ResidualVM) new translations

### DIFF
--- a/configure
+++ b/configure
@@ -166,8 +166,7 @@ _safedisc=no
 _vkeybd=no
 _keymapper=no
 _eventrec=no
-# GUI translation options
-_translation=no
+_translation=yes
 # Default platform settings
 _backend=sdl
 _16bit=auto

--- a/engines/grim/POTFILES
+++ b/engines/grim/POTFILES
@@ -1,3 +1,4 @@
 engines/grim/md5check.cpp
 engines/grim/md5checkdialog.cpp
+engines/grim/resource.cpp
 

--- a/engines/grim/POTFILES
+++ b/engines/grim/POTFILES
@@ -1,3 +1,4 @@
+engines/grim/grim.cpp
 engines/grim/md5check.cpp
 engines/grim/md5checkdialog.cpp
 engines/grim/resource.cpp

--- a/engines/grim/POTFILES
+++ b/engines/grim/POTFILES
@@ -1,0 +1,3 @@
+engines/grim/md5check.cpp
+engines/grim/md5checkdialog.cpp
+

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -31,6 +31,7 @@
 #include "common/foreach.h"
 #include "common/fs.h"
 #include "common/config-manager.h"
+#include "common/translation.h"
 
 #include "graphics/pixelbuffer.h"
 
@@ -280,11 +281,13 @@ Common::Error GrimEngine::run() {
 	if (ConfMan.getBool("check_gamedata")) {
 		MD5CheckDialog d;
 		if (!d.runModal()) {
-			Common::String confirmString("ResidualVM found some problems with your game data files.\n"
-										 "Running ResidualVM nevertheless may cause game bugs or even crashes.\n"
-										 "Do you still want to run ");
-			confirmString += (GType_MONKEY4 == getGameType() ? "Escape From Monkey Island?" : "Grim Fandango?");
-			GUI::MessageDialog msg(confirmString, "Yes", "No");
+			Common::String confirmString = Common::String::format(_(
+				"ResidualVM found some problems with your game data files.\n"
+				"Running ResidualVM nevertheless may cause game bugs or even crashes.\n"
+				"Do you still want to run %s?"),
+			GType_MONKEY4 == getGameType() ? _("Escape From Monkey Island") : _("Grim Fandango")
+			 );
+			GUI::MessageDialog msg(confirmString, _("Yes"), _("No"));
 			if (!msg.runModal()) {
 				return Common::kUserCanceled;
 			}

--- a/engines/grim/md5check.cpp
+++ b/engines/grim/md5check.cpp
@@ -22,6 +22,7 @@
 
 #include "common/file.h"
 #include "common/md5.h"
+#include "common/translation.h"
 
 #include "gui/error.h"
 
@@ -542,17 +543,17 @@ bool MD5Check::advanceCheck(int *pos, int *total) {
 	if (file.open(sum.filename)) {
 		Common::String md5 = Common::computeStreamMD5AsString(file);
 		if (!checkMD5(sum, md5.c_str())) {
-			warning("'%s' may be corrupted. MD5: '%s'", sum.filename, md5.c_str());
-			GUI::displayErrorDialog(Common::String::format("The game data file %s may be corrupted.\nIf you are sure it is "
+			warning(_("'%s' may be corrupted. MD5: '%s'"), sum.filename, md5.c_str());
+			GUI::displayErrorDialog(Common::String::format(_("The game data file %s may be corrupted.\nIf you are sure it is "
 									"not please provide the ResidualVM team the following code, along with the file name, the language and a "
-									"description of your game version (i.e. dvd-box or jewelcase):\n%s", sum.filename, md5.c_str()).c_str());
+									"description of your game version (i.e. dvd-box or jewelcase):\n%s"), sum.filename, md5.c_str()).c_str());
 			return false;
 		}
 	} else {
-		warning("Could not open %s for checking", sum.filename);
-		GUI::displayErrorDialog(Common::String::format("Could not open the file %s for checking.\nIt may be missing or "
+		warning(_("Could not open %s for checking"), sum.filename);
+		GUI::displayErrorDialog(Common::String::format(_("Could not open the file %s for checking.\nIt may be missing or "
 								"you may not have the rights to open it.\nGo to http://wiki.residualvm.org/index.php/Datafiles to see a list "
-								"of the needed files.", sum.filename).c_str());
+								"of the needed files."), sum.filename).c_str());
 		return false;
 	}
 

--- a/engines/grim/md5checkdialog.cpp
+++ b/engines/grim/md5checkdialog.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "common/system.h"
+#include "common/translation.h"
 
 #include "gui/gui-manager.h"
 #include "gui/ThemeEval.h"
@@ -37,9 +38,9 @@ MD5CheckDialog::MD5CheckDialog() :
 	const int screenW = g_system->getOverlayWidth();
 	const int screenH = g_system->getOverlayHeight();
 
-	Common::String message =
+	Common::String message = _(
 		"ResidualVM will now verify the game data files, to make sure you have the best gaming experience.\n"
-		"This may take a while, please wait.\nSuccessive runs will not check them again.";
+		"This may take a while, please wait.\nSuccessive runs will not check them again.");
 
 	// First, determine the size the dialog needs. For this we have to break
 	// down the string into lines, and taking the maximum of their widths.

--- a/engines/grim/resource.cpp
+++ b/engines/grim/resource.cpp
@@ -50,6 +50,7 @@
 #include "common/memstream.h"
 #include "common/file.h"
 #include "common/config-manager.h"
+#include "common/translation.h"
 
 namespace Grim {
 
@@ -92,15 +93,15 @@ ResourceLoader::ResourceLoader() {
 		if (!SearchMan.hasArchive("update")) {
 			const char *errorMessage = nullptr;
 			if (g_grim->getGameType() == GType_GRIM) {
-				errorMessage =  "The original patch of Grim Fandango\n"
+				errorMessage = _("The original patch of Grim Fandango\n"
 								"is missing. Please download it from\n"
 								"http://www.residualvm.org/downloads/\n"
-								"and put it in the game data files directory";
+								"and put it in the game data files directory");
 			} else if (g_grim->getGameType() == GType_MONKEY4) {
-				errorMessage =  "The original patch of Escape from Monkey Island is missing. \n"
+				errorMessage = _("The original patch of Escape from Monkey Island is missing. \n"
 								"Please download it from http://www.residualvm.org/downloads/\n"
 								"and put it in the game data files directory.\n"
-								"Pay attention to download the correct version according to the game's language";
+								"Pay attention to download the correct version according to the game's language");
 			}
 
 			GUI::displayErrorDialog(errorMessage);
@@ -117,7 +118,7 @@ ResourceLoader::ResourceLoader() {
 			SearchMan.listMatchingMembers(files, "voice001.lab");
 		} else {
 			if (!SearchMan.hasFile("residualvm-grim-patch.lab"))
-				error("residualvm-grim-patch.lab not found");
+				error("%s", _("residualvm-grim-patch.lab not found"));
 
 			SearchMan.listMatchingMembers(files, "residualvm-grim-patch.lab");
 			SearchMan.listMatchingMembers(files, "data005.lab");
@@ -139,14 +140,14 @@ ResourceLoader::ResourceLoader() {
 			//In this case put it in the top of the list
 			const char *datausr_name = "datausr.lab";
 			if (SearchMan.hasFile(datausr_name) && ConfMan.getBool("datausr_load")) {
-				warning("Loading datausr.lab. Please note that the ResidualVM-team doesn't provide support for using such patches");
+				warning("%s", _("Loading datausr.lab. Please note that the ResidualVM-team doesn't provide support for using such patches"));
 				files.push_front(SearchMan.getMember(datausr_name));
 			}
 		}
 	} else if (g_grim->getGameType() == GType_MONKEY4) {
 		const char *emi_patches_filename = "residualvm-emi-patch.m4b";
 		if (!SearchMan.hasFile(emi_patches_filename))
-			error("%s not found", emi_patches_filename);
+			error(_("%s not found"), emi_patches_filename);
 
 		SearchMan.listMatchingMembers(files, emi_patches_filename);
 
@@ -177,14 +178,14 @@ ResourceLoader::ResourceLoader() {
 			//In this case put it in the top of the list
 			const char *datausr_name = "datausr.m4b";
 			if (SearchMan.hasFile(datausr_name) && ConfMan.getBool("datausr_load")) {
-				warning("Loading datausr.m4b. Please note that the ResidualVM-team doesn't provide support for using such patches");
+				warning("%s", _("Loading datausr.m4b. Please note that the ResidualVM-team doesn't provide support for using such patches"));
 				files.push_front(SearchMan.getMember(datausr_name));
 			}
 		}
 	}
 
 	if (files.empty())
-		error("Cannot find game data - check configuration file");
+		error("%s", _("Cannot find game data - check configuration file"));
 
 	//load labs
 	int priority = files.size();

--- a/engines/myst3/POTFILES
+++ b/engines/myst3/POTFILES
@@ -1,0 +1,2 @@
+engines/myst3/myst3.cpp
+

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -16,6 +16,9 @@ gui/options.cpp
 gui/predictivedialog.cpp
 gui/recorderdialog.cpp
 gui/saveload-dialog.cpp
+gui/predictivedialog.cpp
+gui/recorderdialog.cpp
+gui/saveload-dialog.cpp
 gui/themebrowser.cpp
 gui/ThemeEngine.cpp
 gui/widget.cpp

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -16,9 +16,6 @@ gui/options.cpp
 gui/predictivedialog.cpp
 gui/recorderdialog.cpp
 gui/saveload-dialog.cpp
-gui/predictivedialog.cpp
-gui/recorderdialog.cpp
-gui/saveload-dialog.cpp
 gui/themebrowser.cpp
 gui/ThemeEngine.cpp
 gui/widget.cpp

--- a/po/module.mk
+++ b/po/module.mk
@@ -12,9 +12,10 @@ updatepot:
 
 	sed -e 's/SOME DESCRIPTIVE TITLE/LANGUAGE translation for ResidualVM/' \
 		-e 's/UTF-8/CHARSET/' -e 's/PACKAGE/ResidualVM/' $(POTFILE)_ > $(POTFILE).new
-	rm $(POTFILE)_
 
-	$(srcdir)/po/msgcut $(POTFILE).new $(srcdir)/po/scummvm.pot
+	rm $(POTFILE)_
+	$(srcdir)/po/msgcut $(POTFILE).new $(srcdir)/po/scummvm.pot 	# ResidualVM specific
+
 
 	if test -f $(POTFILE); then \
 		sed -f $(srcdir)/po/remove-potcdate.sed < $(POTFILE) > $(POTFILE).1 && \
@@ -31,6 +32,8 @@ updatepot:
 	fi;
 
 %.po: $(POTFILE)
+	# ResidualVM specific start ->
+	# msgmerge $@ $(POTFILE) -o $@.new
 	if [ -f $(dir $@)/residualvm/$(notdir $@) ]; then \
 		msgcat --use-first $(dir $@)/residualvm/$(notdir $@) $@ > $@.new; \
 	else \
@@ -42,6 +45,7 @@ updatepot:
 	else \
 		mv -f $@.new $@; \
 	fi;
+	# ResidualVM specific end <-
 
 translations-dat: devtools/create_translations
 	devtools/create_translations/create_translations $(POFILES) $(CPFILES)

--- a/po/module.mk
+++ b/po/module.mk
@@ -12,8 +12,10 @@ updatepot:
 
 	sed -e 's/SOME DESCRIPTIVE TITLE/LANGUAGE translation for ResidualVM/' \
 		-e 's/UTF-8/CHARSET/' -e 's/PACKAGE/ResidualVM/' $(POTFILE)_ > $(POTFILE).new
-
 	rm $(POTFILE)_
+
+	$(srcdir)/po/msgcut $(POTFILE).new $(srcdir)/po/scummvm.pot
+
 	if test -f $(POTFILE); then \
 		sed -f $(srcdir)/po/remove-potcdate.sed < $(POTFILE) > $(POTFILE).1 && \
 		sed -f $(srcdir)/po/remove-potcdate.sed < $(POTFILE).new > $(POTFILE).2 && \
@@ -29,7 +31,12 @@ updatepot:
 	fi;
 
 %.po: $(POTFILE)
-	msgmerge $@ $(POTFILE) -o $@.new
+	if [ -f $(dir $@)/residualvm/$(notdir $@) ]; then \
+		msgcat --use-first $(dir $@)/residualvm/$(notdir $@) $@ > $@.new; \
+	else \
+		cp $@ $@.new; \
+	fi
+	msgmerge --update $@.new $(POTFILE)
 	if cmp $@ $@.new >/dev/null 2>&1; then \
 		rm -f $@.new; \
 	else \

--- a/po/msgcut
+++ b/po/msgcut
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Data::Printer;
+use Tie::IxHash;
+use open qw(:std :utf8);
+
+sub readPOT {
+	my ($fn) = @_;
+	open my $fh, "<", $fn or die "Could not open $fn: $!";
+	local $/ = "";
+
+	my %ids;
+	tie %ids, 'Tie::IxHash';
+	my $ret = { ids => \%ids, header => scalar <$fh> };
+
+	while (defined (my $block = <$fh>)) {
+		my ($context) = $block =~ /msgctxt "(.+)"/ || "(none)";
+		my ($msgid) = $block =~ /msgid "(.*)"/;
+		if (! length $msgid) {
+			($msgid) = $block =~ /msgid ""(.*?)^msgstr/sm;
+			$msgid =~ s/"\n"//;
+		}
+		$ids{"$context/$msgid"} = $block;
+	}
+
+	return $ret;
+}
+
+my ($derivedfn, $mainfn) = @ARGV;
+
+my $main = readPOT $mainfn;
+my $derived = readPOT $derivedfn;
+
+open my $out, ">", $derivedfn or die "Cannot open $derivedfn for writing: $!";
+print $out $derived->{header};
+for my $key (keys %{$derived->{ids}}) {
+	print $out $derived->{ids}{$key} unless exists $main->{ids}{$key};
+}

--- a/po/residualvm/README
+++ b/po/residualvm/README
@@ -1,0 +1,12 @@
+ResidualVM shares much of its code with ScummVM, and therefore much of its
+translations are the same.
+This directory contains translations of the parts that are unique to
+ResidualVM, largely those belonging to its engines.
+
+If you want to contribute a translation, please follow these steps:
+1) call `make updatepot` from a build directory to get a residualvm.pot.
+2) use `msginit -i po/residualvm.pot -o po/residualvm/nl_NL.po -l nl_NL`
+   to generate a template you can fill in. Make sure to set the charset to
+   ISO-8859-1, not UTF-8.
+3) Once your translations are done, call `make update-translations` and
+   `make install` to update the `translations.dat` file.

--- a/po/residualvm/nl_NL.po
+++ b/po/residualvm/nl_NL.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ResidualVM 0.3.0git\n"
 "Report-Msgid-Bugs-To: https://github.com/residualvm/residualvm/issues\n"
-"POT-Creation-Date: 2015-09-02 14:36+0200\n"
+"POT-Creation-Date: 2015-09-08 16:58+0200\n"
 "PO-Revision-Date: 2015-09-02 14:36+0200\n"
 "Last-Translator: Dries Harnie <dries@harnie.be>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: gui/launcher.cpp:630 backends/platform/sdl/macosx/appMenu_osx.mm:95
+#: gui/launcher.cpp:630 backends/platform/sdl/macosx/appmenu_osx.mm:95
 msgid "Quit ResidualVM"
 msgstr "Hiermee verlaat u ResidualVM"
 
-#: gui/launcher.cpp:631 backends/platform/sdl/macosx/appMenu_osx.mm:69
+#: gui/launcher.cpp:631 backends/platform/sdl/macosx/appmenu_osx.mm:69
 msgid "About ResidualVM"
 msgstr "Geeft informatie over ResidualVM"
 
@@ -66,7 +66,8 @@ msgstr "Taal van de ResidualVM GUI"
 
 #: gui/options.cpp:1402
 msgid "You have to restart ResidualVM before your changes will take effect."
-msgstr "U dient ResidualVM opnieuw op te starten om de wijzigingen te activeren."
+msgstr ""
+"U dient ResidualVM opnieuw op te starten om de wijzigingen te activeren."
 
 #: engines/advancedDetector.cpp:318
 msgid ""
@@ -86,13 +87,28 @@ msgstr ""
 "instabiel is, en opgeslagen spellen zullen mogelijk niet werken in "
 "toekomstige versies van ResidualVM."
 
-#: audio/fmopl.cpp:67
-msgid "ALSA Direct FM"
-msgstr ""
-
-#: backends/platform/sdl/macosx/appMenu_osx.mm:77
+#: backends/platform/sdl/macosx/appmenu_osx.mm:77
 msgid "Hide ResidualVM"
 msgstr "Verberg ResidualVM"
+
+#: engines/grim/grim.cpp:285
+#, c-format
+msgid ""
+"ResidualVM found some problems with your game data files.\n"
+"Running ResidualVM nevertheless may cause game bugs or even crashes.\n"
+"Do you still want to run %s?"
+msgstr ""
+"ResidualVM heeft enkele problemen gevonden in uw spelbestanden.\n"
+"Nu opstarten kan leiden tot bugs of crashes.\n"
+"Wilt u %s alsnog opstarten?"
+
+#: engines/grim/grim.cpp:288
+msgid "Escape From Monkey Island"
+msgstr ""
+
+#: engines/grim/grim.cpp:288
+msgid "Grim Fandango"
+msgstr ""
 
 #: engines/grim/md5check.cpp:546
 #, c-format
@@ -109,9 +125,10 @@ msgid ""
 "%s"
 msgstr ""
 "Het spelbestand %s is mogelijk corrupt.\n"
-"Als u zeker bent dat dit niet het geval is, neem contact op met het ResidualVM "
-"team en vermeld de volgende code, samen met de bestandsnaam en een korte "
-"beschrijving van uw spel (bvb. taal en 'dvd-box' of 'jewelcase'): \n"
+"Als u zeker bent dat dit niet het geval is, neem contact op met het "
+"ResidualVM team en vermeld de volgende code, samen met de bestandsnaam en "
+"een korte beschrijving van uw spel (bvb. taal en 'dvd-box' of "
+"'jewelcase'): \n"
 "%s"
 
 #: engines/grim/md5check.cpp:553

--- a/po/residualvm/nl_NL.po
+++ b/po/residualvm/nl_NL.po
@@ -1,0 +1,213 @@
+# LANGUAGE translation for ResidualVM.
+# Copyright (C) 2015 ResidualVM Team
+# This file is distributed under the same license as the ResidualVM package.
+# Dries Harnie <dries@harnie.be>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ResidualVM 0.3.0git\n"
+"Report-Msgid-Bugs-To: https://github.com/residualvm/residualvm/issues\n"
+"POT-Creation-Date: 2015-09-02 14:36+0200\n"
+"PO-Revision-Date: 2015-09-02 14:36+0200\n"
+"Last-Translator: Dries Harnie <dries@harnie.be>\n"
+"Language-Team: Dutch <vertaling@vrijschrift.org>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: gui/launcher.cpp:630 backends/platform/sdl/macosx/appMenu_osx.mm:95
+msgid "Quit ResidualVM"
+msgstr "Hiermee verlaat u ResidualVM"
+
+#: gui/launcher.cpp:631 backends/platform/sdl/macosx/appMenu_osx.mm:69
+msgid "About ResidualVM"
+msgstr "Geeft informatie over ResidualVM"
+
+#: gui/launcher.cpp:632
+msgid "Change global ResidualVM options"
+msgstr "Algemene ResidualVM opties"
+
+#: gui/launcher.cpp:845
+msgid "ResidualVM couldn't open the specified directory!"
+msgstr "ResidualVM kon de opgegeven map niet openen!"
+
+#: gui/launcher.cpp:857
+msgid "ResidualVM could not find any game in the specified directory!"
+msgstr "ResidualVM kon geen enkel spel vinden in de opgegeven map!"
+
+#: gui/launcher.cpp:1056
+msgid ""
+"ResidualVM could not find any engine capable of running the selected game!"
+msgstr ""
+"ResidualVM heeft geen engine gevonden die in staat was het geselecteerde "
+"spel te spelen!"
+
+#: gui/options.cpp:793
+msgid "Preserve aspect ratio"
+msgstr "Behoud de schermverhouding"
+
+#: gui/options.cpp:793
+msgid "Preserve the aspect ratio in fullscreen mode"
+msgstr "Behoud de schermverhouding bij volledig scherm"
+
+#: gui/options.cpp:795
+msgid "Software Rendering"
+msgstr "Software Rendering"
+
+#: gui/options.cpp:795
+msgid "Enable software rendering"
+msgstr "Gebruik software rendering"
+
+#: gui/options.cpp:1243
+msgid "Language of ResidualVM GUI"
+msgstr "Taal van de ResidualVM GUI"
+
+#: gui/options.cpp:1402
+msgid "You have to restart ResidualVM before your changes will take effect."
+msgstr "U dient ResidualVM opnieuw op te starten om de wijzigingen te activeren."
+
+#: engines/advancedDetector.cpp:318
+msgid ""
+"Please, report the following data to the ResidualVM team along with name"
+msgstr ""
+"Raporteer a.u.b. de volgende gegevens aan het ResidualVM team samen met de "
+"naam"
+
+#: engines/engine.cpp:481
+msgid ""
+"WARNING: The game you are about to start is not yet fully supported by "
+"ResidualVM. As such, it is likely to be unstable, and any saves you make "
+"might not work in future versions of ResidualVM."
+msgstr ""
+"WAARSCHUWING: Het spel dat u wilt gaan spelen is nog niet volledig "
+"ondersteund door ResidualVM. Om die reden is het waarschijnlijk dat het spel "
+"instabiel is, en opgeslagen spellen zullen mogelijk niet werken in "
+"toekomstige versies van ResidualVM."
+
+#: audio/fmopl.cpp:67
+msgid "ALSA Direct FM"
+msgstr ""
+
+#: backends/platform/sdl/macosx/appMenu_osx.mm:77
+msgid "Hide ResidualVM"
+msgstr "Verberg ResidualVM"
+
+#: engines/grim/md5check.cpp:546
+#, c-format
+msgid "'%s' may be corrupted. MD5: '%s'"
+msgstr "Het bestand '%s' is mogelijk corrupt. MD5: '%s'"
+
+#: engines/grim/md5check.cpp:547
+#, c-format
+msgid ""
+"The game data file %s may be corrupted.\n"
+"If you are sure it is not please provide the ResidualVM team the following "
+"code, along with the file name, the language and a description of your game "
+"version (i.e. dvd-box or jewelcase):\n"
+"%s"
+msgstr ""
+"Het spelbestand %s is mogelijk corrupt.\n"
+"Als u zeker bent dat dit niet het geval is, neem contact op met het ResidualVM "
+"team en vermeld de volgende code, samen met de bestandsnaam en een korte "
+"beschrijving van uw spel (bvb. taal en 'dvd-box' of 'jewelcase'): \n"
+"%s"
+
+#: engines/grim/md5check.cpp:553
+#, c-format
+msgid "Could not open %s for checking"
+msgstr "Kon bestand %s niet openen voor integriteitscontrole."
+
+#: engines/grim/md5check.cpp:554
+#, c-format
+msgid ""
+"Could not open the file %s for checking.\n"
+"It may be missing or you may not have the rights to open it.\n"
+"Go to http://wiki.residualvm.org/index.php/Datafiles to see a list of the "
+"needed files."
+msgstr ""
+"Kon bestand %s niet openen voor integriteitscontrole.\n"
+"Misschien ontbreekt het of u heeft niet de juiste permissies om het te "
+"openen. Ga naar http://wiki.residualvm.org/index.php/Datafiles voor een "
+"overzicht van de benodigde bestanden en bestandsstructuur"
+
+#: engines/grim/md5checkdialog.cpp:42
+msgid ""
+"ResidualVM will now verify the game data files, to make sure you have the "
+"best gaming experience.\n"
+"This may take a while, please wait.\n"
+"Successive runs will not check them again."
+msgstr ""
+"ResidualVM zal nu de integriteit van uw spelbestanden nagaan, voor de beste "
+"spelervaring.\n"
+"Dit kan eventjes duren, maar is slechts eenmalig."
+
+#: engines/grim/resource.cpp:96
+msgid ""
+"The original patch of Grim Fandango\n"
+"is missing. Please download it from\n"
+"http://www.residualvm.org/downloads/\n"
+"and put it in the game data files directory"
+msgstr ""
+"De originele patch voor Grim Fandango ontbreekt.\n"
+"Download deze van http://www.residualvm.org/downloads/\n"
+"en plaats deze bij de spelbestanden."
+
+#: engines/grim/resource.cpp:101
+msgid ""
+"The original patch of Escape from Monkey Island is missing. \n"
+"Please download it from http://www.residualvm.org/downloads/\n"
+"and put it in the game data files directory.\n"
+"Pay attention to download the correct version according to the game's "
+"language"
+msgstr ""
+"De originele patch voor Escape from Monkey Island ontbreekt. \n"
+"Download deze van http://www.residualvm.org/downloads/ \n"
+"en plaats deze bij de spelbestanden. \n"
+"Let erop dat u de versie downloadt voor de correcte taal."
+
+#: engines/grim/resource.cpp:121
+msgid "residualvm-grim-patch.lab not found"
+msgstr "residualvm-grim-patch.lab: bestand niet gevonden"
+
+#: engines/grim/resource.cpp:143
+msgid ""
+"Loading datausr.lab. Please note that the ResidualVM-team doesn't provide "
+"support for using such patches"
+msgstr ""
+"Bezig met laden van datausr.lab. Merk op dat het ResidualVM team geen "
+"ondersteuning biedt voor zulke patches"
+
+#: engines/grim/resource.cpp:150
+#, c-format
+msgid "%s not found"
+msgstr "Bestand '%s' niet gevonden."
+
+#: engines/grim/resource.cpp:181
+msgid ""
+"Loading datausr.m4b. Please note that the ResidualVM-team doesn't provide "
+"support for using such patches"
+msgstr ""
+"Bezig met laden van datausr.m4b. Merk op dat het ResidualVM team geen "
+"ondersteuning biedt voor zulke patches"
+
+#: engines/grim/resource.cpp:188
+msgid "Cannot find game data - check configuration file"
+msgstr "Kan spelbestanden niet vinden. Check het configuratiebestand."
+
+#: engines/myst3/myst3.cpp:348
+msgid ""
+"This version of Myst III is encrypted with a copy-protection\n"
+"preventing ResidualVM from reading required data.\n"
+"Please replace your 'M3.exe' file with the one from the official update\n"
+"corresponding to your game's language and redetect the game.\n"
+"These updates don't contain the copy-protection and can be downloaded from\n"
+"http://www.residualvm.org/downloads/"
+msgstr ""
+"Deze versie van Myst III is kopieerbeveiligd, waardoor \n"
+"ResidualVM benodigde data niet kan uitlezen.\n"
+"Vervang 'M3.exe' met een kopie van de officiële update die overeenkomt \n"
+"met de taal van uw spel, en laat het spel opnieuw detecteren.\n"
+"De updates zijn vrij van kopieerbeveiliging en kunnen gedownload worden \n"
+"op http://www.residualvm.org/downloads/"


### PR DESCRIPTION
This PR is a suggested fix for #1206.
It enables us to inherit translations from ScummVM where they match (mostly the launcher), and add our own translations (currently the md5 checkers and the "patch needed" dialogs).

I have included a sample translation for the `nl_NL` locale to illustrate.