### PR TITLE
ALL: Add a --bpp option (and simple command-line patches)

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -124,6 +124,8 @@ static const char HELP_STRING[] =
 	"  --no-show-fps            Set the turn off display FPS info\n"
 	"  --renderer=RENDERER      Select renderer (software, opengl, opengl_shaders)\n"
 	"  --aspect-ratio           Enable aspect ratio correction\n"
+	"  --bpp=NUM                Select number of bits per pixel, 0 (auto-detect), 16, 32\n"
+	"                           (default: 0) (only supported by software renderer)\n"
 #ifdef ENABLE_EVENTRECORDER
 	"  --record-mode=MODE       Specify record mode for event recorder (record, playback,\n"
 	"                           passthrough [default])\n"
@@ -167,6 +169,7 @@ void registerDefaults() {
 	ConfMan.registerDefault("filtering", false);
 	ConfMan.registerDefault("show_fps", false);
 	ConfMan.registerDefault("aspect_ratio", false);
+	ConfMan.registerDefault("bpp", 0);
 
 	// Sound & Music
 	ConfMan.registerDefault("music_volume", 192);
@@ -506,6 +509,9 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			END_OPTION
 
 			DO_LONG_OPTION_BOOL("aspect-ratio")
+			END_OPTION
+
+			DO_LONG_OPTION_INT("bpp")
 			END_OPTION
 
 			DO_LONG_OPTION("gamma")

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -126,6 +126,8 @@ static const char HELP_STRING[] =
 	"  --aspect-ratio           Enable aspect ratio correction\n"
 	"  --bpp=NUM                Select number of bits per pixel, 0 (auto-detect), 16, 32\n"
 	"                           (default: 0) (only supported by software renderer)\n"
+	"  --[no-]dirtyrects        Enable dirty rectangles optimisation in software renderer\n"
+	"                           (default: enabled)\n"
 #ifdef ENABLE_EVENTRECORDER
 	"  --record-mode=MODE       Specify record mode for event recorder (record, playback,\n"
 	"                           passthrough [default])\n"
@@ -171,6 +173,7 @@ void registerDefaults() {
 	ConfMan.registerDefault("filtering", false);
 	ConfMan.registerDefault("show_fps", false);
 	ConfMan.registerDefault("aspect_ratio", false);
+	ConfMan.registerDefault("dirtyrects", true);
 	ConfMan.registerDefault("bpp", 0);
 
 	// Sound & Music
@@ -512,6 +515,9 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			END_OPTION
 
 			DO_LONG_OPTION_INT("bpp")
+			END_OPTION
+
+			DO_LONG_OPTION_BOOL("dirtyrects")
 			END_OPTION
 
 			DO_LONG_OPTION("gamma")

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -137,6 +137,8 @@ static const char HELP_STRING[] =
 #ifdef ENABLE_GRIM
 	"  --dimuse-tempo=NUM       Set internal Digital iMuse tempo (10 - 100) per second\n"
 	"                           (default: 10)\n"
+	"  --engine-speed=NUM       Set frame per second limit (0 - 100), 0 = no limit\n"
+	"                           (default: 60)\n"
 #endif
 ;
 #endif
@@ -208,6 +210,7 @@ void registerDefaults() {
 
 #ifdef ENABLE_GRIM
 	ConfMan.registerDefault("dimuse_tempo", 10);
+	ConfMan.registerDefault("engine_speed", 60);
 #endif
 
 	// Miscellaneous
@@ -496,9 +499,6 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			DO_LONG_OPTION_BOOL("disable-sdl-parachute")
 			END_OPTION
 
-			DO_LONG_OPTION("engine-speed")
-			END_OPTION
-
 			DO_LONG_OPTION_BOOL("multi-midi")
 			END_OPTION
 
@@ -568,6 +568,9 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 
 #ifdef ENABLE_GRIM
 			DO_LONG_OPTION_INT("dimuse-tempo")
+			END_OPTION
+
+			DO_LONG_OPTION_INT("engine-speed")
 			END_OPTION
 #endif
 

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "common/config-manager.h"
 #include "common/endian.h"
 #include "common/system.h"
 
@@ -94,6 +95,7 @@ byte *GfxTinyGL::setupScreen(int screenW, int screenH, bool fullscreen) {
 	_pixelFormat = buf.getFormat();
 	_zb = new TinyGL::FrameBuffer(screenW, screenH, buf);
 	TinyGL::glInit(_zb, 256);
+	tglEnableDirtyRects(ConfMan.getBool("dirtyrects"));
 
 	_storedDisplay.create(_pixelFormat, _gameWidth * _gameHeight, DisposeAfterUse::YES);
 	_storedDisplay.clear(_gameWidth * _gameHeight);

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -104,8 +104,6 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 	g_imuse = nullptr;
 
 	//Set default settings
-	ConfMan.registerDefault("fullscreen", false);
-	ConfMan.registerDefault("show_fps", false);
 	ConfMan.registerDefault("use_arb_shaders", true);
 
 	_showFps = ConfMan.getBool("show_fps");

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -104,7 +104,6 @@ GrimEngine::GrimEngine(OSystem *syst, uint32 gameFlags, GrimGameType gameType, C
 	g_imuse = nullptr;
 
 	//Set default settings
-	ConfMan.registerDefault("engine_speed", 60);
 	ConfMan.registerDefault("fullscreen", false);
 	ConfMan.registerDefault("show_fps", false);
 	ConfMan.registerDefault("use_arb_shaders", true);

--- a/engines/myst3/gfx_tinygl.cpp
+++ b/engines/myst3/gfx_tinygl.cpp
@@ -26,6 +26,7 @@
 #undef ARRAYSIZE
 #endif
 
+#include "common/config-manager.h"
 #include "common/rect.h"
 #include "common/textconsole.h"
 
@@ -71,6 +72,7 @@ void TinyGLRenderer::init() {
 	Graphics::PixelBuffer screenBuffer = _system->getScreenPixelBuffer();
 	_fb = new TinyGL::FrameBuffer(kOriginalWidth, kOriginalHeight, screenBuffer);
 	TinyGL::glInit(_fb, 512);
+	tglEnableDirtyRects(ConfMan.getBool("dirtyrects"));
 
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();


### PR DESCRIPTION
Add a --bpp option (0, 16, 32).
Document existing --engine-speed option.
Drop duplicate default option declarations.

Questions for review:
- is "ALL" prefix good here ?
- any idea why command line options only seem to work (from engine point of view) when *not* showing the launcher (ie, starting directly to game is fine) ?
- is it fine to discard duplicate default option declarations ?

/cc @bgK @raziel- 