### PR TITLE
GRIM: Enable the Global Game Menu

### DIFF
--- a/engines/engine.h
+++ b/engines/engine.h
@@ -298,9 +298,8 @@ public:
 
 	/**
 	 * Run the Global Main Menu Dialog
-	 * added 'virtual' ResidualVM specific
 	 */
-	virtual void openMainMenuDialog();
+	void openMainMenuDialog();
 
 	/**
 	 * Display a warning to the user that the game is not fully supported.

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1393,12 +1393,6 @@ bool GrimEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsLoadingDuringRuntime);
 }
 
-void GrimEngine::openMainMenuDialog() {
-	Common::KeyState key(Common::KEYCODE_F1, Common::ASCII_F1);
-	handleControls(Common::EVENT_KEYDOWN, key);
-	handleControls(Common::EVENT_KEYUP, key);
-}
-
 void GrimEngine::pauseEngineIntern(bool pause) {
 	if (g_imuse)
 		g_imuse->pause(pause);

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -179,7 +179,6 @@ public:
 
 	TextObjectDefaults _sayLineDefaults, _printLineDefaults, _blastTextDefaults;
 
-	virtual void openMainMenuDialog() override;
 	void debugLua(const Common::String &str);
 
 	void setSideTextures(const Common::String &setup);

--- a/engines/grim/lua/ltm.cpp
+++ b/engines/grim/lua/ltm.cpp
@@ -54,6 +54,8 @@ static void init_entry(int32 tag) {
 		ttype(luaT_getim(tag, i)) = LUA_T_NIL;
 }
 
+static bool tmFBAdded = false;
+
 void luaT_init() {
 	int32 t;
 	IMtable_size = NUM_TAGS * 2;
@@ -61,6 +63,8 @@ void luaT_init() {
 	IMtable = luaM_newvector(IMtable_size, struct IM);
 	for (t = -(IMtable_size - 1); t <= 0; t++)
 		init_entry(t);
+
+	tmFBAdded = false;
 }
 
 int32 lua_newtag() {
@@ -180,8 +184,6 @@ static luaL_reg tmFB[] = {
 	{"  errorFB", errorFB},
 	{"  nilFB", nilFB}
 };
-
-static bool tmFBAdded = false;
 
 void luaT_setfallback() {
 	static const char *oldnames [] = { "error", "getglobal", "arith", "order", nullptr };


### PR DESCRIPTION
In the grim engine, ResidualVM's Global Game Menu is overridden to show the game menu instead. Now that ResidualVM supports several games, I think that the GMM override is no longer justified.

This re-enables the GMM, allowing to return to the launcher and start another game.
