### PR TITLE
GRIM: Enable TGL_ALPHA_TEST in GfxTinyGL::drawSprite.

### DIFF
--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -796,9 +796,7 @@ void GfxTinyGL::drawSprite(const Sprite *sprite) {
 	tglDisable(TGL_LIGHTING);
 
 	if (g_grim->getGameType() == GType_GRIM) {
-		// Disable Alpha Test, doesn't work the same as OpenGL
-		// It was enabled to sync with OpenGL renderer while TinyGL refactoring
-		//tglEnable(TGL_ALPHA_TEST);
+		tglEnable(TGL_ALPHA_TEST);
 		tglAlphaFunc(TGL_GEQUAL, 0.5f);
 	} else if (sprite->_flags2 & Sprite::AlphaTest) {
 		tglEnable(TGL_ALPHA_TEST);


### PR DESCRIPTION
Forgotten in #1265 . I do not know where this has a visible effect (smoke from Manny's idle animation seemed already alpha-blended with background without this).