### PR TITLE
TINYGL: Expect colorKey in the same pixel format as surface.

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -481,11 +481,7 @@ void BitmapData::convertToColorFormat(int num, const Graphics::PixelFormat &form
 	Graphics::PixelBuffer dst(format, _width * _height, DisposeAfterUse::NO);
 
 	for (int i = 0; i < _width * _height; ++i) {
-		if (_data[num].getValueAt(i) == 0xf81f) { //transparency
-			dst.setPixelAt(i, 0xf81f);
-		} else {
-			dst.setPixelAt(i, _data[num]);
-		}
+		dst.setPixelAt(i, _data[num]);
 	}
 	_data[num].free();
 	_data[num] = dst;

--- a/graphics/tinygl/zblit.cpp
+++ b/graphics/tinygl/zblit.cpp
@@ -52,7 +52,7 @@ public:
 		if (applyColorKey) {
 			for (int x = 0;  x < surface.w; x++) {
 				for (int y = 0; y < surface.h; y++) {
-					uint32 pixel = dataBuffer.getValueAt(y * surface.w + x);
+					uint32 pixel = buffer.getValueAt(y * surface.w + x);
 					if (pixel == colorKey) {
 						// Color keyed pixels become transparent white.
 						dataBuffer.setPixelAt(y * surface.w + x, 0, 255, 255, 255); 


### PR DESCRIPTION
So caller does not have to depend on the pixel format used internally to
BlitImage.
Update callers which do request for color keying (GRIM/EMI only).
Also, remove a special-casing of transparent color when converting image
format which sets a color in a packed format independent from actual
destination format.
Also, in GfxTinyGL::createTextObject, prefer changing invisible colorKey
value than actually-visible color.

This commit is larger than I would like it to be, but involved parts are quite entangled - and this is precisely what this commit tries to address.

For reference, I developped this to allow adding support for 32bits rendering in TinyGL, but is a stand-alone change.