### PR TITLE
GRIM, TINYGL: Always check if texture matrix need applying.

### DIFF
--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -877,7 +877,7 @@ void GfxTinyGL::rotateViewpoint(const Math::Matrix4 &rot) {
 }
 
 void GfxTinyGL::translateViewpointFinish() {
-	//glMatrixMode(GL_MODELVIEW); // exist in opengl but doesn't work properly here
+	tglMatrixMode(TGL_MODELVIEW);
 	tglPopMatrix();
 }
 
@@ -1247,12 +1247,9 @@ void GfxTinyGL::selectTexture(const Texture *texture) {
 
 	// Grim has inverted tex-coords, EMI doesn't
 	if (g_grim->getGameType() != GType_MONKEY4) {
-		tglPushMatrix(); // removed in opengl but here doesn't work properly after remove
 		tglMatrixMode(TGL_TEXTURE);
 		tglLoadIdentity();
 		tglScalef(1.0f / texture->_width, 1.0f / texture->_height, 1);
-		tglMatrixMode(TGL_MODELVIEW); // removed in opengl but here doesn't work properly after remove
-		tglPopMatrix(); // removed in opengl but here doesn't work properly after remove
 	}
 }
 

--- a/graphics/tinygl/vertex.cpp
+++ b/graphics/tinygl/vertex.cpp
@@ -113,11 +113,11 @@ void glopBegin(GLContext *c, GLParam *p) {
 				c->matrix_model_projection_no_w_transform = 1;
 		}
 
-		// test if the texture matrix is not Identity
-		c->apply_texture_matrix = !c->matrix_stack_ptr[2]->isIdentity();
-
 		c->matrix_model_projection_updated = 0;
 	}
+	// test if the texture matrix is not Identity
+	c->apply_texture_matrix = !c->matrix_stack_ptr[2]->isIdentity();
+
 	// viewport
 	if (c->viewport.updated) {
 		gl_eval_viewport(c);


### PR DESCRIPTION
matrix_model_projection_updated is not set when texture matrix alone is
modified.
Allows getting rid of a few TinyGL-only lines.