### PR TITLE
README: Add the easy to miss Local.m4b of EMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You will need to copy the data files from your Escape from Monkey Island CDs
 into one directory. Specifically, you'll need:
   * All of the .M4B files from both CDs
     One of the files is easy to miss:
-    Local.m4b is located on CD1 in Monkey4/MonkeyInstall
+    local.m4b is located on CD1 in Monkey4/MonkeyInstall
         Note: The file voiceAll.m4b is repeated on both CDs. Use the
               copy from the first CD, it contains all of the required
               voice data

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ directory. Specifically, you'll need:
 You will need to copy the data files from your Escape from Monkey Island CDs
 into one directory. Specifically, you'll need:
   * All of the .M4B files from both CDs
+    One of the files is easy to miss:
+    Local.m4b is located on CD1 in Monkey4/MonkeyInstall
         Note: The file voiceAll.m4b is repeated on both CDs. Use the
               copy from the first CD, it contains all of the required
               voice data

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ directory. Specifically, you'll need:
 
 You will need to copy the data files from your Escape from Monkey Island CDs
 into one directory. Specifically, you'll need:
-  * All of the .M4B files from both CDs
+  * All of the .M4B files from both CDs.
     One of the files is easy to miss:
-    local.m4b is located on CD1 in Monkey4/MonkeyInstall
+    local.m4b is located on CD1 in Monkey4/MonkeyInstall.
         Note: The file voiceAll.m4b is repeated on both CDs. Use the
               copy from the first CD, it contains all of the required
               voice data


### PR DESCRIPTION
Some users have difficulties finding/installing that file (as it's a single one and located in the "MonkeyInstall" drawer which never seems to be checked when copying the data over.