### PR TITLE
Tinygl: optimise gl_shade_vertex

### DIFF
--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -102,9 +102,11 @@ void glInit(void *zbuffer1, int textureSize) {
 		if (i == 0) {
 			l->diffuse = Vector4(1, 1, 1, 1);
 			l->specular = Vector4(1, 1, 1, 1);
+			l->has_specular = true;
 		} else {
 			l->diffuse = Vector4(0, 0, 0, 1);
 			l->specular = Vector4(0, 0, 0, 1);
+			l->has_specular = false;
 		}
 		l->position = Vector4(0, 0, 1, 0);
 		l->norm_position = Vector3(0, 0, 1);
@@ -130,6 +132,7 @@ void glInit(void *zbuffer1, int textureSize) {
 		m->ambient = Vector4(0.2f, 0.2f, 0.2f, 1);
 		m->diffuse = Vector4(0.8f, 0.8f, 0.8f, 1);
 		m->specular = Vector4(0, 0, 0, 1);
+		m->has_specular = false;
 		m->shininess = 0;
 	}
 	c->current_color_material_mode = TGL_FRONT_AND_BACK;

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -103,8 +103,8 @@ void glInit(void *zbuffer1, int textureSize) {
 			l->diffuse = Vector4(1, 1, 1, 1);
 			l->specular = Vector4(1, 1, 1, 1);
 		} else {
-			l->diffuse = Vector4(0, 0, 0, 0);
-			l->specular = Vector4(0, 0, 0, 0);
+			l->diffuse = Vector4(0, 0, 0, 1);
+			l->specular = Vector4(0, 0, 0, 1);
 		}
 		l->position = Vector4(0, 0, 1, 0);
 		l->norm_position = Vector3(0, 0, 1);

--- a/graphics/tinygl/light.cpp
+++ b/graphics/tinygl/light.cpp
@@ -58,6 +58,7 @@ void glopMaterial(GLContext *c, GLParam *p) {
 		break;
 	case TGL_SPECULAR:
 		m->specular = v;
+		m->has_specular = v.X != 0 || v.Y != 0 || v.Z != 0 || v.W != 1;
 		break;
 	case TGL_SHININESS:
 		m->shininess = v.X;
@@ -99,6 +100,7 @@ void glopLight(GLContext *c, GLParam *p) {
 		break;
 	case TGL_SPECULAR:
 		l->specular = v;
+		l->has_specular = v.X != 0 || v.Y != 0 || v.Z != 0 || v.W != 1;
 		break;
 	case TGL_POSITION: {
 		Vector4 pos;
@@ -251,65 +253,67 @@ void gl_shade_vertex(GLContext *c, GLVertex *v) {
 			lG += dot * l->diffuse.Y * m->diffuse.Y;
 			lB += dot * l->diffuse.Z * m->diffuse.Z;
 
-			// spot light
-			if (l->spot_cutoff != 180) {
-				dot_spot = -(d.X * l->norm_spot_direction.X +
-							 d.Y * l->norm_spot_direction.Y +
-							 d.Z * l->norm_spot_direction.Z);
-				if (twoside && dot_spot < 0)
-					dot_spot = -dot_spot;
-				if (dot_spot < l->cos_spot_cutoff) {
-					// no contribution
-					continue;
-				} else {
-					// TODO: optimize
-					if (l->spot_exponent > 0) {
-						att = att * pow(dot_spot, l->spot_exponent);
+			const bool is_spotlight = l->spot_cutoff != 180;
+			const bool has_specular = l->has_specular && m->has_specular;
+			if (is_spotlight || has_specular) {
+				if (is_spotlight) {
+					dot_spot = -(d.X * l->norm_spot_direction.X +
+								 d.Y * l->norm_spot_direction.Y +
+								 d.Z * l->norm_spot_direction.Z);
+					if (twoside && dot_spot < 0)
+						dot_spot = -dot_spot;
+					if (dot_spot < l->cos_spot_cutoff) {
+						// no contribution
+						continue;
+					} else {
+						// TODO: optimize
+						if (l->spot_exponent > 0) {
+							att = att * pow(dot_spot, l->spot_exponent);
+						}
 					}
 				}
-			}
 
-			// specular light
+				if (has_specular) {
+					if (c->local_light_model) {
+						Vector3 vcoord;
+						vcoord.X = v->ec.X;
+						vcoord.Y = v->ec.Y;
+						vcoord.Z = v->ec.Z;
+						vcoord.normalize();
+						s.X = d.X - vcoord.X;
+						s.Y = d.Y - vcoord.Y;
+						s.Z = d.Z - vcoord.Z;
+					} else {
+						s.X = d.X;
+						s.Y = d.Y;
+						s.Z = (float)(d.Z + 1.0);
+					}
+					dot_spec = n.X * s.X + n.Y * s.Y + n.Z * s.Z;
+					if (twoside && dot_spec < 0)
+						dot_spec = -dot_spec;
+					if (dot_spec > 0) {
+						GLSpecBuf *specbuf;
+						int idx;
+						tmp = sqrt(s.X * s.X + s.Y * s.Y + s.Z * s.Z);
+						if (tmp > 1E-3) {
+							dot_spec = dot_spec / tmp;
+						}
+						// TODO: optimize
+						// testing specular buffer code
+						// dot_spec= pow(dot_spec,m->shininess)
+						specbuf = specbuf_get_buffer(c, m->shininess_i, m->shininess);
+						tmp = dot_spec * SPECULAR_BUFFER_SIZE;
+						if (tmp > SPECULAR_BUFFER_SIZE)
+							idx = SPECULAR_BUFFER_SIZE;
+						else
+							idx = (int)tmp;
 
-			if (c->local_light_model) {
-				Vector3 vcoord;
-				vcoord.X = v->ec.X;
-				vcoord.Y = v->ec.Y;
-				vcoord.Z = v->ec.Z;
-				vcoord.normalize();
-				s.X = d.X - vcoord.X;
-				s.Y = d.Y - vcoord.Y;
-				s.Z = d.Z - vcoord.Z;
-			} else {
-				s.X = d.X;
-				s.Y = d.Y;
-				s.Z = (float)(d.Z + 1.0);
-			}
-			dot_spec = n.X * s.X + n.Y * s.Y + n.Z * s.Z;
-			if (twoside && dot_spec < 0)
-				dot_spec = -dot_spec;
-			if (dot_spec > 0) {
-				GLSpecBuf *specbuf;
-				int idx;
-				tmp = sqrt(s.X * s.X + s.Y * s.Y + s.Z * s.Z);
-				if (tmp > 1E-3) {
-					dot_spec = dot_spec / tmp;
+						dot_spec = specbuf->buf[idx];
+						lR += dot_spec * l->specular.X * m->specular.X;
+						lG += dot_spec * l->specular.Y * m->specular.Y;
+						lB += dot_spec * l->specular.Z * m->specular.Z;
+					}
 				}
-
-				// TODO: optimize
-				// testing specular buffer code
-				// dot_spec= pow(dot_spec,m->shininess)
-				specbuf = specbuf_get_buffer(c, m->shininess_i, m->shininess);
-				tmp = dot_spec * SPECULAR_BUFFER_SIZE;
-				if (tmp > SPECULAR_BUFFER_SIZE)
-					idx = SPECULAR_BUFFER_SIZE;
-				else
-					idx = (int)tmp;
-
-				dot_spec = specbuf->buf[idx];
-				lR += dot_spec * l->specular.X * m->specular.X;
-				lG += dot_spec * l->specular.Y * m->specular.Y;
-				lB += dot_spec * l->specular.Z * m->specular.Z;
 			}
 		}
 

--- a/graphics/tinygl/light.cpp
+++ b/graphics/tinygl/light.cpp
@@ -230,6 +230,7 @@ void gl_shade_vertex(GLContext *c, GLVertex *v) {
 			d.X = l->norm_position.X;
 			d.Y = l->norm_position.Y;
 			d.Z = l->norm_position.Z;
+			dist = 1;
 			att = 1;
 		} else {
 			// distance attenuation
@@ -237,10 +238,6 @@ void gl_shade_vertex(GLContext *c, GLVertex *v) {
 			d.Y = l->position.Y - v->ec.Y;
 			d.Z = l->position.Z - v->ec.Z;
 			dist = sqrt(d.X * d.X + d.Y * d.Y + d.Z * d.Z);
-			if (dist > 1E-3) {
-				tmp = 1 / dist;
-				d *= tmp;
-			}
 			att = 1.0f / (l->attenuation[0] + dist * (l->attenuation[1] +
 			              dist * l->attenuation[2]));
 		}
@@ -248,6 +245,9 @@ void gl_shade_vertex(GLContext *c, GLVertex *v) {
 		if (twoside && dot < 0)
 			dot = -dot;
 		if (dot > 0) {
+			tmp = 1 / dist;
+			d *= tmp;
+			dot *= tmp;
 			// diffuse light
 			lR += dot * l->diffuse.X * m->diffuse.X;
 			lG += dot * l->diffuse.Y * m->diffuse.Y;
@@ -294,10 +294,7 @@ void gl_shade_vertex(GLContext *c, GLVertex *v) {
 					if (dot_spec > 0) {
 						GLSpecBuf *specbuf;
 						int idx;
-						tmp = sqrt(s.X * s.X + s.Y * s.Y + s.Z * s.Z);
-						if (tmp > 1E-3) {
-							dot_spec = dot_spec / tmp;
-						}
+						dot_spec = dot_spec / sqrt(s.X * s.X + s.Y * s.Y + s.Z * s.Z);
 						// TODO: optimize
 						// testing specular buffer code
 						// dot_spec= pow(dot_spec,m->shininess)

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -88,6 +88,7 @@ struct GLLight {
 	Vector4 ambient;
 	Vector4 diffuse;
 	Vector4 specular;
+	bool has_specular;
 	Vector4 position;
 	Vector3 spot_direction;
 	float spot_exponent;
@@ -107,6 +108,7 @@ struct GLMaterial {
 	Vector4 ambient;
 	Vector4 diffuse;
 	Vector4 specular;
+	bool has_specular;
 	float shininess;
 
 	// computed values


### PR DESCRIPTION
Avoids or deffer normalising when possible.
Avoids computing specular when light & material combination would produce no specular effect.