### PR TITLE
GRIM: Convert save game image to original pixel format.

### DIFF
--- a/engines/grim/bitmap.h
+++ b/engines/grim/bitmap.h
@@ -165,6 +165,7 @@ public:
 
 	const Graphics::PixelBuffer &getData(int num) const { return _data->getImageData(num); }
 	const Graphics::PixelBuffer &getData() const { return getData(_currImage); }
+	BitmapData *getBitmapData() const { return _data; }
 	void *getTexIds() const { return _data->_texIds; }
 	int getNumTex() const { return _data->_numTex; }
 	const Graphics::PixelFormat &getPixelFormat(int num) const;

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1061,6 +1061,7 @@ void GrimEngine::restoreGRIM() {
 }
 
 void GrimEngine::storeSaveGameImage(SaveGame *state) {
+	const Graphics::PixelFormat image_format = Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
 	int width = 250, height = 188;
 	Bitmap *screenshot;
 
@@ -1076,6 +1077,7 @@ void GrimEngine::storeSaveGameImage(SaveGame *state) {
 	if (screenshot) {
 		int size = screenshot->getWidth() * screenshot->getHeight();
 		screenshot->setActiveImage(0);
+		screenshot->getBitmapData()->convertToColorFormat(image_format);
 		uint16 *data = (uint16 *)screenshot->getData().getRawBuffer();
 		for (int l = 0; l < size; l++) {
 			state->writeLEUint16(data[l]);


### PR DESCRIPTION
Pixel format does not seem to be stored in save game, so when loading a
save game produced in 32 bits mode it appears corrupted. So, to preserve
backward compatibility, convert to 16bits format before storing.

I guess it would be better to store this inside the savegame, but:
- we need to preserve backward compatibility
- I think forcing 16 bits for the save/load game screenshots is perfectly acceptable
so I do no feel it is worth the effort.

For reference, I developped this to allow adding support for 32bits rendering in TinyGL, but is a stand-alone change.