### PR TITLE
Multisampling for framebuffers

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -226,7 +226,7 @@ void SurfaceSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, boo
 
 #ifdef USE_OPENGL
 	if (_opengl) {
-		createScreenOpenGL(effectiveWidth, effectiveHeight);
+		createScreenOpenGL(effectiveWidth, effectiveHeight, gameRenderTarget);
 	} else
 #endif
 	{
@@ -484,10 +484,10 @@ SurfaceSdlGraphicsManager::OpenGLPixelFormat::OpenGLPixelFormat(uint screenBytes
 
 }
 
-void SurfaceSdlGraphicsManager::createScreenOpenGL(uint effectiveWidth, uint effectiveHeight) {
+void SurfaceSdlGraphicsManager::createScreenOpenGL(uint effectiveWidth, uint effectiveHeight, GameRenderTarget gameRenderTarget) {
 	// Build a list of OpenGL pixel formats usable by ResidualVM
 	Common::Array<OpenGLPixelFormat> pixelFormats;
-	if (_antialiasing > 0) {
+	if (_antialiasing > 0 && gameRenderTarget == kScreen) {
 		// Don't enable screen level multisampling when rendering to a framebuffer
 		pixelFormats.push_back(OpenGLPixelFormat(32, 8, 8, 8, 8, _antialiasing));
 		pixelFormats.push_back(OpenGLPixelFormat(16, 5, 5, 5, 1, _antialiasing));

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -344,7 +344,11 @@ void SurfaceSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, boo
 #if defined(USE_OPENGL) && !defined(AMIGAOS)
 	if (gameRenderTarget == kFramebuffer) {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		_frameBuffer = new OpenGL::FrameBuffer(gameWidth, gameHeight);
+		if (_antialiasing) {
+			_frameBuffer = new OpenGL::MultiSampleFrameBuffer(gameWidth, gameHeight);
+		} else {
+			_frameBuffer = new OpenGL::FrameBuffer(gameWidth, gameHeight);
+		}
 		_frameBuffer->attach();
 	}
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -344,11 +344,7 @@ void SurfaceSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, boo
 #if defined(USE_OPENGL) && !defined(AMIGAOS)
 	if (gameRenderTarget == kFramebuffer) {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		if (_antialiasing) {
-			_frameBuffer = new OpenGL::MultiSampleFrameBuffer(gameWidth, gameHeight);
-		} else {
-			_frameBuffer = new OpenGL::FrameBuffer(gameWidth, gameHeight);
-		}
+		_frameBuffer = createFramebuffer(gameWidth, gameHeight);
 		_frameBuffer->attach();
 	}
 #endif
@@ -616,6 +612,17 @@ void SurfaceSdlGraphicsManager::drawSideTexturesOpenGL() {
 			Math::Rect2d rightRect(_gameRect.getTopRight() - nudge, Math::Vector2d(right, 1.0));
 			_surfaceRenderer->render(_sideTextures[1], rightRect, true);
 		}
+	}
+}
+
+OpenGL::FrameBuffer *SurfaceSdlGraphicsManager::createFramebuffer(uint width, uint height) {
+#ifndef USE_GLES2
+	if (_antialiasing && OpenGLContext.framebufferObjectMultisampleSupported) {
+		return new OpenGL::MultiSampleFrameBuffer(width, height, _antialiasing);
+	} else
+#endif
+	{
+		return new OpenGL::FrameBuffer(width, height);
 	}
 }
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -226,6 +226,7 @@ protected:
 	void drawSideTexturesOpenGL();
 
 	OpenGL::FrameBuffer *_frameBuffer;
+	OpenGL::FrameBuffer *createFramebuffer(uint width, uint height);
 
 	OpenGL::SurfaceRenderer *_surfaceRenderer;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -169,9 +169,27 @@ protected:
 	Math::Rect2d _gameRect;
 
 #ifdef USE_OPENGL
+	struct OpenGLPixelFormat {
+		uint bytesPerPixel;
+		uint redSize;
+		uint blueSize;
+		uint greenSize;
+		uint alphaSize;
+		int multisampleSamples;
+
+		OpenGLPixelFormat(uint screenBytesPerPixel, uint red, uint blue, uint green, uint alpha, int samples);
+	};
+
+	/**
+	 * Initialize an OpenGL window matching as closely as possible the required properties
+	 *
+	 * When unable to create a context with anti-aliasing this tries without.
+	 * When unable to create a context with the desired pixel depth this tries lower values.
+	 */
+	void createScreenOpenGL(uint effectiveWidth, uint effectiveHeight);
+
 	// Antialiasing
 	int _antialiasing;
-	void setAntialiasing(bool enable);
 
 	// Overlay
 	Common::Array<OpenGL::Texture *> _overlayTextures;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -138,6 +138,30 @@ public:
 	virtual void notifyMousePos(Common::Point mouse);
 
 protected:
+	/**
+	 * Places where the game can be drawn
+	 */
+	enum GameRenderTarget {
+		kScreen,     /** The game is drawn directly on the screen */
+				kSubScreen,  /** The game is drawn to a surface, which is centered on the screen */
+				kFramebuffer /** The game is drawn to a framebuffer, which is scaled to fit the screen */
+	};
+
+	/** Select the best draw target according to the specified parameters */
+	GameRenderTarget selectGameRenderTarget(bool fullscreen, bool accel3d,
+	                                        bool engineSupportsArbitraryResolutions,
+	                                        bool framebufferSupported,
+	                                        bool lockAspectRatio);
+
+	/** Compute the size and position of the game rectangle in the screen */
+	Math::Rect2d computeGameRect(GameRenderTarget gameRenderTarget, uint gameWidth, uint gameHeight,
+	                             uint effectiveWidth, uint effectiveHeight);
+
+	/** Checks if the render target supports drawing at arbitrary resolutions */
+	bool canUsePreferredResolution(GameRenderTarget gameRenderTarget, bool engineSupportsArbitraryResolutions);
+
+	/** Obtain the user configured fullscreen resolution, or default to the desktop resolution */
+	Common::Rect getPreferredFullscreenResolution();
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_Renderer *_renderer;
@@ -186,7 +210,7 @@ protected:
 	 * When unable to create a context with anti-aliasing this tries without.
 	 * When unable to create a context with the desired pixel depth this tries lower values.
 	 */
-	void createScreenOpenGL(uint effectiveWidth, uint effectiveHeight);
+	void createScreenOpenGL(uint effectiveWidth, uint effectiveHeight, GameRenderTarget gameRenderTarget);
 
 	// Antialiasing
 	int _antialiasing;
@@ -218,31 +242,6 @@ protected:
 	void drawSideTextures();
 
 	bool detectFramebufferSupport();
-
-	/**
-	 * Places where the game can be drawn
-	 */
-	enum GameRenderTarget {
-		kScreen,     /** The game is drawn directly on the screen */
-		kSubScreen,  /** The game is drawn to a surface, which is centered on the screen */
-		kFramebuffer /** The game is drawn to a framebuffer, which is scaled to fit the screen */
-	};
-
-	/** Select the best draw target according to the specified parameters */
-	GameRenderTarget selectGameRenderTarget(bool fullscreen, bool accel3d,
-	                                        bool engineSupportsArbitraryResolutions,
-	                                        bool framebufferSupported,
-	                                        bool lockAspectRatio);
-
-	/** Compute the size and position of the game rectangle in the screen */
-	Math::Rect2d computeGameRect(GameRenderTarget gameRenderTarget, uint gameWidth, uint gameHeight,
-	                             uint effectiveWidth, uint effectiveHeight);
-
-	/** Checks if the render target supports drawing at arbitrary resolutions */
-	bool canUsePreferredResolution(GameRenderTarget gameRenderTarget, bool engineSupportsArbitraryResolutions);
-
-	/** Obtain the user configured fullscreen resolution, or default to the desktop resolution */
-	Common::Rect getPreferredFullscreenResolution();
 };
 
 #endif

--- a/graphics/opengl/context.h
+++ b/graphics/opengl/context.h
@@ -71,6 +71,15 @@ public:
 	/** Whether FBO support is available or not. */
 	bool framebufferObjectSupported;
 
+	/** Whether multisample FBO support is available or not */
+	bool framebufferObjectMultisampleSupported;
+
+	/**
+	 * Contains the maximum number of supported multisample samples
+	 * if multisample FBOs are supported. Contains -1 otherwise.
+	 */
+	int multisampleMaxSamples;
+
 	/** Whether packing the depth and stencil buffers is possible or not. */
 	bool packedDepthStencilSupported;
 

--- a/graphics/opengl/framebuffer.cpp
+++ b/graphics/opengl/framebuffer.cpp
@@ -36,7 +36,9 @@
 #define GL_STENCIL_ATTACHMENT GL_STENCIL_ATTACHMENT_EXT
 #define GL_STENCIL_INDEX8 GL_STENCIL_INDEX8_EXT
 #define GL_DEPTH24_STENCIL8 0x88F0
-#endif
+#define GL_READ_FRAMEBUFFER 0x8CA8
+#define GL_DRAW_FRAMEBUFFER 0x8CA9
+#endif // defined(GL_ARB_framebuffer_object)
 #include "backends/platform/sdl/sdl-sys.h"
 #else
 #include "graphics/opengl/framebuffer.h"
@@ -62,6 +64,11 @@ static PFNGLFRAMEBUFFERTEXTURE2DEXTPROC glFramebufferTexture2D;
 static PFNGLGENFRAMEBUFFERSEXTPROC glGenFramebuffers;
 static PFNGLGENRENDERBUFFERSEXTPROC glGenRenderbuffers;
 static PFNGLRENDERBUFFERSTORAGEEXTPROC glRenderbufferStorage;
+typedef void (* PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
+static PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisample;
+typedef void (* PFNGLBLITFRAMEBUFFEREXTPROC) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+static PFNGLBLITFRAMEBUFFEREXTPROC glBlitFramebuffer;
+
 
 static void grabFramebufferObjectPointers() {
 	if (framebuffer_object_functions)
@@ -75,6 +82,8 @@ static void grabFramebufferObjectPointers() {
 	// We're casting from an object pointer to a function pointer, the
 	// sizes need to be the same for this to work.
 	assert(sizeof(u.obj_ptr) == sizeof(u.func_ptr));
+	u.obj_ptr = SDL_GL_GetProcAddress("glBlitFramebuffer");
+	glBlitFramebuffer = (PFNGLBLITFRAMEBUFFEREXTPROC)u.func_ptr;
 	u.obj_ptr = SDL_GL_GetProcAddress("glBindFramebuffer");
 	glBindFramebuffer = (PFNGLBINDFRAMEBUFFEREXTPROC)u.func_ptr;
 	u.obj_ptr = SDL_GL_GetProcAddress("glBindRenderbuffer");
@@ -95,6 +104,8 @@ static void grabFramebufferObjectPointers() {
 	glGenRenderbuffers = (PFNGLGENRENDERBUFFERSEXTPROC)u.func_ptr;
 	u.obj_ptr = SDL_GL_GetProcAddress("glRenderbufferStorage");
 	glRenderbufferStorage = (PFNGLRENDERBUFFERSTORAGEEXTPROC)u.func_ptr;
+	u.obj_ptr = SDL_GL_GetProcAddress("glRenderbufferStorageMultisample");
+	glRenderbufferStorageMultisample = (PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC)u.func_ptr;
 }
 #endif // defined(SDL_BACKEND) && !defined(USE_GLEW) && !defined(USE_GLES2)
 

--- a/graphics/opengl/framebuffer.h
+++ b/graphics/opengl/framebuffer.h
@@ -56,7 +56,7 @@ private:
 #if !defined(USE_GLES2) && !defined(AMIGAOS)
 class MultiSampleFrameBuffer : public FrameBuffer {
 public:
-	MultiSampleFrameBuffer(uint width, uint height);
+	MultiSampleFrameBuffer(uint width, uint height, int samples);
 	virtual ~MultiSampleFrameBuffer();
 
 	virtual void attach();
@@ -67,6 +67,7 @@ private:
 	GLuint _msFrameBufferId;
 	GLuint _msColorId;
 	GLuint _msDepthId;
+	GLuint _msSamples;
 };
 #endif
 

--- a/graphics/opengl/framebuffer.h
+++ b/graphics/opengl/framebuffer.h
@@ -40,15 +40,35 @@ public:
 #else
 	virtual ~FrameBuffer();
 
-	void attach();
-	void detach();
+	virtual void attach();
+	virtual void detach();
 #endif
+
+protected:
+	GLuint getFrameBufferName() const { return _frameBuffer; }
 
 private:
 	void init();
 	GLuint _renderBuffers[2];
 	GLuint _frameBuffer;
 };
+
+#if !defined(USE_GLES2) && !defined(AMIGAOS)
+class MultiSampleFrameBuffer : public FrameBuffer {
+public:
+	MultiSampleFrameBuffer(uint width, uint height);
+	virtual ~MultiSampleFrameBuffer();
+
+	virtual void attach();
+	virtual void detach();
+
+private:
+	void init();
+	GLuint _msFrameBufferId;
+	GLuint _msColorId;
+	GLuint _msDepthId;
+};
+#endif
 
 } // End of namespace OpenGL
 

--- a/graphics/opengl/system_headers.h
+++ b/graphics/opengl/system_headers.h
@@ -46,6 +46,11 @@
 #define GL_UNPACK_ROW_LENGTH 0x0CF2
 #endif
 
+#if !defined(GL_MAX_SAMPLES)
+// The Android SDK does not declare GL_MAX_SAMPLES
+#define GL_MAX_SAMPLES 0x8D57
+#endif
+
 #elif defined(USE_GLEW)
 #include <GL/glew.h>
 #elif defined(SDL_BACKEND) && defined(USE_OPENGL)


### PR DESCRIPTION
The Grim engine draws to a framebuffer, when used in fullscreen mode, in order to use the desktop resolution and scale keeping a correct aspect ratio. This is an updated version of @Botje's work on enabling anti-aliasing when rendering to framebuffers (#1191).

I have added error checking and fallbacks to Botje's work, so that it should be in a mergable state.