### PR TITLE
TINYGL: Simplify zline.cpp .

### DIFF
--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -411,9 +411,6 @@ struct FrameBuffer {
 	template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, int kDrawMode>
 	void fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2);
 
-	template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
-	void fillLineGeneric(ZBufferPoint *p1, ZBufferPoint *p2, int color);
-
 	void fillTriangleTextureMappingPerspectiveSmooth(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2);
 	void fillTriangleTextureMappingPerspectiveFlat(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2);
 	void fillTriangleDepthOnly(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2);
@@ -425,9 +422,9 @@ struct FrameBuffer {
 	void plot(ZBufferPoint *p);
 	void fillLine(ZBufferPoint *p1, ZBufferPoint *p2);
 	void fillLineZ(ZBufferPoint *p1, ZBufferPoint *p2);
-	void fillLineFlatZ(ZBufferPoint *p1, ZBufferPoint *p2, int color);
+	void fillLineFlatZ(ZBufferPoint *p1, ZBufferPoint *p2);
 	void fillLineInterpZ(ZBufferPoint *p1, ZBufferPoint *p2);
-	void fillLineFlat(ZBufferPoint *p1, ZBufferPoint *p2, int color);
+	void fillLineFlat(ZBufferPoint *p1, ZBufferPoint *p2);
 	void fillLineInterp(ZBufferPoint *p1, ZBufferPoint *p2);
 
 	void setScissorRectangle(int left, int right, int top, int bottom) {
@@ -469,6 +466,14 @@ struct FrameBuffer {
 	FORCEINLINE int getDepthTestEnabled() const { return _depthTestEnabled; }
 
 private:
+
+	template <bool kDepthWrite>
+	FORCEINLINE void putPixel(unsigned int pixelOffset, int color, unsigned int z);
+
+	FORCEINLINE void putPixel(unsigned int pixelOffset, int color);
+
+	template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
+	void drawLine(const ZBufferPoint *p1, const ZBufferPoint *p2);
 
 	unsigned int *_zbuf;
 	bool _depthWrite;

--- a/graphics/tinygl/zline.cpp
+++ b/graphics/tinygl/zline.cpp
@@ -30,191 +30,146 @@
 
 namespace TinyGL {
 
-template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
-FORCEINLINE static void putPixel(FrameBuffer *buffer, int pixelOffset,
-                                 const Graphics::PixelFormat &cmode, unsigned int *pz, unsigned int &z, int &color, unsigned int &r,
-                                 unsigned int &g, unsigned int &b) {
-	if (buffer->scissorPixel(pixelOffset)) {
+template <bool kDepthWrite>
+FORCEINLINE void FrameBuffer::putPixel(unsigned int pixelOffset, int color, unsigned int z) {
+	if (scissorPixel(pixelOffset))
 		return;
-	}
-	if (kInterpZ) {
-		if (buffer->compareDepth(z, *pz)) {
-			if (kInterpRGB) {
-				buffer->writePixel<true, true, kDepthWrite>(pixelOffset, RGB_TO_PIXEL(r, g, b), z);
-			} else {
-				buffer->writePixel<true, true, kDepthWrite>(pixelOffset, color, z);
-			}
-		}
-	} else {
-		if (kInterpRGB) {
-			buffer->writePixel<true, true>(pixelOffset, RGB_TO_PIXEL(r, g, b));
-		} else {
-			buffer->writePixel<true, true>(pixelOffset, color);
-		}
+	unsigned int *pz = _zbuf + pixelOffset;
+	if (compareDepth(z, *pz)) {
+		writePixel<true, true, kDepthWrite>(pixelOffset, color, z);
 	}
 }
 
-template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
-FORCEINLINE static void drawLine(FrameBuffer *buffer, ZBufferPoint *p1, ZBufferPoint *p2,
-                                 int &pixelOffset, const Graphics::PixelFormat &cmode, unsigned int *pz, unsigned int &z, int &color,
-                                 unsigned int &r, unsigned int &g, unsigned int &b, int dx, int dy, int inc_1, int inc_2) {
-	int n = dx;
-	int rinc, ginc, binc;
-	int zinc;
-	if (kInterpZ) {
-		zinc = (p2->z - p1->z) / n;
-	}
-	if (kInterpRGB) {
-		rinc = ((p2->r - p1->r) << 8) / n;
-		ginc = ((p2->g - p1->g) << 8) / n;
-		binc = ((p2->b - p1->b) << 8) / n;
-	}
-	int a = 2 * dy - dx;
-	dy = 2 * dy;
-	dx = 2 * dx - dy;
-	int pp_inc_1 = (inc_1);
-	int pp_inc_2 = (inc_2);
-	do {
-		putPixel<kInterpRGB, kInterpZ, kDepthWrite>(buffer, pixelOffset, cmode, pz, z, color, r, g, b);
-		if (kInterpZ) {
-			z += zinc;
-		}
-		if (kInterpRGB) {
-			r += rinc;
-			g += ginc;
-			b += binc;
-		}
-		if (a > 0) {
-			pixelOffset += pp_inc_1;
-			if (kInterpZ) {
-				pz += inc_1;
-			}
-			a -= dx;
-		} else {
-			pixelOffset += pp_inc_2;
-			if (kInterpZ) {
-				pz += inc_2;
-			}
-			a += dy;
-		}
-	} while (--n >= 0);
+FORCEINLINE void FrameBuffer::putPixel(unsigned int pixelOffset, int color) {
+	if (scissorPixel(pixelOffset))
+		return;
+	writePixel<true, true>(pixelOffset, color);
 }
 
 template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
-void FrameBuffer::fillLineGeneric(ZBufferPoint *p1, ZBufferPoint *p2, int color) {
-	int dx, dy, sx;
-	unsigned int r, g, b;
-	unsigned int *pz = NULL;
+void FrameBuffer::drawLine(const ZBufferPoint *p1, const ZBufferPoint *p2) {
+	// Based on Bresenham's line algorithm, as implemented in
+	// https://rosettacode.org/wiki/Bitmap/Bresenham%27s_line_algorithm#C
+	// with a loop exit condition based on the (unidimensional) taxicab
+	// distance between p1 and p2 (which is cheap to compute and
+	// rounding-error-free) so that interpolations are possible without
+	// code duplication.
+
+	// Where we are in unidimensional framebuffer coordinate
+	unsigned int pixelOffset = p1->y * xsize + p1->x;
+
+	// How to move on each axis, in both coordinates systems
+	const int dx = abs(p2->x - p1->x);
+	const int inc_x = p1->x < p2->x ? 1 : -1;
+	const int dy = abs(p2->y - p1->y);
+	const int inc_y = p1->y < p2->y ? xsize : -xsize;
+
+	// When to move on each axis
+	int err = (dx > dy ? dx : -dy) / 2;
+	int e2;
+
+	// How many moves
+	int n = dx > dy ? dx : dy;
+
+	// kInterpZ
 	unsigned int z;
-	int pixelOffset;
+	int sz;
 
-	if (p1->y > p2->y || (p1->y == p2->y && p1->x > p2->x)) {
-		ZBufferPoint *tmp;
-		tmp = p1;
-		p1 = p2;
-		p2 = tmp;
-	}
-	sx = xsize;
-	pixelOffset = xsize * p1->y + p1->x;
-	if (kInterpZ) {
-		pz = _zbuf + (p1->y * sx + p1->x);
+	// kInterpRGB
+	int r = p1->r;
+	int g = p1->g;
+	int b = p1->b;
+	int color = RGB_TO_PIXEL(r, g, b);
+	int sr, sg, sb;
+
+        if (kInterpZ) {
+		sz = (p2->z - p1->z) / n;
 		z = p1->z;
 	}
-	dx = p2->x - p1->x;
-	dy = p2->y - p1->y;
 	if (kInterpRGB) {
-		r = p2->r << 8;
-		g = p2->g << 8;
-		b = p2->b << 8;
+		sr = (p2->r - p1->r) / n;
+		sg = (p2->g - p1->g) / n;
+		sb = (p2->b - p1->b) / n;
 	}
-
-	if (dx == 0 && dy == 0) {
-		putPixel<kInterpRGB, kInterpZ, kDepthWrite>(this, pixelOffset, cmode, pz, z, color, r, g, b);
-	} else if (dx > 0) {
-		if (dx >= dy) {
-			drawLine<kInterpRGB, kInterpZ, kDepthWrite>(this, p1, p2, pixelOffset, cmode, pz, z, color, r, g, b, dx, dy, sx + 1, 1);
-		} else {
-			drawLine<kInterpRGB, kInterpZ, kDepthWrite>(this, p1, p2, pixelOffset, cmode, pz, z, color, r, g, b, dx, dy, sx + 1, sx);
+	while (n--) {
+		if (kInterpZ)
+			putPixel<kDepthWrite>(pixelOffset, color, z);
+		else
+			putPixel(pixelOffset, color);
+		e2 = err;
+		if (e2 > -dx) {
+			err -= dy;
+			pixelOffset += inc_x;
 		}
-	} else {
-		dx = -dx;
-		if (dx >= dy) {
-			drawLine<kInterpRGB, kInterpZ, kDepthWrite>(this, p1, p2, pixelOffset, cmode, pz, z, color, r, g, b, dx, dy, sx - 1, -1);
-		} else {
-			drawLine<kInterpRGB, kInterpZ, kDepthWrite>(this, p1, p2, pixelOffset, cmode, pz, z, color, r, g, b, dx, dy, sx - 1, sx);
+		if (e2 < dy) {
+			err += dx;
+			pixelOffset += inc_y;
+		}
+		if (kInterpZ)
+			z += sz;
+		if (kInterpRGB) {
+			r += sr;
+			g += sg;
+			b += sb;
+			color = RGB_TO_PIXEL(r, g, b);
 		}
 	}
 }
 
 void FrameBuffer::plot(ZBufferPoint *p) {
-	unsigned int *pz;
-	unsigned int r, g, b;
-
-	pz = _zbuf + (p->y * xsize + p->x);
-	int col = RGB_TO_PIXEL(p->r, p->g, p->b);
-	unsigned int z = p->z;
+	const unsigned int pixelOffset = p->y * xsize + p->x;
+	const int col = RGB_TO_PIXEL(p->r, p->g, p->b);
+	const unsigned int z = p->z;
 	if (_depthWrite && _depthTestEnabled)
-		putPixel<false, true, true>(this, linesize * p->y + p->x * PSZB, cmode, pz, z, col, r, g, b);
+		putPixel<true>(pixelOffset, col, z);
 	else 
-		putPixel<false, true, false>(this, linesize * p->y + p->x * PSZB, cmode, pz, z, col, r, g, b);
+		putPixel<false>(pixelOffset, col, z);
 }
 
-void FrameBuffer::fillLineFlatZ(ZBufferPoint *p1, ZBufferPoint *p2, int color) {
+void FrameBuffer::fillLineFlatZ(ZBufferPoint *p1, ZBufferPoint *p2) {
 	if (_depthWrite && _depthTestEnabled)
-		fillLineGeneric<false, true, true>(p1, p2, color);
+		drawLine<false, true, true>(p1, p2);
 	else
-		fillLineGeneric<false, true, false>(p1, p2, color);
+		drawLine<false, true, false>(p1, p2);
 }
 
 // line with color interpolation
 void FrameBuffer::fillLineInterpZ(ZBufferPoint *p1, ZBufferPoint *p2) {
 	if (_depthWrite && _depthTestEnabled)
-		fillLineGeneric<true, true, true>(p1, p2, 0);
+		drawLine<true, true, true>(p1, p2);
 	else
-		fillLineGeneric<true, true, false>(p1, p2, 0);
+		drawLine<true, true, false>(p1, p2);
 }
 
 // no Z interpolation
-void FrameBuffer::fillLineFlat(ZBufferPoint *p1, ZBufferPoint *p2, int color) {
+void FrameBuffer::fillLineFlat(ZBufferPoint *p1, ZBufferPoint *p2) {
 	if (_depthWrite && _depthTestEnabled)
-		fillLineGeneric<false, false, true>(p1, p2, color);
+		drawLine<false, false, true>(p1, p2);
 	else
-		fillLineGeneric<false, false, false>(p1, p2, color);
+		drawLine<false, false, false>(p1, p2);
 }
 
 void FrameBuffer::fillLineInterp(ZBufferPoint *p1, ZBufferPoint *p2) {
 	if (_depthWrite && _depthTestEnabled)
-		fillLineGeneric<false, true, true>(p1, p2, 0);
+		drawLine<false, true, true>(p1, p2);
 	else
-		fillLineGeneric<false, true, false>(p1, p2, 0);
+		drawLine<false, true, false>(p1, p2);
 }
 
 void FrameBuffer::fillLineZ(ZBufferPoint *p1, ZBufferPoint *p2) {
-	int color1, color2;
-
-	color1 = RGB_TO_PIXEL(p1->r, p1->g, p1->b);
-	color2 = RGB_TO_PIXEL(p2->r, p2->g, p2->b);
-
 	// choose if the line should have its color interpolated or not
-	if (color1 == color2) {
-		fillLineFlatZ(p1, p2, color1);
-	} else {
+	if (p1->r == p2->r && p1->g == p2->g && p1->b == p2->b)
+		fillLineFlatZ(p1, p2);
+	else
 		fillLineInterpZ(p1, p2);
-	}
 }
 
 void FrameBuffer::fillLine(ZBufferPoint *p1, ZBufferPoint *p2) {
-	int color1, color2;
-
-	color1 = RGB_TO_PIXEL(p1->r, p1->g, p1->b);
-	color2 = RGB_TO_PIXEL(p2->r, p2->g, p2->b);
-
 	// choose if the line should have its color interpolated or not
-	if (color1 == color2) {
-		fillLineFlat(p1, p2, color1);
-	} else {
+	if (p1->r == p2->r && p1->g == p2->g && p1->b == p2->b)
+		fillLineFlat(p1, p2);
+	else
 		fillLineInterp(p1, p2);
-	}
 }
 
 } // end of namespace TinyGL


### PR DESCRIPTION
drawLine was broken for dx = 0 lines.
Also, the split between fillLineGeneric and drawLine, along with the many
parameters exchanged (with obscure names with subtle differences), made
the code hard to understand.
This implementation should be easier to check.
There was no visible CPU usage change.
Fixes GRIM's ticket printer (#1262 is needed too), which are composed of a lot of vertical
segments.

I am not used to C++, so there may be possible simplifications. For example:
- I split `putPixel` to avoid a "variable may be used before being initialised" warning, although it should be harmless in practice (the 3rd argument would be used in `putPixel` when `kInterpZ` is false anyway).
- I made `putPixel` and `drawLine` into (private) methods rather that static functions because this seems more natural than passing them a `this` argument. I have no idea if this has an adverse effect (performance ?).