### PR TITLE
ANDROID: Apply a few missed backports

### DIFF
--- a/backends/platform/android/org/residualvm/residualvm/ResidualVM.java
+++ b/backends/platform/android/org/residualvm/residualvm/ResidualVM.java
@@ -53,6 +53,8 @@ public abstract class ResidualVM implements SurfaceHolder.Callback, Runnable {
 	// Callbacks from C++ peer instance
 	abstract protected void getDPI(float[] values);
 	abstract protected void displayMessageOnOSD(String msg);
+	abstract protected void openUrl(String url);
+	abstract protected boolean isConnectionLimited();
 	abstract protected void setWindowCaption(String caption);
 	abstract protected void showVirtualKeyboard(boolean enable);
 	abstract protected String[] getSysArchives();

--- a/backends/platform/android/org/residualvm/residualvm/ResidualVMActivity.java
+++ b/backends/platform/android/org/residualvm/residualvm/ResidualVMActivity.java
@@ -2,8 +2,13 @@ package org.residualvm.residualvm;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.media.AudioManager;
+import android.net.Uri;
+import android.net.wifi.WifiManager;
+import android.net.wifi.WifiInfo;
 import android.os.Bundle;
 import android.os.Environment;
 import android.util.DisplayMetrics;
@@ -125,6 +130,21 @@ public View.OnClickListener pickUpBtnOnClickListener = new View.OnClickListener(
 		protected void displayMessageOnOSD(String msg) {
 			Log.i(LOG_TAG, "OSD: " + msg);
 			Toast.makeText(ResidualVMActivity.this, msg, Toast.LENGTH_LONG).show();
+		}
+
+		@Override
+		protected void openUrl(String url) {
+			startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+		}
+
+		@Override
+		protected boolean isConnectionLimited() {
+			WifiManager wifiMgr = (WifiManager)getSystemService(Context.WIFI_SERVICE);
+			if (wifiMgr != null && wifiMgr.isWifiEnabled()) {
+				WifiInfo wifiInfo = wifiMgr.getConnectionInfo();
+				return (wifiInfo == null || wifiInfo.getNetworkId() == -1); //WiFi is on, but it's not connected to any network
+			}
+			return true;
 		}
 
 		@Override


### PR DESCRIPTION
These make ResidualVM crash on application initialisation.

Note: this alone is merely enough to get residualvm to start. There are many issues after that:
- adding a game, as of android 7, is impossible as / is "empty", so once there user cannot go down in filesystem tree. Hacked to force /storage/ initial path (not in this PR).
- upon adding a game it crashes because configuration parser somehow finds `vsync=""`, and the emty string is not a boolean (indeed). Hacked parser to return `true` when failing to parse (not in this PR)
- then, shaders are not easily found: they are not copied to the install tree (and makefile does not update that part of the install tree for some reason), and even when shaders are present they are still not found on the device (not sure what made this work, between deleting the install tree, removing the conditional in makefile and requesting the engine static)
- then, before entering game world, debugger window pops up as sound effect rate is not supported (and I am stuck there at the moment)

Apparently, scummvm is also in a sorry state on android. As I have no experience developing on android, I don't think I'll spend much more time on this.