### PR TITLE
I18N: Add German translation for ResidualVM-specific strings

### DIFF
--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ScummVM 1.8.0git\n"
 "Report-Msgid-Bugs-To: scummvm-devel@lists.sf.net\n"
-"POT-Creation-Date: 2015-09-06 15:14+0200\n"
-"PO-Revision-Date: 2015-07-04 12:06+0200\n"
+"POT-Creation-Date: 2015-10-11 18:59+0100\n"
+"PO-Revision-Date: 2015-10-16 11:00+0200\n"
 "Last-Translator: Lothar Serra Mari <scummvm@rootfather.de>\n"
 "Language-Team: Simon Sawatzki <SimSaw@gmx.de>, Lothar Serra Mari "
 "<scummvm@rootfather.de>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 1.8.2\n"
+"X-Generator: Poedit 1.8.5\n"
 
 #: gui/about.cpp:94
 #, c-format
@@ -75,7 +75,6 @@ msgid "Choose"
 msgstr "Auswählen"
 
 #: gui/editrecorddialog.cpp:58
-#, fuzzy
 msgid "Author:"
 msgstr "Autor:"
 
@@ -84,13 +83,12 @@ msgid "Name:"
 msgstr "Name:"
 
 #: gui/editrecorddialog.cpp:60
-#, fuzzy
 msgid "Notes:"
 msgstr "Notizen:"
 
 #: gui/editrecorddialog.cpp:68 gui/predictivedialog.cpp:75
 msgid "Ok"
-msgstr ""
+msgstr "OK"
 
 #: gui/gui-manager.cpp:117 backends/keymapper/remap-dialog.cpp:53
 #: engines/scumm/help.cpp:126 engines/scumm/help.cpp:141
@@ -579,19 +577,17 @@ msgstr "%d neue Spiele gefunden, %d bereits hinzugefügte Spiele ignoriert..."
 
 #: gui/onscreendialog.cpp:101 gui/onscreendialog.cpp:103
 msgid "Stop"
-msgstr ""
+msgstr "Anhalten"
 
 #: gui/onscreendialog.cpp:106
 msgid "Edit record description"
-msgstr ""
+msgstr "Aufnahme-Beschreibung ändern"
 
 #: gui/onscreendialog.cpp:108
-#, fuzzy
 msgid "Switch to Game"
 msgstr "Wechsle"
 
 #: gui/onscreendialog.cpp:110
-#, fuzzy
 msgid "Fast replay"
 msgstr "Schneller Modus"
 
@@ -879,7 +875,7 @@ msgstr "Musiklautstärke:"
 
 #: gui/options.cpp:968
 msgid "Mute All"
-msgstr "Alles stumm"
+msgstr "Alles aus"
 
 #: gui/options.cpp:971
 msgid "SFX volume:"
@@ -1000,29 +996,28 @@ msgstr ""
 #. I18N: You must leave "#" as is, only word 'next' is translatable
 #: gui/predictivedialog.cpp:87
 msgid "#  next"
-msgstr ""
+msgstr "#  nächste"
 
 #: gui/predictivedialog.cpp:88
 msgid "add"
-msgstr ""
+msgstr "hinzufügen"
 
 #: gui/predictivedialog.cpp:92
-#, fuzzy
 msgid "Delete char"
 msgstr "Löschen"
 
 #: gui/predictivedialog.cpp:96
 msgid "<"
-msgstr ""
+msgstr "<"
 
 #. I18N: Pre means 'Predictive', leave '*' as is
 #: gui/predictivedialog.cpp:98
 msgid "*  Pre"
-msgstr ""
+msgstr "*  Vorschau"
 
 #: gui/recorderdialog.cpp:64
 msgid "Recorder or Playback Gameplay"
-msgstr "Spiel aufzeichnen oder wiedergeben"
+msgstr "Spiel aufzeichnen/wiedergeben"
 
 #: gui/recorderdialog.cpp:69 gui/recorderdialog.cpp:156
 #: gui/saveload-dialog.cpp:220 gui/saveload-dialog.cpp:276
@@ -1054,6 +1049,10 @@ msgstr "Notizen:"
 #: gui/recorderdialog.cpp:155
 msgid "Do you really want to delete this record?"
 msgstr "Möchten Sie diese Aufnahme wirklich löschen?"
+
+#: gui/recorderdialog.cpp:174
+msgid "Unknown Author"
+msgstr "Unbekannter Autor"
 
 #: gui/saveload-dialog.cpp:167
 msgid "List view"
@@ -1520,7 +1519,7 @@ msgstr "DOSBox-OPL-Emulator"
 
 #: audio/fmopl.cpp:67
 msgid "ALSA Direct FM"
