### PR TITLE
BUILD: Add back icon for MacOS X bundle

### DIFF
--- a/dists/macosx/Info.plist
+++ b/dists/macosx/Info.plist
@@ -10,6 +10,8 @@
 	<string>residualvm</string>
 	<key>CFBundleGetInfoString</key>
 	<string>0.3.0git, Copyright 2003-2016 The ResidualVM Team</string>
+	<key>CFBundleIconFile</key>
+	<string>residualvm.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/dists/macosx/Info.plist.in
+++ b/dists/macosx/Info.plist.in
@@ -10,6 +10,8 @@
 	<string>residualvm</string>
 	<key>CFBundleGetInfoString</key>
 	<string>@VERSION@, Copyright 2003-2016 The ResidualVM Team</string>
+	<key>CFBundleIconFile</key>
+	<string>residualvm.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
This was removed, I assume by mistake, in commit 9ba9c69b that sync'ed
the code with ScummVM.