### PR TITLE
Move computations out of renderer

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -979,7 +979,7 @@ void GfxOpenGL::setupLight(Light *light, int lightId) {
 	GLfloat spot_exp = 0.0f;
 	GLfloat q_attenuation = 1.0f;
 
-	GLfloat intensity = light->_intensity / 15.0f;
+	GLfloat intensity = light->_scaledintensity;
 	lightColor[0] = (GLfloat)light->_color.getRed() * intensity;
 	lightColor[1] = (GLfloat)light->_color.getGreen() * intensity;
 	lightColor[2] = (GLfloat)light->_color.getBlue() * intensity;

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1115,16 +1115,10 @@ void GfxOpenGLS::setupLight(Grim::Light *light, int lightId) {
 	Math::Vector4d &lightDir    = _lights[lightId]._direction;
 	Math::Vector4d &lightParams = _lights[lightId]._params;
 
-	float intensity = light->_intensity;
-	if (g_grim->getGameType() == GType_MONKEY4) {
-		intensity /= 255.0f;
-	} else {
-		intensity /= 15.0f;
-	}
 	lightColor.x() = (float)light->_color.getRed();
 	lightColor.y() = (float)light->_color.getGreen();
 	lightColor.z() = (float)light->_color.getBlue();
-	lightColor.w() = intensity;
+	lightColor.w() = light->_scaledintensity;
 
 	if (light->_type == Grim::Light::Omni) {
 		lightPos = Math::Vector4d(light->_pos.x(), light->_pos.y(), light->_pos.z(), 1.0f);

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1128,11 +1128,9 @@ void GfxOpenGLS::setupLight(Grim::Light *light, int lightId) {
 		lightPos = Math::Vector4d(-light->_dir.x(), -light->_dir.y(), -light->_dir.z(), 0.0f);
 		lightDir = Math::Vector4d(0.0f, 0.0f, 0.0f, -1.0f);
 	} else if (light->_type == Grim::Light::Spot) {
-		float cosPenumbra = cosf(light->_penumbraangle * M_PI / 180.0f);
-		float cosUmbra = cosf(light->_umbraangle * M_PI / 180.0f);
 		lightPos = Math::Vector4d(light->_pos.x(), light->_pos.y(), light->_pos.z(), 1.0f);
 		lightDir = Math::Vector4d(light->_dir.x(), light->_dir.y(), light->_dir.z(), 1.0f);
-		lightParams = Math::Vector4d(light->_falloffNear, light->_falloffFar, cosPenumbra, cosUmbra);
+		lightParams = Math::Vector4d(light->_falloffNear, light->_falloffFar, light->_cospenumbraangle, light->_cosumbraangle);
 	} else if (light->_type == Grim::Light::Ambient) {
 		lightPos = Math::Vector4d(0.0f, 0.0f, 0.0f, -1.0f);
 		lightDir = Math::Vector4d(0.0f, 0.0f, 0.0f, -1.0f);

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -899,7 +899,7 @@ void GfxTinyGL::setupLight(Light *light, int lightId) {
 	float spot_exp = 0.0f;
 	float q_attenuation = 1.0f;
 
-	float intensity = light->_intensity / 15.0f;
+	float intensity = light->_scaledintensity;
 	lightColor[0] = (float)light->_color.getRed() * intensity;
 	lightColor[1] = (float)light->_color.getGreen() * intensity;
 	lightColor[2] = (float)light->_color.getBlue() * intensity;

--- a/engines/grim/set.cpp
+++ b/engines/grim/set.cpp
@@ -488,9 +488,10 @@ bool Set::Setup::restoreState(SaveGame *savedState) {
 	return true;
 }
 
-Light::Light() : _umbraangle(0.0f), _penumbraangle(0.0f),
-		_falloffNear(0.0f), _falloffFar(0.0f), _enabled(false), _id(0) {
+Light::Light() : _falloffNear(0.0f), _falloffFar(0.0f), _enabled(false), _id(0) {
 	setIntensity(0.0f);
+	setUmbra(0.0f);
+	setPenumbra(0.0f);
 }
 
 void Set::Setup::getRotation(float *x, float *y, float *z) {
@@ -541,6 +542,16 @@ void Set::Setup::setRoll(Math::Angle roll) {
 	}
 }
 
+void Light::setUmbra(float angle) {
+	_umbraangle = angle;
+	_cosumbraangle = cosf(angle * M_PI / 180.0f);
+}
+
+void Light::setPenumbra(float angle) {
+	_penumbraangle = angle;
+	_cospenumbraangle = cosf(angle * M_PI / 180.0f);
+}
+
 void Light::setIntensity(float intensity) {
 	_intensity = intensity;
 	if (g_grim->getGameType() == GType_MONKEY4) {
@@ -579,8 +590,10 @@ void Light::load(TextSplitter &ts) {
 	ts.scanString(" direction %f %f %f", 3, &_dir.x(), &_dir.y(), &_dir.z());
 	ts.scanString(" intensity %f", 1, &tmp);
 	setIntensity(tmp);
-	ts.scanString(" umbraangle %f", 1, &_umbraangle);
-	ts.scanString(" penumbraangle %f", 1, &_penumbraangle);
+	ts.scanString(" umbraangle %f", 1, &tmp);
+	setUmbra(tmp);
+	ts.scanString(" penumbraangle %f", 1, &tmp);
+	setPenumbra(tmp);
 
 	int r, g, b;
 	ts.scanString(" color %d %d %d", 3, &r, &g, &b);
@@ -627,8 +640,8 @@ void Light::loadBinary(Common::SeekableReadStream *data) {
 	data->read(v, sizeof(float) * 4);
 	_falloffNear = get_float(v);
 	_falloffFar = get_float(v + 4);
-	_umbraangle = get_float(v + 8);
-	_penumbraangle = get_float(v + 12);
+	setUmbra(get_float(v + 8));
+	setPenumbra(get_float(v + 12));
 
 	_enabled = true;
 }
@@ -689,8 +702,8 @@ bool Light::restoreState(SaveGame *savedState) {
 	_color         = savedState->readColor();
 
 	setIntensity(    savedState->readFloat());
-	_umbraangle    = savedState->readFloat();
-	_penumbraangle = savedState->readFloat();
+	setUmbra(        savedState->readFloat());
+	setPenumbra(     savedState->readFloat());
 
 	if (savedState->saveMinorVersion() >= 20) {
 		_falloffNear = savedState->readFloat();

--- a/engines/grim/set.h
+++ b/engines/grim/set.h
@@ -184,6 +184,7 @@ struct Light {
 	void loadBinary(Common::SeekableReadStream *data);
 	void saveState(SaveGame *savedState) const;
 	bool restoreState(SaveGame *savedState);
+	void setIntensity(float intensity);
 
 	enum LightType {
 		Omni = 1,
@@ -197,6 +198,7 @@ struct Light {
 	Math::Vector3d _pos, _dir;
 	Color _color;
 	float _intensity, _umbraangle, _penumbraangle, _falloffNear, _falloffFar;
+	float _scaledintensity;
 	bool _enabled;
 	// there may be more lights with the same position, so this is used to make the sort stable
 	int _id;

--- a/engines/grim/set.h
+++ b/engines/grim/set.h
@@ -185,6 +185,8 @@ struct Light {
 	void saveState(SaveGame *savedState) const;
 	bool restoreState(SaveGame *savedState);
 	void setIntensity(float intensity);
+	void setUmbra(float angle);
+	void setPenumbra(float angle);
 
 	enum LightType {
 		Omni = 1,
@@ -198,7 +200,7 @@ struct Light {
 	Math::Vector3d _pos, _dir;
 	Color _color;
 	float _intensity, _umbraangle, _penumbraangle, _falloffNear, _falloffFar;
-	float _scaledintensity;
+	float _scaledintensity, _cosumbraangle, _cospenumbraangle;
 	bool _enabled;
 	// there may be more lights with the same position, so this is used to make the sort stable
 	int _id;


### PR DESCRIPTION
Low-hanging fruits I found while working on lighting last year, where computation could be obviously moved to less-called code.
I do not remember formally benchmarking the difference. Feel free to reject.