### PR TITLE
GRIM: Adds support for loading embedded colormaps.

### DIFF
--- a/engines/grim/material.h
+++ b/engines/grim/material.h
@@ -52,7 +52,7 @@ public:
 	static Common::List<MaterialData *> *_materials;
 
 	Common::String _fname;
-	const ObjectPtr<CMap> _cmap;
+	ObjectPtr<CMap> _cmap;
 	int _numImages;
 	Texture **_textures;
 	int _refCount;
@@ -60,6 +60,7 @@ public:
 private:
 	void initGrim(Common::SeekableReadStream *data);
 	void initEMI(Common::SeekableReadStream *data);
+	bool _ownCMap;
 };
 
 class Material : public Object {


### PR DESCRIPTION
Implementing some understanding I had of material file structure while working no lighting code last year.

Very few material files define their own color maps:
  DATA000.LAB/blue.mat
  DATA000.LAB/orange.mat
  DATA000.LAB/pink.mat
  DATA000.LAB/white.mat
  DATA001.LAB/bren_chest.mat
  DATA001.LAB/bren_shin.mat
  DATA001.LAB/bren_skin.mat
  DATA001.LAB/bren_thigh.mat
  DATA004.LAB/bren_chest.mat
  DATA004.LAB/bren_shin.mat
  DATA004.LAB/bren_skin.mat
  DATA004.LAB/bren_thigh.mat
Also, walk (but ignore) downscaled mipmaps. Even fewer files contain them, and
they contain a single image each (with 3 mipmaps):
  DATA000.LAB/dflt.mat
  DATA000.LAB/shadow.mat