-msgstr ""
+msgstr "ALSA Direct FM"
 
 #: audio/mididrv.cpp:209
 #, c-format
@@ -3371,6 +3370,22 @@ msgstr "Nach rechts fliegen"
 msgid "Fly to lower right"
 msgstr "Nach unten rechts fliegen"
 
+#: engines/scumm/input.cpp:572
+msgid "Snap scroll on"
+msgstr "Blättern einschalten"
+
+#: engines/scumm/input.cpp:574
+msgid "Snap scroll off"
+msgstr "Blättern ausschalten"
+
+#: engines/scumm/input.cpp:587
+msgid "Music volume: "
+msgstr "Musiklautstärke:"
+
+#: engines/scumm/input.cpp:604
+msgid "Subtitle speed: "
+msgstr "Untertitel-Tempo:"
+
 #: engines/scumm/scumm.cpp:1832
 #, c-format
 msgid ""
@@ -3538,7 +3553,6 @@ msgstr ""
 "Zeige die aktuelle Anzahl von Bildern pro Sekunde in der oberen linken Ecke"
 
 #: engines/zvision/detection_tables.h:52
-#, fuzzy
 msgid "Use the original save/load screens instead of the ScummVM interface"
 msgstr ""
 "Verwendet die originalen Menüs zum Speichern und Laden statt der von ScummVM."
@@ -3548,7 +3562,6 @@ msgid "Double FPS"
 msgstr "FPS verdoppeln"
 
 #: engines/zvision/detection_tables.h:62
-#, fuzzy
 msgid "Increase framerate from 30 to 60 FPS"
 msgstr "Bilder pro Sekunde im Spiel von 30 auf 60 erhöhen"
 
@@ -3565,17 +3578,14 @@ msgid "Disable animation while turning"
 msgstr "Animation während Drehen ausschalten"
 
 #: engines/zvision/detection_tables.h:82
-#, fuzzy
 msgid "Disable animation while turning in panorama mode"
 msgstr "Animation während Drehen im Panorama-Modus ausschalten"
 
 #: engines/zvision/detection_tables.h:91
-#, fuzzy
 msgid "Use high resolution MPEG video"
 msgstr "Nutze hochauflösende MPEG-Filme"
 
 #: engines/zvision/detection_tables.h:92
-#, fuzzy
 msgid "Use MPEG video from the DVD version, instead of lower resolution AVI"
 msgstr ""
 "Verwende hochauflösende MPEG-Filme der DVD-Version anstelle der AVI-Filme"

