### PR TITLE
STARK: Add support for opRumble

### DIFF
--- a/engines/stark/resources/command.cpp
+++ b/engines/stark/resources/command.cpp
@@ -101,7 +101,7 @@ Command *Command::execute(uint32 callMode, Script *script) {
 	case kGoto2DLocation:
 		return opGoto2DLocation(_arguments[0].stringValue, _arguments[1].stringValue);
 	case kRumbleScene:
-		return opRumbleScene(_arguments[1].intValue, _arguments[2].intValue);
+		return opRumbleScene(script, _arguments[1].intValue, _arguments[2].intValue);
 	case kFadeScene:
 		return opFadeScene(_arguments[1].intValue, _arguments[2].intValue, _arguments[3].intValue);
 	case kGameEnd:
@@ -360,10 +360,20 @@ Command *Command::opGoto2DLocation(const Common::String &level, const Common::St
 	return nullptr;
 }
 
-Command *Command::opRumbleScene(int32 unknown1, int32 unknown2) {
-	warning("(TODO: Implement) opRumble(%d, %d)", unknown1, unknown2);
+Command *Command::opRumbleScene(Script *script, int32 rumbleDuration, int32 pause) {
+	uint gameloopDuration = StarkGlobal->getMillisecondsPerGameloop();
+	int32 rumbleFrames = rumbleDuration / gameloopDuration;
 
-	return nextCommand();
+	Current *current = StarkGlobal->getCurrent();
+	Location *location = current->getLocation();
+	location->setRumbleFramesRemaining(rumbleFrames);
+
+	if (pause) {
+		script->pause(rumbleDuration);
+		return this; // Stay on this command while the script is suspended
+	} else {
+		return nextCommand();
+	}
 }
 
 Command *Command::opFadeScene(int32 unknown1, int32 unknown2, int32 unknown3) {

--- a/engines/stark/resources/command.h
+++ b/engines/stark/resources/command.h
@@ -208,7 +208,7 @@ protected:
 	Command *opScriptAbort(ResourceReference scriptRef, bool disable);
 	Command *opExit2DLocation();
 	Command *opGoto2DLocation(const Common::String &level, const Common::String &location);
-	Command *opRumbleScene(int32 unknown1, int32 unknown2);
+	Command *opRumbleScene(Script *script, int32 rumbleDuration, int32 pause);
 	Command *opFadeScene(int32 unknown1, int32 unknown2, int32 unknown3);
 	Command *opGameEnd();
 	Command *opInventoryOpen(bool open);

--- a/engines/stark/resources/layer.cpp
+++ b/engines/stark/resources/layer.cpp
@@ -71,6 +71,14 @@ void Layer::setScrollPosition(const Common::Point &position) {
 	_scroll.y = (_scrollScale + 1.0) * (float) position.y;
 }
 
+Common::Point Layer::getScroll() const {
+	return _scroll;
+}
+
+void Layer::setScroll(const Common::Point &scroll) {
+	_scroll = scroll;
+}
+
 bool Layer::isEnabled() const {
 	return _enabled;
 }

--- a/engines/stark/resources/layer.h
+++ b/engines/stark/resources/layer.h
@@ -74,6 +74,12 @@ public:
 	/** Scroll the layer to the specified position */
 	void setScrollPosition(const Common::Point &position);
 
+	/** Get the current scroll for this layer */
+	Common::Point getScroll() const;
+
+	/** Set the current scroll for this layer */
+	void setScroll(const Common::Point &scroll);
+
 	/** Enable the layer */
 	void enable(bool enabled);
 

--- a/engines/stark/resources/location.cpp
+++ b/engines/stark/resources/location.cpp
@@ -51,7 +51,8 @@ Location::Location(Object *parent, byte subType, uint16 index, const Common::Str
 		_canScroll(false),
 		_currentLayer(nullptr),
 		_hasActiveScroll(false),
-		_scrollFollowCharacter(false) {
+		_scrollFollowCharacter(false),
+		_rumbleFramesRemaining(0) {
 	_type = TYPE;
 }
 

--- a/engines/stark/resources/location.cpp
+++ b/engines/stark/resources/location.cpp
@@ -38,6 +38,8 @@
 #include "engines/stark/services/services.h"
 #include "engines/stark/services/global.h"
 
+#include "common/random.h"
+
 namespace Stark {
 namespace Resources {
 
@@ -76,6 +78,10 @@ void Location::onGameLoop() {
 			_scrollFollowCharacter = false;
 		}
 	}
+
+	if (_rumbleFramesRemaining > 0) {
+		_rumbleFramesRemaining--;
+	}
 }
 
 bool Location::has3DLayer() {
@@ -88,7 +94,22 @@ Gfx::RenderEntryArray Location::listRenderEntries() {
 	for (uint i = 0; i < _layers.size(); i++) {
 		Layer *layer = _layers[i];
 		if (layer->isEnabled()) {
+			Common::Point baseScroll;
+
+			if (_rumbleFramesRemaining > 0) {
+				baseScroll = layer->getScroll();
+				Common::Point offsetScroll = baseScroll;
+				offsetScroll.x = StarkRandomSource->getRandomBit() - 1;
+				offsetScroll.y = StarkRandomSource->getRandomBit() - 1;
+
+				layer->setScroll(offsetScroll);
+			}
+
 			renderEntries.push_back(layer->listRenderEntries());
+
+			if (_rumbleFramesRemaining > 0) {
+				layer->setScroll(baseScroll);
+			}
 		}
 	}
 
@@ -368,6 +389,10 @@ Sound *Location::findStockSound(const Object *parent, uint32 stockSoundType) con
 	}
 
 	return nullptr;
+}
+
+void Location::setRumbleFramesRemaining(int32 rumbleFramesRemaining) {
+	_rumbleFramesRemaining = rumbleFramesRemaining;
 }
 
 } // End of namespace Resources

--- a/engines/stark/resources/location.h
+++ b/engines/stark/resources/location.h
@@ -119,6 +119,9 @@ public:
 	/** Find a stock sound by its type in the location, the level, or the global level */
 	Sound *findStockSound(uint32 stockSoundType) const;
 
+	/** Set remaining frames to rumble on this lcation */
+	void setRumbleFramesRemaining(int32 rumbleFramesRemaining);
+
 protected:
 	void printData() override;
 
@@ -141,6 +144,8 @@ private:
 	Common::Point _maxScroll;
 
 	Common::HashMap<int32, ItemVisual *> _characterItemMap;
+
+	int32 _rumbleFramesRemaining;
 
 	uint getScrollStep();
 };


### PR DESCRIPTION
Implementation of opRumble based on the original version. I have 2 questions here:

- @bgK mentioned in #1305 that the random values are between -1 and 1. Am I missing something here, I can only see offset in each axis of either -1 or 0 and restoring in the end?

- Rumbling is still quite fast in a visual comparison. This seems down to the value of millisecondsPerGameLoop, which I think is set in w_module.dll(0x10029372) to a static value of 33? Is it worth either increasing our mainLoop delayMillis call or something more complicated in updateDisplayScene?