### PR TITLE
GRIM,EMI: Drop Grim::Component::setupTexture

### DIFF
--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1745,11 +1745,6 @@ bool Actor::updateTalk(uint frameTime) {
 }
 
 void Actor::draw() {
-	for (Common::List<Costume *>::iterator i = _costumeStack.begin(); i != _costumeStack.end(); ++i) {
-		Costume *c = *i;
-		c->setupTextures();
-	}
-
 	if (!g_driver->isHardwareAccelerated() && g_grim->getFlagRefreshShadowMask()) {
 		for (int l = 0; l < MAX_SHADOWS; l++) {
 			if (!_shadowArray[l].active)

--- a/engines/grim/costume.cpp
+++ b/engines/grim/costume.cpp
@@ -81,10 +81,6 @@ namespace Grim {
 //                given by a playing chore
 // update() -- gives the component a chance to update its internal
 //             state once every frame
-// setupTexture() -- sets up animated textures for the object.  This
-//                   is a separate stage from update() since all the
-//                   costumes on screen need to get updated before any
-//                   drawing can start.
 // draw() -- actually draws the component onto the screen
 // reset() -- notifies the component that a chore controlling it
 //            has stopped
@@ -418,12 +414,6 @@ int Costume::isChoring(bool excludeLooping) {
 			return i;
 	}
 	return -1;
-}
-
-void Costume::setupTextures() {
-	for (int i = 0; i < _numComponents; i++)
-		if (_components[i])
-			_components[i]->setupTexture();
 }
 
 void Costume::draw() {

--- a/engines/grim/costume.h
+++ b/engines/grim/costume.h
@@ -83,7 +83,6 @@ public:
 
 	virtual int update(uint frameTime);
 	void animate();
-	void setupTextures();
 	virtual void draw();
 	void getBoundingBox(int *x1, int *y1, int *x2, int *y2);
 	void setPosRotate(const Math::Vector3d &pos, const Math::Angle &pitch,

--- a/engines/grim/costume/component.h
+++ b/engines/grim/costume/component.h
@@ -49,7 +49,6 @@ public:
 	virtual void setMapName(char *) { }
 	virtual int update(uint time) { return 0; }
 	virtual void animate() { }
-	virtual void setupTexture() { }
 	virtual void draw() { }
 	virtual void reset() { }
 	virtual void fade(Animation::FadeMode, int) { }


### PR DESCRIPTION
This method is never implemented, so drop its declaration and callers.