### PR TITLE
AMIGAOS: Static builds preferred

### DIFF
--- a/configure
+++ b/configure
@@ -2105,7 +2105,7 @@ echo_n "Checking hosttype... "
 echo $_host_os
 case $_host_os in
 	amigaos*)
-		append_var LDFLAGS "-use-dynld -Wl,--export-dynamic"
+		append_var LDFLAGS "-Wl,--export-dynamic"
 		append_var LDFLAGS "-L/sdk/local/newlib/lib"
 		# We have to use 'long' for our 4 byte typedef because AmigaOS already typedefs (u)int32
 		# as (unsigned) long, and consequently we'd get a compiler error otherwise.


### PR DESCRIPTION
Reasons:
- Shared objects aren't really shared on AmigaOS.
(Once two programs load the same .so, it will be available twice in memory, instead of sharing the already available one)
- To make the program run for everyone i need to provide a subdir (SObjs/) which holds all the .so's used while compiling (which are not available in a clean OS install), otherwise most people have to go hunting for the correct .so's online.
Even worse is the fact that, if users have older (incompatible) .so's installed, they might experience crashes.
- There is no benefit in building ResidualVM with shared objects (at least on AmigaOS), because even *if* a new lib version (i.e. libPNG) would be made available as an .so (and features new stuff), it won't be mandatory to immediately switch to it, because ResidualVM probably won't take advantage of the new features as fast anyway.
So, a rebuilt is always better (imho).

In short:
Switchting to static builds to reduce user grief, crash reports, a little less work to create the package and as a bonus have ResidualVM start a little faster.