### PR TITLE
GRIM: Fix support for reverse-order 32bits video frames in OpenGL

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1587,6 +1587,9 @@ void GfxOpenGL::prepareMovieFrame(Graphics::Surface *frame) {
 	if (frame->format == Graphics::PixelFormat(4, 8, 8, 8, 0, 8, 16, 24, 0)) {
 		format = GL_BGRA;
 		dataType = GL_UNSIGNED_INT_8_8_8_8;
+	} else if (frame->format == Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 0)) {
+		format = GL_BGRA;
+		dataType = GL_UNSIGNED_INT_8_8_8_8_REV;
 	} else if (frame->format == Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0)) {
 		format = GL_RGB;
 		dataType = GL_UNSIGNED_SHORT_5_6_5;

--- a/engines/grim/gfx_opengl_shaders.h
+++ b/engines/grim/gfx_opengl_shaders.h
@@ -241,6 +241,7 @@ private:
 	int _smushHeight;
 	GLuint _smushTexId;
 	bool _smushSwizzle;
+	bool _smushSwap;
 	void setupTexturedQuad();
 	void setupQuadEBO();
 

--- a/engines/grim/shaders/smush.fragment
+++ b/engines/grim/shaders/smush.fragment
@@ -3,11 +3,13 @@ in vec2 Texcoord;
 OUTPUT
 
 uniform sampler2D tex;
+uniform bool swap;
 uniform bool swizzle;
 
 void main()
 {
 	vec4 color = texture(tex, Texcoord);
-	if (swizzle) color.rgba = color.gbar;
+	if (swap) color.rgba = color.abgr;
+	if (swizzle) color.rgba = color.bgra;
 	outColor = vec4(color.rgb, 1.0);
 }


### PR DESCRIPTION
Make shader renderer fail the same way as opengl renderer on unexpected pixel format, which also allows getting rid of the "swizzle" uniform by letting opengl handle it ( @Botje : please confirm there was no other intent, like maybe some android workaround).

Add support for RGBA REV pixel format, so opengl and shader renderers do not fail as reported in #1300 .

Also, request quicktime high-color videos to use the 8/16/24 pixel format (untested as I could not identify a quicktime video in the EMI EN demo linked from residualvm website).

Patch set tested against:
- shaders + grim-win-fr (intro video is RGB, so it's a different code path anyway)
- shaders + monkey4-win-fr (sinking ship & arrival on melee videos are RGBA REV, hitting the new code path)
- opengl + monkey4-win-fr (likewise)
- shaders + monkey4-demo-en (intro video is  RGBA REV, hitting the new code path)
- opengl + monkey4-demo-en (likewise)