--- a/po/residualvm/de_DE.po
+++ b/po/residualvm/de_DE.po
@@ -1,0 +1,234 @@
+# LANGUAGE translation for ResidualVM.
+# Copyright (C) 2015 ResidualVM Team
+# This file is distributed under the same license as the ResidualVM package.
+# Lothar Serra Mari <scummvm@rootfather.de>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ResidualVM 0.3.0git\n"
+"Report-Msgid-Bugs-To: https://github.com/residualvm/residualvm/issues\n"
+"POT-Creation-Date: 2015-10-17 09:10+0000\n"
+"PO-Revision-Date: 2015-10-17 12:29+0200\n"
+"Last-Translator: Lothar Serra Mari <scummvm@rootfather.de>\n"
+"Language-Team: Lothar Serra Mari <scummvm@rootfather.de>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.5\n"
+
+#: gui/launcher.cpp:630 backends/platform/sdl/macosx/appmenu_osx.mm:95
+msgid "Quit ResidualVM"
+msgstr "ResidualVM beenden"
+
+#: gui/launcher.cpp:631 backends/platform/sdl/macosx/appmenu_osx.mm:69
+msgid "About ResidualVM"
+msgstr "Über ResidualVM"
+
+#: gui/launcher.cpp:632
+msgid "Change global ResidualVM options"
+msgstr "Globale ResidualVM-Optionen ändern"
+
+#: gui/launcher.cpp:845
+msgid "ResidualVM couldn't open the specified directory!"
+msgstr "ResidualVM kann das gewählte Verzeichnis nicht öffnen!"
+
+#: gui/launcher.cpp:857
+msgid "ResidualVM could not find any game in the specified directory!"
+msgstr "ResidualVM kann kein Spiel im gewählten Verzeichnis finden!"
+
+#: gui/launcher.cpp:1056
+msgid ""
+"ResidualVM could not find any engine capable of running the selected game!"
+msgstr "ResidualVM kann keine für diese Spiel geeignete Engine finden!"
+
+#: gui/options.cpp:793
+msgid "Preserve aspect ratio"
+msgstr "Seitenverhältnis beibehalten"
+
+#: gui/options.cpp:793
+msgid "Preserve the aspect ratio in fullscreen mode"
+msgstr "Seitenverhältnis im Vollbildmodus beibehalten"
+
+#: gui/options.cpp:795
+msgid "Software Rendering"
+msgstr "Software-Rendering"
+
+#: gui/options.cpp:795
+msgid "Enable software rendering"
+msgstr "Software-Rendering aktivieren"
+
+#: gui/options.cpp:1243
+msgid "Language of ResidualVM GUI"
+msgstr "Sprache der ResidualVM-Oberfläche"
+
+#: gui/options.cpp:1402
+msgid "You have to restart ResidualVM before your changes will take effect."
+msgstr ""
+"Sie müssen ResidualVM neu starten, damit die Änderungen wirksam werden."
+
+#: engines/advancedDetector.cpp:318
+msgid ""
+"Please, report the following data to the ResidualVM team along with name"
+msgstr ""
+"Bitte melden Sie die folgenden Daten an das ResidualVM-Team, zusammen mit "
+"dem Namen"
+
+#: engines/engine.cpp:481
+msgid ""
+"WARNING: The game you are about to start is not yet fully supported by "
+"ResidualVM. As such, it is likely to be unstable, and any saves you make "
+"might not work in future versions of ResidualVM."
+msgstr ""
+"WARNUNG: Das Spiel, welches Sie starten wollen, wird noch nicht vollständig "
+"von ResidualVM unterstützt. Somit ist es wahrscheinlich, dass es instabil "
+"ist und jegliche Spielstände, die Sie erstellen, könnten in zukünftigen "
+"Versionen von ResidualVM nicht mehr funktionieren."
+
+#: backends/platform/sdl/macosx/appmenu_osx.mm:77
+msgid "Hide ResidualVM"
+msgstr "ResidualVM verstecken"
+
+#: engines/myst3/myst3.cpp:348
+msgid ""
+"This version of Myst III is encrypted with a copy-protection\n"
+"preventing ResidualVM from reading required data.\n"
+"Please replace your 'M3.exe' file with the one from the official update\n"
+"corresponding to your game's language and redetect the game.\n"
+"These updates don't contain the copy-protection and can be downloaded from\n"
+"http://www.residualvm.org/downloads/"
+msgstr ""
+"Diese Version von Myst III ist mit einem Kopierschutz verschlüsselt,\n"
+"weshalb ResidualVM die nötigen Daten nicht lesen kann.\n"
+"Bitte ersetzen Sie Ihre 'M3.exe'-Datei mit der aus dem offiziellen Update,\n"
+"passend zu der Sprache Ihres Spiels und fügen Sie das Spiel erneut hinzu.\n"
+"Diese Updates beinhalten keinen Kopierschutz und können von\n"
+"http://www.residualvm.org/downloads/ heruntergeladen werden."
+
+#: engines/grim/grim.cpp:285
+#, c-format
+msgid ""
+"ResidualVM found some problems with your game data files.\n"
+"Running ResidualVM nevertheless may cause game bugs or even crashes.\n"
+"Do you still want to run %s?"
+msgstr ""
+"ResidualVM hat Probleme mit Ihren Spiel-Dateien gefunden.\n"
+"Wenn Sie ResidualVM trotzdem starten, kann dies Fehler im Spiel oder "
+"Abstürze verursachen.\n"
+"Möchten Sie %s trotzdem ausführen?"
+
+#: engines/grim/grim.cpp:288
+msgid "Escape From Monkey Island"
+msgstr "Escape From Monkey Island"
+
+#: engines/grim/grim.cpp:288
+msgid "Grim Fandango"
+msgstr "Grim Fandango"
+
+#: engines/grim/md5check.cpp:546
+#, c-format
+msgid "'%s' may be corrupted. MD5: '%s'"
+msgstr "'%s' ist möglicherweise defekt. MD5: '%s'"
+
+#: engines/grim/md5check.cpp:547
+#, c-format
+msgid ""
+"The game data file %s may be corrupted.\n"
+"If you are sure it is not please provide the ResidualVM team the following "
+"code, along with the file name, the language and a description of your game "
+"version (i.e. dvd-box or jewelcase):\n"
+"%s"
+msgstr ""
+"Die Spiel-Datei %s ist möglicherweise defekt.\n"
+"Wenn Sie sicher sind, dass dies nicht der Fall ist, schicken Sie den "
+"folgenden Code an das ResidualVM-Team, zusammen mit Dateinamen, der Sprache "
+"und einer Beschreibung Ihrer Spiele-Version (z.B. DVD-Box oder Jewelcase):\n"
+"%s"
+
+#: engines/grim/md5check.cpp:553
+#, c-format
+msgid "Could not open %s for checking"
+msgstr "Kann %s nicht zur Überprüfung öffnen"
+
+#: engines/grim/md5check.cpp:554
+#, c-format
+msgid ""
+"Could not open the file %s for checking.\n"
+"It may be missing or you may not have the rights to open it.\n"
+"Go to http://wiki.residualvm.org/index.php/Datafiles to see a list of the "
+"needed files."
+msgstr ""
+"Die Datei %s kann nicht zur Überprüfung geöffnet werden.\n"
+"Entweder fehlt die Datei, oder Sie haben nicht die nötigen Rechte, um sie zu "
+"öffnen.\n"
+"Auf http://wiki.residualvm.org/index.php/Datafiles finden Sie eine Liste der "
+"benötigten Dateien."
+
+#: engines/grim/md5checkdialog.cpp:42
+msgid ""
+"ResidualVM will now verify the game data files, to make sure you have the "
+"best gaming experience.\n"
+"This may take a while, please wait.\n"
+"Successive runs will not check them again."
+msgstr ""
+"ResidualVM wird jetzt die Spiel-Dateien überprüfen, um ein optimales "
+"Spielerlebnis sicherzustellen.\n"
+"Dies wird eine Weile dauern - bitte warten.\n"
+"Zukünftig werden sie nicht mehr überprüft."
+
+#: engines/grim/resource.cpp:96
+msgid ""
+"The original patch of Grim Fandango\n"
+"is missing. Please download it from\n"
+"http://www.residualvm.org/downloads/\n"
+"and put it in the game data files directory"
+msgstr ""
+"Der originale Patch von Grim Fandango\n"
+"ist nicht vorhanden. Bitte laden Sie ihn von\n"
+"http://www.residualvm.org/downloads/\n"
+"herunter und kopieren Sie ihn in das Verzeichnis\n"
+"mit den Spiel-Dateien."
+
+#: engines/grim/resource.cpp:101
+msgid ""
+"The original patch of Escape from Monkey Island is missing. \n"
+"Please download it from http://www.residualvm.org/downloads/\n"
+"and put it in the game data files directory.\n"
+"Pay attention to download the correct version according to the game's "
+"language"
+msgstr ""
+"Der originale Patch von Escape from Monkey Island ist nicht vorhanden. \n"
+"Bitte Laden Sie ihn von http://www.residualvm.org/downloads/ herunter \n"
+"und kopieren Sie ihn in das Verzeichnis mit den Spiel-Dateien.\n"
+"Achten Sie darauf, dass Sie die zur Spiel-Sprache passende Version "
+"herunterladen."
+
+#: engines/grim/resource.cpp:121
+msgid "residualvm-grim-patch.lab not found"
+msgstr "residualvm-grim-patch.lab nicht gefunden"
+
+#: engines/grim/resource.cpp:143
+msgid ""
+"Loading datausr.lab. Please note that the ResidualVM-team doesn't provide "
+"support for using such patches"
+msgstr ""
+"Lade datausr.lab. Bitte beachten Sie, dass das ResidualVM-Team keine "
+"Unterstützung für solche Patches anbietet."
+
+#: engines/grim/resource.cpp:150
+#, c-format
+msgid "%s not found"
+msgstr "%s nicht gefunden"
+
+#: engines/grim/resource.cpp:181
+msgid ""
+"Loading datausr.m4b. Please note that the ResidualVM-team doesn't provide "
+"support for using such patches"
+msgstr ""
+"Lade datausr.m4b. Bitte beachten Sie, dass das ResidualVM-Team keine "
+"Unterstützung für solche Patches anbietet."
+
+#: engines/grim/resource.cpp:188
+msgid "Cannot find game data - check configuration file"
+msgstr "Spiel-Daten nicht gefunden - Konfigurationsdatei überprüfen!"


### PR DESCRIPTION
This adds a German translation file (de_DE.po) that includes all ResidualVM-specific stuff to ResidualVM.

All strings are translated, but unfortunately, I'm currently unable to build a working translations.dat - the changes I made in /po/residualvm/de_DE.po are not included in /po/de_DE.po and therefore not build into translations.dat.

I followed all instructions in /po/residualvm/README, but without luck - the /po/de_DE.po file always contains the untranslated strings and ignores the translated strings in /po/residualvm/de_DE.po

Best regards
rootfather