### PR TITLE
Basic port to SDL2

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -166,7 +166,9 @@ protected:
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_Renderer *_renderer;
 	SDL_Texture *_screenTexture;
+	SDL_GLContext _glContext;
 	void deinitializeRenderer();
+	SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags);
 #endif
 
 	SDL_Surface *_screen;
@@ -243,6 +245,7 @@ protected:
 	void drawSideTextures();
 
 	bool detectFramebufferSupport();
+	void detectDesktopResolution();
 };
 
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -210,7 +210,7 @@ protected:
 	 * When unable to create a context with anti-aliasing this tries without.
 	 * When unable to create a context with the desired pixel depth this tries lower values.
 	 */
-	void createScreenOpenGL(uint effectiveWidth, uint effectiveHeight, GameRenderTarget gameRenderTarget);
+	bool createScreenOpenGL(uint effectiveWidth, uint effectiveHeight, GameRenderTarget gameRenderTarget);
 
 	// Antialiasing
 	int _antialiasing;

--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -79,6 +79,23 @@ typedef struct { int FAKE; } FAKE_FILE;
 
 #endif
 
+#ifdef MACOSX
+
+// ResidualVM specific undefs for SDL2 to allow compile with MacOS X:
+#undef asctime
+#undef time
+#undef ctime
+#undef mktime
+#undef difftime
+#undef getdate
+#undef localtime
+#undef gmtime
+#undef clock
+#undef longjmp
+#undef setjmp
+
+#endif
+
 #if defined(__SYMBIAN32__)
 #include <esdl\SDL.h>
 #else


### PR DESCRIPTION
This PR contains minimal changes to make ResidualVM work with SDL2. It is based on previous work by @aquadran and the ScummVM team.

Features are the same as with SDL1. The only exception being that it is now possible to use GLES2 contexts when building with SDL2.

Configuring with SDL2 is done using the following command:
`SDL_CONFIG=sdl2-config ./configure`

Configuring with SDL2 for GLES2 is done using the following command:
`SDL_CONFIG=sdl2-config ./configure --force-opengles2 --disable-glew --enable-opengl-shaders`
This command looks like a black magic invocation, and should probably be simplified at a later point.

I've done tests without noticing bugs in the following configurations:
- Linux OpenGL (mesa/radeonsi)
- Linux GLES2 (mesa/radeonsi)
- Windows 7 OpenGL (AMD Catalyst)
- Windows 7 GLES2 (ANGLE) (Manny is not visible)

I'd be curious to have test results with OS X, Raspberry PI, (and AmigaOS, if the SDL2 port is mature enough).