### PR TITLE
GRIM: Drop off-screen buffers

### DIFF
--- a/engines/grim/actor.h
+++ b/engines/grim/actor.h
@@ -365,6 +365,14 @@ public:
 	void putInSet(const Common::String &setName);
 	/**
 	 * Returns true if the actor is in the given set.
+	 * For engine internal use only, do not expose via lua API.
+	 *
+	 * @param setName The name of the set.
+	 */
+	bool isDrawableInSet(const Common::String &setName) const;
+	/**
+	 * Returns true if the actor is in the given set.
+	 * Can be exposed via lua API.
 	 *
 	 * @param setName The name of the set.
 	 */
@@ -549,9 +557,7 @@ public:
 	void activateShadow(bool active, const char *shadowName);
 	void activateShadow(bool active, SetShadow *shadow);
 
-	void restoreCleanBuffer();
 	void drawToCleanBuffer();
-	void clearCleanBuffer();
 
 	bool isTalkingForeground() const;
 
@@ -715,7 +721,7 @@ private:
 	int _sectorSortOrder;
 	bool _useParentSortOrder;
 
-	int _cleanBuffer;
+	bool _fakeUnbound;
 	bool _drawnToClean;
 
 	LightMode _lightMode;

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -268,13 +268,6 @@ public:
 	virtual void updateEMIModel(const EMIModel *model) {}
 	virtual void destroyEMIModel(EMIModel *model) {}
 
-	virtual int genBuffer() { return 0; }
-	virtual void delBuffer(int buffer) {}
-	virtual void selectBuffer(int buffer) {}
-	virtual void clearBuffer(int buffer) {}
-	virtual void drawBuffers() {}
-	virtual void refreshBuffers() {}
-
 	virtual void createSpecialtyTexture(uint id, const uint8 *data, int width, int height);
 	virtual void createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) = 0;
 

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -27,10 +27,6 @@
 
 #include "graphics/tinygl/zgl.h"
 
-namespace TinyGL {
-	struct Buffer;
-}
-
 namespace Grim {
 
 class ModelNode;
@@ -126,13 +122,6 @@ public:
 	void drawMovieFrame(int offsetX, int offsetY) override;
 	void releaseMovieFrame() override;
 
-	int genBuffer() override;
-	void delBuffer(int buffer) override;
-	void selectBuffer(int buffer) override;
-	void clearBuffer(int buffer) override;
-	void drawBuffers() override;
-	void refreshBuffers() override;
-
 	void setBlendMode(bool additive) override;
 
 protected:
@@ -145,8 +134,6 @@ private:
 	Graphics::BlitImage *_smushImage;
 	Graphics::PixelBuffer _storedDisplay;
 	float _alpha;
-	Common::HashMap<int, TinyGL::Buffer *> _buffers;
-	uint _bufferId;
 	const Actor *_currentActor;
 	TGLenum _depthFunc;
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -641,8 +641,6 @@ void GrimEngine::updateNormalMode() {
 
 	drawNormalMode();
 
-	g_driver->drawBuffers();
-
 	_iris->draw();
 	drawTextObjects();
 }
@@ -1016,12 +1014,8 @@ void GrimEngine::savegameRestore() {
 	invalidateActiveActorsList();
 	buildActiveActorsList();
 
-	g_driver->refreshBuffers();
 	_currSet->setupCamera();
 	g_driver->set3DMode();
-	foreach (Actor *a, Actor::getPool()) {
-		a->restoreCleanBuffer();
-	}
 }
 
 void GrimEngine::restoreGRIM() {
@@ -1259,9 +1253,7 @@ void GrimEngine::setSet(Set *scene) {
 	// and coords change too.
 	foreach (Actor *a, Actor::getPool()) {
 		a->stopWalking();
-		a->clearCleanBuffer();
 	}
-	g_driver->refreshBuffers();
 
 	Set *lastSet = _currSet;
 	_currSet = scene;
@@ -1278,11 +1270,6 @@ void GrimEngine::setSet(Set *scene) {
 void GrimEngine::makeCurrentSetup(int num) {
 	int prevSetup = g_grim->getCurrSet()->getSetup();
 	if (prevSetup != num) {
-		foreach (Actor *a, Actor::getPool()) {
-			a->clearCleanBuffer();
-		}
-		g_driver->refreshBuffers();
-
 		getCurrSet()->setSetup(num);
 		getCurrSet()->setSoundParameters(20, 127);
 		cameraChangeHandle(prevSetup, num);
@@ -1332,7 +1319,7 @@ void GrimEngine::buildActiveActorsList() {
 
 	_activeActors.clear();
 	foreach (Actor *a, Actor::getPool()) {
-		if (((_mode == NormalMode || _mode == DrawMode) && a->isInSet(_currSet->getName())) ||
+		if (((_mode == NormalMode || _mode == DrawMode) && a->isDrawableInSet(_currSet->getName())) ||
 		    a->isInOverworld()) {
 			_activeActors.push_back(a);
 		}

--- a/engines/grim/lua_v1_graphics.cpp
+++ b/engines/grim/lua_v1_graphics.cpp
@@ -521,12 +521,7 @@ void Lua_V1::EngineDisplay() {
 }
 
 void Lua_V1::ForceRefresh() {
-	// refreshBuffers() must clean the backing buffer but NOT the actors' buffers.
-	// In set at Glottis and Albinizod are frozen not at the same time, so this is called every time
-	// one of the two is frozen.
-	// That one gets redrawn to its buffer, but not the other one, so it must still have its buffer
-	// otherwise it will disappear.
-	g_driver->refreshBuffers();
+	// Nothing to do, no off-screen buffers
 }
 
 void Lua_V1::RenderModeUser() {

--- a/engines/grim/savegame.cpp
+++ b/engines/grim/savegame.cpp
@@ -35,7 +35,7 @@ namespace Grim {
 #define SAVEGAME_FOOTERTAG  'ESAV'
 
 uint SaveGame::SAVEGAME_MAJOR_VERSION = 22;
-uint SaveGame::SAVEGAME_MINOR_VERSION = 26;
+uint SaveGame::SAVEGAME_MINOR_VERSION = 27;
 
 SaveGame *SaveGame::openForLoading(const Common::String &filename) {
 	Common::InSaveFile *inSaveFile = g_system->getSavefileManager()->openForLoading(filename);


### PR DESCRIPTION
This should fix #1042 and #1251 .

These were present to implement actor freezing in software rendering mode
in the way original engine was intended for performance reason.
In residualvm, software rendering will generalise the principle through
dirty-rectangles management, so off-screen buffers should not be needed.

Also, properly implementing them requires invasive changes (move previous
draw call list from global OpenGL context to individual off-screen buffers,
along with associated linear vertex allocator, adding a new draw call to
track requested buffer changes until final on-screen frame buffer
presentation).
So instead of such added complexity, lie to lua API about actor not being
in set but keep it in so it is part of normal redraw sequence.

Fixes disappearing actors in cn, bi.
Likely also fixes at, ly, sh, mn, dd which uses free/thaw lua API, but
which I did not check.