### PR TITLE
TinyGL: Fix TGL_ALPHA_TEST support with clipped triangles

### DIFF
--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -730,9 +730,13 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 }
 
 void GfxTinyGL::drawModelFace(const Mesh *mesh, const MeshFace *face) {
+	// Support transparency in actor objects, such as the message tube
+	// in Manny's Office
 	float *vertices = mesh->_vertices;
 	float *vertNormals = mesh->_vertNormals;
 	float *textureVerts = mesh->_textureVerts;
+	tglAlphaFunc(TGL_GREATER, 0.5);
+	tglEnable(TGL_ALPHA_TEST);
 	tglNormal3fv(const_cast<float *>(face->getNormal().getData()));
 	tglBegin(TGL_POLYGON);
 	for (int i = 0; i < face->getNumVertices(); i++) {
@@ -741,10 +745,11 @@ void GfxTinyGL::drawModelFace(const Mesh *mesh, const MeshFace *face) {
 		if (face->hasTexture())
 			tglTexCoord2fv(textureVerts + 2 * face->getTextureVertex(i));
 
-		tglColor4f(1.0f, 1.0f, 1.0f, _alpha);
 		tglVertex3fv(vertices + 3 * face->getVertex(i));
 	}
 	tglEnd();
+	// Done with transparency-capable objects
+	tglDisable(TGL_ALPHA_TEST);
 }
 
 void GfxTinyGL::drawSprite(const Sprite *sprite) {

--- a/graphics/tinygl/clip.cpp
+++ b/graphics/tinygl/clip.cpp
@@ -226,13 +226,12 @@ float(*clip_proc[6])(Vector4 *, Vector4 *, Vector4 *) =  {
 
 static inline void updateTmp(GLContext *c, GLVertex *q, GLVertex *p0, GLVertex *p1, float t) {
 	if (c->current_shade_model == TGL_SMOOTH) {
-		float a = q->color.W;
 		q->color = p0->color + (p1->color - p0->color) * t;
-		q->color.W = a;
 	} else {
 		q->color.X = (p0->color.X);
 		q->color.Y = (p0->color.Y);
 		q->color.Z = (p0->color.Z);
+		q->color.W = (p0->color.W);
 	}
 
 	if (c->texture_2d_enabled) {

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -188,13 +188,21 @@ struct FrameBuffer {
 
 	template <bool kEnableAlphaTest, bool kBlendingEnabled>
 	FORCEINLINE void writePixel(int pixel, int value) {
+		writePixel<kEnableAlphaTest, kBlendingEnabled, false>(pixel, value, 0);
+	}
+
+	template <bool kEnableAlphaTest, bool kBlendingEnabled, bool kDepthWrite>
+	FORCEINLINE void writePixel(int pixel, int value, unsigned int z) {
 		byte rSrc, gSrc, bSrc, aSrc;
 		this->pbuf.getFormat().colorToARGB(value, aSrc, rSrc, gSrc, bSrc);
 
 		if (kBlendingEnabled == false) {
 			this->pbuf.setPixelAt(pixel, value);
+			if (kDepthWrite) {
+				_zbuf[pixel] = z;
+			}
 		} else {
-			writePixel<kEnableAlphaTest, kBlendingEnabled>(pixel, aSrc, rSrc, gSrc, bSrc);
+			writePixel<kEnableAlphaTest, kBlendingEnabled, kDepthWrite>(pixel, aSrc, rSrc, gSrc, bSrc, z);
 		}
 	}
 
@@ -218,9 +226,17 @@ struct FrameBuffer {
 
 	template <bool kEnableAlphaTest, bool kBlendingEnabled>
 	FORCEINLINE void writePixel(int pixel, byte aSrc, byte rSrc, byte gSrc, byte bSrc) {
+		writePixel<kEnableAlphaTest, kBlendingEnabled, false>(pixel, aSrc, rSrc, gSrc, bSrc, 0);
+	}
+
+	template <bool kEnableAlphaTest, bool kBlendingEnabled, bool kDepthWrite>
+	FORCEINLINE void writePixel(int pixel, byte aSrc, byte rSrc, byte gSrc, byte bSrc, unsigned int z) {
 		if (kEnableAlphaTest) {
 			if (!checkAlphaTest(aSrc))
 				return;
+		}
+		if (kDepthWrite) {
+			_zbuf[pixel] = z;
 		}
 		
 		if (kBlendingEnabled == false) {

--- a/graphics/tinygl/zline.cpp
+++ b/graphics/tinygl/zline.cpp
@@ -40,19 +40,16 @@ FORCEINLINE static void putPixel(FrameBuffer *buffer, int pixelOffset,
 	if (kInterpZ) {
 		if (buffer->compareDepth(z, *pz)) {
 			if (kInterpRGB) {
-				buffer->writePixel(pixelOffset, RGB_TO_PIXEL(r, g, b));
+				buffer->writePixel<true, true, kDepthWrite>(pixelOffset, RGB_TO_PIXEL(r, g, b), z);
 			} else {
-				buffer->writePixel(pixelOffset, color);
-			}
-			if (kDepthWrite) {
-				*pz = z;
+				buffer->writePixel<true, true, kDepthWrite>(pixelOffset, color, z);
 			}
 		}
 	} else {
 		if (kInterpRGB) {
-			buffer->writePixel(pixelOffset, RGB_TO_PIXEL(r, g, b));
+			buffer->writePixel<true, true>(pixelOffset, RGB_TO_PIXEL(r, g, b));
 		} else {
-			buffer->writePixel(pixelOffset, color);
+			buffer->writePixel<true, true>(pixelOffset, color);
 		}
 	}
 }

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -43,10 +43,7 @@ FORCEINLINE static void putPixelFlat(FrameBuffer *buffer, int buf, unsigned int 
 		unsigned int r = (color & 0xF800) >> 8;
 		unsigned int g = (color & 0x07E0) >> 3;
 		unsigned int b = (color & 0x001F) << 3;
-		buffer->writePixel<kEnableAlphaTest, kEnableBlending>(buf + _a, a / 256, r, g, b);
-		if (kDepthWrite) {
-			pz[_a] = z;
-		}
+		buffer->writePixel<kEnableAlphaTest, kEnableBlending, kDepthWrite>(buf + _a, a / 256, r, g, b, z);
 	}
 	z += dzdx;
 }
@@ -61,10 +58,7 @@ FORCEINLINE static void putPixelSmooth(FrameBuffer *buffer, int buf, unsigned in
 		unsigned int r = (color & 0xF800) >> 8;
 		unsigned int g = (color & 0x07E0) >> 3;
 		unsigned int b = (color & 0x001F) << 3;
-		buffer->writePixel<kEnableAlphaTest, kEnableBlending>(buf + _a, a / 256, r, g, b);
-		if (kDepthWrite) {
-			pz[_a] = z;
-		}
+		buffer->writePixel<kEnableAlphaTest, kEnableBlending, kDepthWrite>(buf + _a, a / 256, r, g, b, z);
 	}
 	z += dzdx;
 	a += dadx;
@@ -111,10 +105,7 @@ FORCEINLINE static void putPixelTextureMappingPerspective(FrameBuffer *buffer, i
 			c_g = (c_g * l_g) / 256;
 			c_b = (c_b * l_b) / 256;
 		}
-		buffer->writePixel<kEnableAlphaTest, kEnableBlending>(buf + _a, c_a, c_r, c_g, c_b);
-		if (kDepthWrite) {
-			pz[_a] = z;
-		}
+		buffer->writePixel<kEnableAlphaTest, kEnableBlending, kDepthWrite>(buf + _a, c_a, c_r, c_g, c_b, z);
 	}
 	z += dzdx;
 	s += dsdx;
@@ -490,10 +481,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 					while (n >= 3) {
 						for (int a = 0; a < 4; a++) {
 							if ((!kEnableScissor || !scissorPixel(buf + a)) && compareDepth(z, pz[a]) && pm[0]) {
-								writePixel<kAlphaTestEnabled, kBlendingEnabled>(buf + a, color);
-								if (kDepthWrite) {
-									pz[a] = z;
-								}
+								writePixel<kAlphaTestEnabled, kBlendingEnabled, kDepthWrite>(buf + a, color, z);
 							}
 							z += dzdx;
 						}
@@ -504,10 +492,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 					}
 					while (n >= 0) {
 						if ((!kEnableScissor || !scissorPixel(buf)) && compareDepth(z, pz[0]) && pm[0]) {
-							writePixel<kAlphaTestEnabled, kBlendingEnabled>(buf, color);
-							if (kDepthWrite) {
-								pz[0] = z;
-							}
+							writePixel<kAlphaTestEnabled, kBlendingEnabled, kDepthWrite>(buf, color, z);
 						}
 						pz += 1;
 						pm += 1;


### PR DESCRIPTION
Before the first patch, enabling TGL_ALPHA_TEST in GRIM would cause clipped faces to completely disappear (with a striking effect in set mo when near the tube): their vertices' color would become 0 because of updateTmp saving & restoring W color component while it was never set before. And of course, enabling alpha testing makes these vertices go away along with their textures.
The TinyGL patch corrects this original issue, and the GRIM patch makes use of alpha test.

As a result, alpha textures (like the card) look better than before.