### PR TITLE
TINYGL:  Enable dirtyrect by default.

### DIFF
--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -237,7 +237,7 @@ void glInit(void *zbuffer1, int textureSize) {
 	c->_currentAllocatorIndex = 0;
 	c->_drawCallAllocator[0].initialize(kDrawCallMemory);
 	c->_drawCallAllocator[1].initialize(kDrawCallMemory);
-	c->_enableDirtyRectangles = false;
+	c->_enableDirtyRectangles = true;
 
 	Graphics::Internal::tglBlitResetScissorRect();
 }

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -189,6 +189,10 @@ static void tglPresentBufferDirtyRects(TinyGL::GLContext *c) {
 		}
 	}
 
+	for (RectangleIterator it1 = rectangles.begin(); it1 != rectangles.end(); ++it1) {
+		(*it1).rectangle.clip(c->renderRect);
+	}
+
 	if (!rectangles.empty()) {
 		// Execute draw calls.
 		for (DrawCallIterator it = c->_drawCallsQueue.begin(); it != c->_drawCallsQueue.end(); ++it) {


### PR DESCRIPTION
Once #1295 and #1335 are merged, I believe dirty rectangles can finally be enabled by default ! (this PR contains both, for testing ease)

Actually, I think about getting rid of the non-dirtyrect code paths in TinyGL. Not sure it would be a good idea to include in this PR, though.

I gave up on my attempts to rework rectangle merging algorithm: current code is simple where my code is complex and brittle - and both perform just the same.

There is one part where current code would likely benefit from improvements: using a diff algorithm against draw call lists, instead of current `a++ == b++`-style comparison.

Also, a bit of trivia: on my T450s, TinyGL now give more FPS than OpenGL (i5-4300U 1.9GHz + HD4400), both with same residualvm built with `--enable-optimisations`. Both being in the few hundreds, it does not mean much but... I found it funny and kind of rewarding.