### PR TITLE
COMMON: Synch changes to {game,advancedDetector}.{h,cpp} from ScummVM

### DIFF
--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -81,6 +81,7 @@ typedef Common::HashMap<Common::String, ADFileProperties, Common::IgnoreCase_Has
 
 enum ADGameFlags {
 	ADGF_NO_FLAGS = 0,
+	ADGF_AUTOGENTARGET = (1 << 20),  // automatically generate gameid from extra
 	ADGF_UNSTABLE = (1 << 21),    	// flag to designate not yet officially-supported games that are not fit for public testing
 	ADGF_TESTING = (1 << 22),    	// flag to designate not yet officially-supported games that are fit for public testing
 	ADGF_PIRATED = (1 << 23), ///< flag to designate well known pirated versions with cracks
@@ -94,7 +95,7 @@ enum ADGameFlags {
 };
 
 struct ADGameDescription {
-	const char *gameid;
+	const char *gameId;
 	const char *extra;
 	ADGameFileDescription filesDescriptions[14];
 	Common::Language language;
@@ -107,7 +108,7 @@ struct ADGameDescription {
 	 */
 	uint32 flags;
 
-	const char *guioptions;
+	const char *guiOptions;
 };
 
 /**
@@ -191,7 +192,7 @@ protected:
 	 * A list of all gameids (and their corresponding descriptions) supported
 	 * by this engine.
 	 */
-	const PlainGameDescriptor *_gameids;
+	const PlainGameDescriptor *_gameIds;
 
 	/**
 	 * A map containing all the extra game GUI options the engine supports.
@@ -219,7 +220,7 @@ protected:
 	 * address a more generic problem. We should find a better way to
 	 * disambiguate gameids.
 	 */
-	const char *_singleid;
+	const char *_singleId;
 
 	/**
 	 * A bitmask of flags which can be used to configure the behavior
@@ -233,7 +234,7 @@ protected:
 	 * entry in addition to per-game options. Refer to GameGUIOption
 	 * enum for the list.
 	 */
-	Common::String _guioptions;
+	Common::String _guiOptions;
 
 	/**
 	 * Maximum depth of directories to look up.
@@ -251,7 +252,7 @@ protected:
 	const char * const *_directoryGlobs;
 
 public:
-	AdvancedMetaEngine(const void *descs, uint descItemSize, const PlainGameDescriptor *gameids, const ADExtraGuiOptionsMap *extraGuiOptions = 0);
+	AdvancedMetaEngine(const void *descs, uint descItemSize, const PlainGameDescriptor *gameIds, const ADExtraGuiOptionsMap *extraGuiOptions = 0);
 
 	/**
 	 * Returns list of targets supported by the engine.
@@ -259,7 +260,7 @@ public:
 	 */
 	virtual GameList getSupportedGames() const;
 
-	virtual GameDescriptor findGame(const char *gameid) const;
+	virtual GameDescriptor findGame(const char *gameId) const;
 
 	virtual GameList detectGames(const Common::FSList &fslist) const;
 

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -26,8 +26,8 @@
 
 const PlainGameDescriptor *findPlainGameDescriptor(const char *gameid, const PlainGameDescriptor *list) {
 	const PlainGameDescriptor *g = list;
-	while (g->gameid) {
-		if (0 == scumm_stricmp(gameid, g->gameid))
+	while (g->gameId) {
+		if (0 == scumm_stricmp(gameid, g->gameId))
 			return g;
 		g++;
 	}
@@ -40,7 +40,7 @@ GameDescriptor::GameDescriptor() {
 }
 
 GameDescriptor::GameDescriptor(const PlainGameDescriptor &pgd, Common::String guioptions) {
-	setVal("gameid", pgd.gameid);
+	setVal("gameid", pgd.gameId);
 	setVal("description", pgd.description);
 
 	if (!guioptions.empty())

--- a/engines/game.h
+++ b/engines/game.h
@@ -36,7 +36,7 @@
  * consisting of PlainGameDescriptors.
  */
 struct PlainGameDescriptor {
-	const char *gameid;
+	const char *gameId;
 	const char *description;
 };
 
@@ -108,7 +108,7 @@ public:
 	GameList() {}
 	GameList(const GameList &list) : Common::Array<GameDescriptor>(list) {}
 	GameList(const PlainGameDescriptor *g) {
-		while (g->gameid) {
+		while (g->gameId) {
 			push_back(GameDescriptor(*g));
 			g++;
 		}

--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -593,11 +593,11 @@ static const Engines::ObsoleteGameID obsoleteGameIDsTable[] = {
 class GrimMetaEngine : public AdvancedMetaEngine {
 public:
 	GrimMetaEngine() : AdvancedMetaEngine(Grim::gameDescriptions, sizeof(Grim::GrimGameDescription), grimGames, gameGuiOptions) {
-		_guioptions = GUIO_NOMIDI;
+		_guiOptions = GUIO_NOMIDI;
 	}
 
 	virtual GameDescriptor findGame(const char *gameid) const override {
-		return Engines::findGameID(gameid, _gameids, obsoleteGameIDsTable);
+		return Engines::findGameID(gameid, _gameIds, obsoleteGameIDsTable);
 	}
 
 	virtual const char *getName() const override {

--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -180,8 +180,8 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 class Myst3MetaEngine : public AdvancedMetaEngine {
 public:
 	Myst3MetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(Myst3GameDescription), myst3Games, optionsList) {
-		_singleid = "myst3";
-		_guioptions = GUIO5(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOSPEECH, GUIO_NOSUBTITLES, GAMEOPTION_WIDESCREEN_MOD);
+		_singleId = "myst3";
+		_guiOptions = GUIO5(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOSPEECH, GUIO_NOSUBTITLES, GAMEOPTION_WIDESCREEN_MOD);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/stark/detection.cpp
+++ b/engines/stark/detection.cpp
@@ -298,8 +298,8 @@ static const ADFileBasedFallback fileBasedFallback[] = {
 class StarkMetaEngine : public AdvancedMetaEngine {
 public:
 	StarkMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(ADGameDescription), starkGames) {
-		_singleid = "stark";
-		_guioptions = GUIO1(GUIO_NOMIDI);
+		_singleId = "stark";
+		_guiOptions = GUIO1(GUIO_NOMIDI);
 	}
 
 	const char *getName() const override {


### PR DESCRIPTION
While attempting to copy over the Wintermute engine code, I noticed that ScummVM renamed some variables in the detection-system.

So, I copied over the relevant files from ScummVM-master, added all the changes, and resolved the compile-errors I found in the other engines.

AdvancedDetector had a single ResidualVM-specific string (The string saying where to file missing detection entries says "ResidualVM team" in ResidualVM, and "ScummVM Team" in ScummVM), which I did NOT add to this patch, so you will find that diff between ScummVM and this, but otherwise the files are exact copies.