### PR TITLE
TINYGL: Actually set memory to the requested legnth.

### DIFF
--- a/graphics/tinygl/zbuffer.cpp
+++ b/graphics/tinygl/zbuffer.cpp
@@ -47,7 +47,7 @@ void memset_s(void *adr, int val, int count) {
 	p = (unsigned int *)adr;
 	v = val | (val << 16);
 
-	n = count >> 3;
+	n = count >> 2;
 	for (int i = 0; i < n; i++) {
 		p[0] = v;
 		p[1] = v;


### PR DESCRIPTION
4 is 1 << 2, not 1 << 3.
Fixes display corruption (especially visible in Myst 3) where the right
half of the screen contains data from previous frame.