### PR TITLE
TINYGL, GRIM: Fix various errors (mostly memory leaks) found by valgrind

### DIFF
--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -63,6 +63,7 @@ GfxTinyGL::GfxTinyGL() :
 }
 
 GfxTinyGL::~GfxTinyGL() {
+	releaseMovieFrame();
 	for (unsigned int i = 0; i < _numSpecialtyTextures; i++) {
 		destroyTexture(&_specialtyTextures[i]);
 	}

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -66,13 +66,13 @@ GfxTinyGL::~GfxTinyGL() {
 	for (unsigned int i = 0; i < _numSpecialtyTextures; i++) {
 		destroyTexture(&_specialtyTextures[i]);
 	}
+	for (int i = 0; i < 96; i++) {
+		Graphics::tglDeleteBlitImage(_emergFont[i]);
+	}
 	if (_zb) {
 		delBuffer(1);
 		TinyGL::glClose();
 		delete _zb;
-	}
-	for (int i = 0; i < 96; i++) {
-		Graphics::tglDeleteBlitImage(_emergFont[i]);
 	}
 }
 

--- a/engines/grim/imuse/imuse_mcmp_mgr.cpp
+++ b/engines/grim/imuse/imuse_mcmp_mgr.cpp
@@ -106,7 +106,7 @@ int32 McmpMgr::decompressSample(int32 offset, int32 size, byte **comp_final) {
 		last_block = _numCompItems - 1;
 
 	int32 blocks_final_size = 0x2000 * (1 + last_block - first_block);
-	*comp_final = (byte *)malloc(blocks_final_size * sizeof(byte));
+	*comp_final = new byte[blocks_final_size];
 	final_size = 0;
 
 	for (i = first_block; i <= last_block; i++) {

--- a/engines/grim/imuse/imuse_sndmgr.cpp
+++ b/engines/grim/imuse/imuse_sndmgr.cpp
@@ -356,7 +356,7 @@ int32 ImuseSndMgr::getDataFromRegion(SoundDesc *sound, int region, byte **buf, i
 	if (sound->mcmpData) {
 		size = sound->mcmpMgr->decompressSample(region_offset + offset, size, buf);
 	} else {
-		*buf = (byte *)malloc(sizeof(byte) * size);
+		*buf = new byte[size];
 		sound->inStream->seek(region_offset + offset + sound->headerSize, SEEK_SET);
 		sound->inStream->read(*buf, size);
 	}

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -237,6 +237,8 @@ void glInit(void *zbuffer1, int textureSize) {
 void glClose() {
 	GLContext *c = gl_get_context();
 
+	Graphics::Internal::tglCleanupImages();
+
 	specbuf_cleanup(c);
 	for (int i = 0; i < 3; i++)
 		gl_free(c->matrix_stack[i]);

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -47,10 +47,13 @@ static GLTexture *find_texture(GLContext *c, unsigned int h) {
 }
 
 void free_texture(GLContext *c, int h) {
-	GLTexture *t, **ht;
+	free_texture(c, find_texture(c, h));
+}
+
+void free_texture(GLContext *c, GLTexture *t) {
+	GLTexture **ht;
 	GLImage *im;
 
-	t = find_texture(c, h);
 	if (!t->prev) {
 		ht = &c->shared_state.texture_hash_table[t->handle % TEXTURE_HASH_TABLE_SIZE];
 		*ht = t->next;

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -34,7 +34,7 @@
 
 namespace TinyGL {
 
-static GLTexture *find_texture(GLContext *c, int h) {
+static GLTexture *find_texture(GLContext *c, unsigned int h) {
 	GLTexture *t;
 
 	t = c->shared_state.texture_hash_table[h % TEXTURE_HASH_TABLE_SIZE];
@@ -279,7 +279,7 @@ void glopPixelStore(GLContext *, GLParam *p) {
 
 void tglGenTextures(int n, unsigned int *textures) {
 	TinyGL::GLContext *c = TinyGL::gl_get_context();
-	int max;
+	unsigned int max;
 	TinyGL::GLTexture *t;
 
 	max = 0;

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -80,14 +80,16 @@ void tglDisposeResources(TinyGL::GLContext *c) {
 	bool allDisposed = true;
 	do {
 		allDisposed = true;
-		TinyGL::GLTexture *t = c->shared_state.texture_hash_table[0];
-		while (t) {
-			if (t->disposed) {
-				TinyGL::free_texture(c, t->handle);
-				allDisposed = false;
-				break;
+		for (int i = 0; i < TEXTURE_HASH_TABLE_SIZE; i++) {
+			TinyGL::GLTexture *t = c->shared_state.texture_hash_table[i];
+			while (t) {
+				if (t->disposed) {
+					TinyGL::free_texture(c, t->handle);
+					allDisposed = false;
+					break;
+				}
+				t = t->next;
 			}
-			t = t->next;
 		}
 
 	} while (allDisposed == false);

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -84,7 +84,7 @@ void tglDisposeResources(TinyGL::GLContext *c) {
 			TinyGL::GLTexture *t = c->shared_state.texture_hash_table[i];
 			while (t) {
 				if (t->disposed) {
-					TinyGL::free_texture(c, t->handle);
+					TinyGL::free_texture(c, t);
 					allDisposed = false;
 					break;
 				}

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -181,7 +181,7 @@ struct GLImage {
 
 struct GLTexture {
 	GLImage images[MAX_TEXTURE_LEVELS];
-	int handle;
+	unsigned int handle;
 	int versionNumber;
 	struct GLTexture *next, *prev;
 	bool disposed;

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -417,6 +417,7 @@ void glInitTextures(GLContext *c);
 void glEndTextures(GLContext *c);
 GLTexture *alloc_texture(GLContext *c, int h);
 void free_texture(GLContext *c, int h);
+void free_texture(GLContext *c, GLTexture *t);
 
 // image_util.c
 void gl_resizeImage(unsigned char *dest, int xsize_dest, int ysize_dest,


### PR DESCRIPTION
There are still some errors, but this gets rid of a few tens of megabytes of leaks around textures.