### PR TITLE
Tinygl: optimise scissorpixel

### DIFF
--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -214,9 +214,7 @@ struct FrameBuffer {
 		writePixel(pixel, 255, rSrc, gSrc, bSrc);
 	}
 
-	FORCEINLINE bool scissorPixel(int pixel) {
-		int x = pixel % xsize;
-		int y = pixel / xsize;
+	FORCEINLINE bool scissorPixel(int x, int y) {
 		return x < _clipRectangle.left || x > _clipRectangle.right || y < _clipRectangle.top || y > _clipRectangle.bottom;
 	}
 
@@ -468,9 +466,9 @@ struct FrameBuffer {
 private:
 
 	template <bool kDepthWrite>
-	FORCEINLINE void putPixel(unsigned int pixelOffset, int color, unsigned int z);
+	FORCEINLINE void putPixel(unsigned int pixelOffset, int color, int x, int y, unsigned int z);
 
-	FORCEINLINE void putPixel(unsigned int pixelOffset, int color);
+	FORCEINLINE void putPixel(unsigned int pixelOffset, int color, int x, int y);
 
 	template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
 	void drawLine(const ZBufferPoint *p1, const ZBufferPoint *p2);

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -430,9 +430,11 @@ struct FrameBuffer {
 		_clipRectangle.right = right;
 		_clipRectangle.top = top;
 		_clipRectangle.bottom = bottom;
+		_enableScissor = left != 0 || right != xsize || top != 0 || bottom != ysize;
 	}
 
 	Common::Rect _clipRectangle;
+	bool _enableScissor;
 	int xsize, ysize;
 	int linesize; // line size, in bytes
 	Graphics::PixelFormat cmode;
@@ -468,9 +470,16 @@ private:
 	template <bool kDepthWrite>
 	FORCEINLINE void putPixel(unsigned int pixelOffset, int color, int x, int y, unsigned int z);
 
+	template <bool kDepthWrite, bool kEnableScissor>
+	FORCEINLINE void putPixel(unsigned int pixelOffset, int color, int x, int y, unsigned int z);
+
+	template <bool kEnableScissor>
 	FORCEINLINE void putPixel(unsigned int pixelOffset, int color, int x, int y);
 
 	template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
+	void drawLine(const ZBufferPoint *p1, const ZBufferPoint *p2);
+
+	template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite, bool kEnableScissor>
 	void drawLine(const ZBufferPoint *p1, const ZBufferPoint *p2);
 
 	unsigned int *_zbuf;


### PR DESCRIPTION
And avoid calling it altogether when possible.

Note: contains #1266 as it would otherwise conflict, I don't know how to do otherwise to still propose these patches.