### PR TITLE
GRIM: Do not draw when flipping is forbidden.

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -634,7 +634,7 @@ void GrimEngine::updateDisplayScene() {
 }
 
 void GrimEngine::updateNormalMode() {
-	if (!_currSet)
+	if (!_currSet || !_flipEnable)
 		return;
 
 	g_driver->clearScreen();


### PR DESCRIPTION
Fixes
  "Allocator out of memory: couldn't allocate more memory from linear allocator."
error with TinyGL in Grim at the begining of Year 2 after the cinematic
where meche boards the ship. The error only happens when not skipping
the video.

This is an RFC because I am not sure:
- if it is correct at all ? (ie, are their effects beyond just rendering in not calling updateDisplayScene ?)
- if something else should also be done to understand why it takes several frames for flipping to be enabled again after that video (maybe actor rotation is not instant, and if not should it be ?)
- should I also move the _flipEnable test outside of doFlip ?
