### PR TITLE
(DO NOT MERGE) TINYGL: Ignore zero-coordinate-delta textures.

### DIFF
--- a/graphics/tinygl/clip.cpp
+++ b/graphics/tinygl/clip.cpp
@@ -409,6 +409,7 @@ void gl_draw_triangle_fill(GLContext *c, GLVertex *p0, GLVertex *p1, GLVertex *p
 		count_triangles++;
 	}
 #endif
+	const Vector4 default_tex_coord = Vector4(0.0f, 0.0f, 0.0f, 1.0f);
 
 	if (c->color_mask == 0) {
 		// FIXME: Accept more than just 0 or 1.
@@ -420,7 +421,11 @@ void gl_draw_triangle_fill(GLContext *c, GLVertex *p0, GLVertex *p1, GLVertex *p
 	} else if (c->shadow_mode & 2) {
 		assert(c->fb->shadow_mask_buf);
 		c->fb->fillTriangleFlatShadow(&p0->zp, &p1->zp, &p2->zp);
-	} else if (c->texture_2d_enabled) {
+	} else if (c->texture_2d_enabled && (
+		p0->tex_coord != default_tex_coord ||
+		p1->tex_coord != default_tex_coord ||
+		p2->tex_coord != default_tex_coord
+	)) {
 #ifdef TINYGL_PROFILE
 		count_triangles_textured++;
 #endif


### PR DESCRIPTION
The holepunch in ha has what is likely a data error: all textures
coordinates are (0, 0). TinyGL used to render the holepunch in the (likely
intended) dark blue color from the texture. But this is inconsistently
handled between TinyGL and OpenGL (with and without shaders): the latter
ignore the texture, and render the holepunch as shaded grey. So make
TinyGL behave consistently - data error can be fixed independently.

Original Grim software renderer display the holepunch in a very dark grey
color, making it hard to tell if it takes the texture into account at all.
Data remained the same in remastered edition, which displays the holepunch
as light grey (on linux at least), consistently with residual OpenGL
renderer.

Note: this modifies bug #58 as now all renderers are consistent. But the
data error remains.
