### PR TITLE
TINYGL: Implement tglDrawArrays.

### DIFF
--- a/graphics/tinygl/arrays.cpp
+++ b/graphics/tinygl/arrays.cpp
@@ -77,20 +77,49 @@ void glopArrayElement(GLContext *c, GLParam *param) {
 	}
 }
 
-void glArrayElement(TGLint i) {
-	GLParam p[2];
-	p[0].op = OP_ArrayElement;
-	p[1].i = i;
-	gl_add_op(p);
-}
-
 void glopEnableClientState(GLContext *c, GLParam *p) {
 	c->client_states |= p[1].i;
 }
 
-void glEnableClientState(TGLenum array) {
-	GLParam p[2];
-	p[0].op = OP_EnableClientState;
+void glopDisableClientState(GLContext *c, GLParam *p) {
+	c->client_states &= p[1].i;
+}
+
+void glopVertexPointer(GLContext *c, GLParam *p) {
+	c->vertex_array_size = p[1].i;
+	c->vertex_array_stride = p[2].i;
+	c->vertex_array = (float *)p[3].p;
+}
+
+void glopColorPointer(GLContext *c, GLParam *p) {
+	c->color_array_size = p[1].i;
+	c->color_array_stride = p[2].i;
+	c->color_array = (float *)p[3].p;
+}
+
+void glopNormalPointer(GLContext *c, GLParam *p) {
+	c->normal_array_stride = p[1].i;
+	c->normal_array = (float *)p[2].p;
+}
+
+void glopTexCoordPointer(GLContext *c, GLParam *p) {
+	c->texcoord_array_size = p[1].i;
+	c->texcoord_array_stride = p[2].i;
+	c->texcoord_array = (float *)p[3].p;
+}
+
+} // end of namespace TinyGL
+
+void tglArrayElement(TGLint i) {
+	TinyGL::GLParam p[2];
+	p[0].op = TinyGL::OP_ArrayElement;
+	p[1].i = i;
+	gl_add_op(p);
+}
+
+void tglEnableClientState(TGLenum array) {
+	TinyGL::GLParam p[2];
+	p[0].op = TinyGL::OP_EnableClientState;
 
 	switch (array) {
 	case TGL_VERTEX_ARRAY:
@@ -112,13 +141,9 @@ void glEnableClientState(TGLenum array) {
 	gl_add_op(p);
 }
 
-void glopDisableClientState(GLContext *c, GLParam *p) {
-	c->client_states &= p[1].i;
-}
-
-void glDisableClientState(TGLenum array) {
-	GLParam p[2];
-	p[0].op = OP_DisableClientState;
+void tglDisableClientState(TGLenum array) {
+	TinyGL::GLParam p[2];
+	p[0].op = TinyGL::OP_DisableClientState;
 
 	switch (array) {
 	case TGL_VERTEX_ARRAY:
@@ -140,66 +165,41 @@ void glDisableClientState(TGLenum array) {
 	gl_add_op(p);
 }
 
-void glopVertexPointer(GLContext *c, GLParam *p) {
-	c->vertex_array_size = p[1].i;
-	c->vertex_array_stride = p[2].i;
-	c->vertex_array = (float *)p[3].p;
-}
-
-void  glVertexPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
-	GLParam p[4];
+void tglVertexPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
+	TinyGL::GLParam p[4];
 	assert(type == TGL_FLOAT);
-	p[0].op = OP_VertexPointer;
+	p[0].op = TinyGL::OP_VertexPointer;
 	p[1].i = size;
 	p[2].i = stride;
 	p[3].p = const_cast<void *>(pointer);
 	gl_add_op(p);
 }
 
-void glopColorPointer(GLContext *c, GLParam *p) {
-	c->color_array_size = p[1].i;
-	c->color_array_stride = p[2].i;
-	c->color_array = (float *)p[3].p;
-}
-
-void  glColorPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
-	GLParam p[4];
+void tglColorPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
+	TinyGL::GLParam p[4];
 	assert(type == TGL_FLOAT);
-	p[0].op = OP_ColorPointer;
+	p[0].op = TinyGL::OP_ColorPointer;
 	p[1].i = size;
 	p[2].i = stride;
 	p[3].p = const_cast<void *>(pointer);
 	gl_add_op(p);
 }
 
-void glopNormalPointer(GLContext *c, GLParam *p) {
-	c->normal_array_stride = p[1].i;
-	c->normal_array = (float *)p[2].p;
-}
-
-void glNormalPointer(TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
-	GLParam p[3];
+void tglNormalPointer(TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
+	TinyGL::GLParam p[3];
 	assert(type == TGL_FLOAT);
-	p[0].op = OP_NormalPointer;
+	p[0].op = TinyGL::OP_NormalPointer;
 	p[1].i = stride;
 	p[2].p = const_cast<void *>(pointer);
 	gl_add_op(p);
 }
 
-void glopTexCoordPointer(GLContext *c, GLParam *p) {
-	c->texcoord_array_size = p[1].i;
-	c->texcoord_array_stride = p[2].i;
-	c->texcoord_array = (float *)p[3].p;
-}
-
-void glTexCoordPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
-	GLParam p[4];
+void tglTexCoordPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer) {
+	TinyGL::GLParam p[4];
 	assert(type == TGL_FLOAT);
-	p[0].op = OP_TexCoordPointer;
+	p[0].op = TinyGL::OP_TexCoordPointer;
 	p[1].i = size;
 	p[2].i = stride;
 	p[3].p = const_cast<void *>(pointer);
 	gl_add_op(p);
 }
-
-} // end of namespace TinyGL

--- a/graphics/tinygl/arrays.cpp
+++ b/graphics/tinygl/arrays.cpp
@@ -77,6 +77,18 @@ void glopArrayElement(GLContext *c, GLParam *param) {
 	}
 }
 
+void glopDrawArrays(GLContext *c, GLParam *p) {
+	GLParam array_element[2];
+	GLParam begin[2];
+	begin[1].i = p[1].i;
+	glopBegin(c, begin);
+	for (int i=0; i < p[3].i; i++) {
+		array_element[1].i = p[2].i + i;
+		glopArrayElement(c, array_element);
+	}
+	glopEnd(c, NULL);
+}
+
 void glopEnableClientState(GLContext *c, GLParam *p) {
 	c->client_states |= p[1].i;
 }
@@ -114,6 +126,15 @@ void tglArrayElement(TGLint i) {
 	TinyGL::GLParam p[2];
 	p[0].op = TinyGL::OP_ArrayElement;
 	p[1].i = i;
+	gl_add_op(p);
+}
+
+void tglDrawArrays(TGLenum mode, TGLint first, TGLsizei count) {
+	TinyGL::GLParam p[4];
+	p[0].op = TinyGL::OP_DrawArrays;
+	p[1].i = mode;
+	p[2].i = first;
+	p[3].i = count;
 	gl_add_op(p);
 }
 

--- a/graphics/tinygl/gl.h
+++ b/graphics/tinygl/gl.h
@@ -836,6 +836,7 @@ void tglSetShadowColor(unsigned char r, unsigned char g, unsigned char b);
 void tglEnableClientState(TGLenum array);
 void tglDisableClientState(TGLenum array);
 void tglArrayElement(TGLint i);
+void tglDrawArrays(TGLenum mode, TGLint first, TGLsizei count);
 void tglVertexPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer);
 void tglColorPointer(TGLint size, TGLenum type, TGLsizei stride, const TGLvoid *pointer);
 void tglNormalPointer(TGLenum type, TGLsizei stride, const TGLvoid *pointer);

--- a/graphics/tinygl/opinfo.h
+++ b/graphics/tinygl/opinfo.h
@@ -91,6 +91,7 @@ ADD_OP(NextBuffer, 1, "%p")
 
 // opengl 1.1 arrays
 ADD_OP(ArrayElement, 1, "%d")
+ADD_OP(DrawArrays, 3, "%C %d %d")
 ADD_OP(EnableClientState, 1, "%C")
 ADD_OP(DisableClientState, 1, "%C")
 ADD_OP(VertexPointer, 4, "%d %C %d %p")


### PR DESCRIPTION
To be used in GRIM iris implementation, avoiding direct framebuffer writes.