### PR TITLE
ALL: Improve big-endian support

### DIFF
--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -479,10 +479,7 @@ void BitmapData::convertToColorFormat(int num, const Graphics::PixelFormat &form
 	}
 
 	Graphics::PixelBuffer dst(format, _width * _height, DisposeAfterUse::NO);
-
-	for (int i = 0; i < _width * _height; ++i) {
-		dst.setPixelAt(i, _data[num]);
-	}
+	dst.copyBuffer(0, _width * _height, _data[num]);
 	_data[num].free();
 	_data[num] = dst;
 }

--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -335,13 +335,12 @@ bool BitmapData::loadTile(Common::SeekableReadStream *o) {
 				uint8 r = (p & 0x001F) << 3;
 				uint8 a = (p & 0x8000) ? 0xFF : 0x00;
 				// Recombine the color components into a 32 bit RGB value
-				uint32 tmp = (r << 24) | (g << 16) | (b << 8) | a;
-				WRITE_BE_UINT32(&d[j], tmp);
+				d[j] = (a << 24) | (b << 16) | (g << 8) | r;
 			}
 		} else if (_bpp == 32) {
 			uint32 *d = (uint32 *)data[i];
 			for (int j = 0; j < _width * _height; ++j) {
-				o->read(&(d[j]), 4);
+				d[j] = o->readUint32LE();
 			}
 		}
 	}

--- a/engines/grim/emi/emi.cpp
+++ b/engines/grim/emi/emi.cpp
@@ -223,7 +223,7 @@ void EMIEngine::storeSaveGameImage(SaveGame *state) {
 	unsigned int texWidth = 256, texHeight = 128;
 	unsigned int size = texWidth * texHeight;
 	Graphics::PixelBuffer buffer = Graphics::PixelBuffer::createBuffer<565>(size, DisposeAfterUse::YES);
-	buffer.clear(texWidth * texHeight);
+	buffer.clear(size);
 	for (unsigned int j = 0; j < 120; j++) {
 		buffer.copyBuffer(j * texWidth, j * width, width, screenshot->getData(0));
 	}

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -500,25 +500,14 @@ void Lua_V2::ThumbnailFromFile() {
 		delete savedState;
 		return;
 	}
-	uint16 *data = new uint16[dataSize / 2];
+	Graphics::Surface screenshot;
+	screenshot.create(width, height, Graphics::createPixelFormat<565>());
+	uint16 *data = (uint16 *) screenshot.getPixels();
 	for (int l = 0; l < dataSize / 2; l++) {
 		data[l] = savedState->readLEUint16();
 	}
-	Graphics::PixelBuffer buf(Graphics::createPixelFormat<565>(), (byte *)data);
-	Bitmap *screenshot = new Bitmap(buf, width, height, "screenshot");
-	if (!screenshot) {
-		lua_pushnil();
-		warning("Lua_V2::ThumbnailFromFile: Could not restore screenshot from file %s", filename.c_str());
-		delete screenshot;
-		delete[] data;
-		delete savedState;
-		return;
-	}
-
-	screenshot->_data->convertToColorFormat(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-	g_driver->createSpecialtyTexture(index, screenshot->getData(0).getRawBuffer(), width, height);
-	delete screenshot;
-	delete[] data;
+	g_driver->createSpecialtyTexture(index, screenshot);
+	screenshot.free();
 	savedState->endSection();
 	delete savedState;
 

--- a/engines/grim/gfx_base.cpp
+++ b/engines/grim/gfx_base.cpp
@@ -161,18 +161,16 @@ Math::Matrix4 GfxBase::makeProjMatrix(float fov, float nclip, float fclip) {
 }
 
 
-void GfxBase::createSpecialtyTexture(uint id, const uint8 *data, int width, int height) {
+void GfxBase::createSpecialtyTexture(uint id, uint8 *data, int width, int height) {
+	Graphics::PixelFormat pf(4, 8, 8, 8, 8, 0, 8, 16, 24);
 	if (id >= _numSpecialtyTextures)
 		return;
 	if (_specialtyTextures[id]._texture) {
 		destroyTexture(&_specialtyTextures[id]);
 	}
-	delete[] _specialtyTextures[id]._data;
-	_specialtyTextures[id]._width = width;
-	_specialtyTextures[id]._height = height;
-	_specialtyTextures[id]._bpp = 4;
-	_specialtyTextures[id]._colorFormat = BM_RGBA;
-	createTexture(&_specialtyTextures[id], data, nullptr, true);
+	_specialtyTextures[id].create(width, height, pf);
+	memcpy(_specialtyTextures[id].getPixels(), data, width * height * pf.bytesPerPixel);
+	createTexture(&_specialtyTextures[id], nullptr, true);
 }
 
 Bitmap *GfxBase::createScreenshotBitmap(const Graphics::PixelBuffer src, int w, int h, bool flipOrientation) {

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -268,8 +268,7 @@ public:
 	virtual void updateEMIModel(const EMIModel *model) {}
 	virtual void destroyEMIModel(EMIModel *model) {}
 
-	virtual void createSpecialtyTexture(uint id, uint8 *data, int width, int height);
-	virtual void createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) = 0;
+	virtual void createSpecialtyTexture(uint id, const Graphics::Surface &surface);
 
 	static Math::Matrix4 makeLookMatrix(const Math::Vector3d& pos, const Math::Vector3d& interest, const Math::Vector3d& up);
 	static Math::Matrix4 makeProjMatrix(float fov, float nclip, float fclip);

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -153,7 +153,7 @@ public:
 	virtual void setupLight(Light *light, int lightId) = 0;
 	virtual void turnOffLight(int lightId) = 0;
 
-	virtual void createTexture(Texture *texture, const uint8 *data, const CMap *cmap, bool clamp) = 0;
+	virtual void createTexture(Texture *texture, const CMap *cmap, bool clamp) = 0;
 	virtual void selectTexture(const Texture *texture) = 0;
 	virtual void destroyTexture(Texture *texture) = 0;
 
@@ -268,7 +268,7 @@ public:
 	virtual void updateEMIModel(const EMIModel *model) {}
 	virtual void destroyEMIModel(EMIModel *model) {}
 
-	virtual void createSpecialtyTexture(uint id, const uint8 *data, int width, int height);
+	virtual void createSpecialtyTexture(uint id, uint8 *data, int width, int height);
 	virtual void createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) = 0;
 
 	static Math::Matrix4 makeLookMatrix(const Math::Vector3d& pos, const Math::Vector3d& interest, const Math::Vector3d& up);

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -2040,19 +2040,6 @@ void GfxOpenGL::drawPolygon(const PrimitiveObject *primitive) {
 #endif
 }
 
-void GfxOpenGL::readPixels(int x, int y, int width, int height, uint8 *buffer) {
-	uint8 *p = buffer;
-	for (int i = y; i < y + height; i++) {
-		glReadPixels(x, _screenHeight - 1 - i, width, 1, GL_RGBA, GL_UNSIGNED_BYTE, p);
-		p += width * 4;
-	}
-}
-
-void GfxOpenGL::createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) {
-	readPixels(x, y, width, height, data);
-	createSpecialtyTexture(id, data, width, height);
-}
-
 void GfxOpenGL::setBlendMode(bool additive) {
 	if (additive) {
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE);

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -95,7 +95,7 @@ public:
 	void setupLight(Light *light, int lightId) override;
 	void turnOffLight(int lightId) override;
 
-	void createTexture(Texture *texture, const uint8 *data, const CMap *cmap, bool clamp) override;
+	void createTexture(Texture *texture, const CMap *cmap, bool clamp) override;
 	void selectTexture(const Texture *texture) override;
 	void destroyTexture(Texture *texture) override;
 

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -132,9 +132,9 @@ public:
 	void setBlendMode(bool additive) override;
 
 protected:
-	void createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) override;
 	void drawDepthBitmap(int x, int y, int w, int h, char *data);
 	void initExtensions();
+
 private:
 	GLuint _emergFont;
 	int _smushNumTex;
@@ -150,8 +150,6 @@ private:
 	float _alpha;
 	const Actor *_currentActor;
 	GLenum _depthFunc;
-
-	void readPixels(int x, int y, int width, int height, uint8 *buffer);
 };
 
 } // end of namespace Grim

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -2075,14 +2075,6 @@ void GfxOpenGLS::destroyMesh(const Mesh *mesh) {
 	delete mud;
 }
 
-static void readPixels(int x, int y, int width, int height, byte *buffer) {
-	byte *p = buffer;
-	for (int i = y; i < y + height; i++) {
-		glReadPixels(x, 479 - i, width, 1, GL_RGBA, GL_UNSIGNED_BYTE, p);
-		p += width * 4;
-	}
-}
-
 Bitmap *GfxOpenGLS::getScreenshot(int w, int h, bool useStored) {
 	Graphics::PixelBuffer src(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), _screenWidth * _screenHeight, DisposeAfterUse::YES);
 #ifndef USE_GLES2
@@ -2099,14 +2091,13 @@ Bitmap *GfxOpenGLS::getScreenshot(int w, int h, bool useStored) {
 	} else
 #endif
 	{
-		readPixels(0, 0, _screenWidth, _screenHeight, src.getRawBuffer());
+		byte *p = src.getRawBuffer();
+		for (int i = 0; i < _screenHeight; i++) {
+			glReadPixels(0, 479 - i, _screenWidth, 1, GL_RGBA, GL_UNSIGNED_BYTE, p);
+			p += _screenWidth * 4;
+		}
 	}
 	return createScreenshotBitmap(src, w, h, true);
-}
-
-void GfxOpenGLS::createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) {
-	readPixels(x, y, width, height, data);
-	createSpecialtyTexture(id, data, width, height);
 }
 
 void GfxOpenGLS::setBlendMode(bool additive) {

--- a/engines/grim/gfx_opengl_shaders.h
+++ b/engines/grim/gfx_opengl_shaders.h
@@ -215,7 +215,6 @@ protected:
 	void setupShaders();
 	GLuint compileShader(const char *vertex, const char *fragment);
 	GLuint compileShader(const char *shader) { return compileShader(shader, shader); }
-	void createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) override;
 
 private:
 	const Actor *_currentActor;

--- a/engines/grim/gfx_opengl_shaders.h
+++ b/engines/grim/gfx_opengl_shaders.h
@@ -101,7 +101,7 @@ public:
 	virtual void setupLight(Light *light, int lightId) override;
 	virtual void turnOffLight(int lightId) override;
 
-	virtual void createTexture(Texture *texture, const uint8 *data, const CMap *cmap, bool clamp) override;
+	virtual void createTexture(Texture *texture, const CMap *cmap, bool clamp) override;
 	virtual void selectTexture(const Texture *texture) override;
 	virtual void destroyTexture(Texture *texture) override;
 

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -93,6 +93,7 @@ byte *GfxTinyGL::setupScreen(int screenW, int screenH, bool fullscreen) {
 	g_system->setWindowCaption("ResidualVM: Software 3D Renderer");
 
 	_pixelFormat = buf.getFormat();
+	debug("INFO: TinyGL front buffer pixel format: %s", _pixelFormat.toString().c_str());
 	_zb = new TinyGL::FrameBuffer(screenW, screenH, buf);
 	TinyGL::glInit(_zb, 256);
 	tglEnableDirtyRects(ConfMan.getBool("dirtyrects"));

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -1230,11 +1230,6 @@ Bitmap *GfxTinyGL::getScreenshot(int w, int h, bool useStored) {
 	}
 }
 
-void GfxTinyGL::createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) {
-	readPixels(x, y, width, height, data);
-	createSpecialtyTexture(id, data, width, height);
-}
-
 void GfxTinyGL::storeDisplay() {
 	TinyGL::tglPresentBuffer();
 	_zb->copyToBuffer(_storedDisplay);
@@ -1471,31 +1466,6 @@ void GfxTinyGL::drawPolygon(const PrimitiveObject *primitive) {
 	tglDepthMask(TGL_TRUE);
 	tglEnable(TGL_DEPTH_TEST);
 	tglEnable(TGL_LIGHTING);
-}
-
-void GfxTinyGL::readPixels(int x, int y, int width, int height, uint8 *buffer) {
-	assert(x >= 0);
-	assert(y >= 0);
-	assert(x < _screenWidth);
-	assert(y < _screenHeight);
-
-	uint8 r, g, b;
-	int pos = x + y * _screenWidth;
-	for (int i = 0; i < height; ++i) {
-		for (int j = 0; j < width; ++j) {
-			if ((j + x) >= _screenWidth || (i + y) >= _screenHeight) {
-				buffer[0] = buffer[1] = buffer[2] = 0;
-			} else {
-				_zb->readPixelRGB(pos + j, r, g, b);
-				buffer[0] = r;
-				buffer[1] = g;
-				buffer[2] = b;
-			}
-			buffer[3] = 255;
-			buffer += 4;
-		}
-		pos += _screenWidth;
-	}
 }
 
 void GfxTinyGL::setBlendMode(bool additive) {

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -87,7 +87,7 @@ public:
 	void setupLight(Light *light, int lightId) override;
 	void turnOffLight(int lightId) override;
 
-	void createTexture(Texture *texture, const uint8 *data, const CMap *cmap, bool clamp) override;
+	void createTexture(Texture *texture, const CMap *cmap, bool clamp) override;
 	void selectTexture(const Texture *texture) override;
 	void destroyTexture(Texture *texture) override;
 

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -124,9 +124,6 @@ public:
 
 	void setBlendMode(bool additive) override;
 
-protected:
-	void createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height);
-
 private:
 	TinyGL::FrameBuffer *_zb;
 	Graphics::PixelFormat _pixelFormat;
@@ -136,8 +133,6 @@ private:
 	float _alpha;
 	const Actor *_currentActor;
 	TGLenum _depthFunc;
-
-	void readPixels(int x, int y, int width, int height, uint8 *buffer);
 };
 
 } // end of namespace Grim

--- a/engines/grim/material.h
+++ b/engines/grim/material.h
@@ -24,22 +24,17 @@
 #define GRIM_MATERIAL_H
 
 #include "engines/grim/object.h"
+#include "graphics/surface.h"
 
 namespace Grim {
 
 class CMap;
 
-class Texture {
+class Texture : public Graphics::Surface{
 public:
-	Texture() :
-		_width(0), _height(0), _colorFormat(0), _bpp(0), _hasAlpha(false), _texture(nullptr), _data(nullptr), _isShared(false) {};
-	int _width;
-	int _height;
-	int _colorFormat;
-	int _bpp;
+	Texture() : Surface(), _hasAlpha(false), _texture(nullptr), _isShared(false) {};
 	bool _hasAlpha;
 	void *_texture;
-	uint8 *_data;
 	bool _isShared;
 };
 

--- a/engines/grim/shaders/emi_actor.fragment
+++ b/engines/grim/shaders/emi_actor.fragment
@@ -3,7 +3,6 @@ in vec4 Color;
 
 uniform sampler2D tex;
 uniform bool textured;
-uniform bool swapRandB;
 uniform float alphaRef;
 uniform float meshAlpha;
 
@@ -14,10 +13,6 @@ void main()
 	outColor = Color;
 	if (textured) {
 		vec4 texColor = texture(tex, Texcoord);
-#ifdef GL_ES
-		if (swapRandB)
-			texColor.rb = texColor.br;
-#endif
 		outColor.rgba *= texColor.rgba;
 		outColor.a *= meshAlpha;
 		if (outColor.a < alphaRef)

--- a/engines/myst3/gfx_opengl_shaders.cpp
+++ b/engines/myst3/gfx_opengl_shaders.cpp
@@ -390,18 +390,9 @@ Graphics::Surface *ShaderRenderer::getScreenshot() {
 	Graphics::Surface *s = new Graphics::Surface();
 	s->create(screen.width(), screen.height(), Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
 
-#if defined(USE_GLES2)
 	GLenum format = GL_UNSIGNED_BYTE;
-#else
-	GLenum format = GL_UNSIGNED_INT_8_8_8_8_REV;
-#endif
 
 	glReadPixels(screen.left, screen.top, screen.width(), screen.height(), GL_RGBA, format, s->getPixels());
-
-#if defined(USE_GLES2) && defined(SCUMM_BIG_ENDIAN)
-	// OpenGL ES does not support the GL_UNSIGNED_INT_8_8_8_8_REV texture format, we need to byteswap the surface
-	OpenGLTexture::byteswapSurface(s);
-#endif
 
 	flipVertical(s);
 

--- a/engines/myst3/gfx_opengl_texture.cpp
+++ b/engines/myst3/gfx_opengl_texture.cpp
@@ -59,11 +59,7 @@ OpenGLTexture::OpenGLTexture(const Graphics::Surface *surface) {
 	if (format.bytesPerPixel == 4) {
 		internalFormat = GL_RGBA;
 
-#if defined(USE_GLES2)
 		sourceFormat = GL_UNSIGNED_BYTE;
-#else
-		sourceFormat = GL_UNSIGNED_INT_8_8_8_8_REV;
-#endif
 	} else if (format.bytesPerPixel == 2) {
 		internalFormat = GL_RGB;
 		sourceFormat = GL_UNSIGNED_SHORT_5_6_5;
@@ -109,34 +105,7 @@ void OpenGLTexture::updateTexture(const Graphics::Surface* surface, const Common
 }
 
 void OpenGLTexture::updatePartial(const Graphics::Surface *surface, const Common::Rect &rect) {
-#if defined(USE_GLES2) && defined(SCUMM_BIG_ENDIAN)
-	// OpenGL ES does not support the GL_UNSIGNED_INT_8_8_8_8_REV texture format
-	// we need to byteswap before hand
-	Graphics::Surface swappedSurface;
-	swappedSurface.copyFrom(*surface);
-	byteswapSurface(&swappedSurface);
-	updateTexture(&swappedSurface, rect);
-	swappedSurface.free();
-#else
 	updateTexture(surface, rect);
-#endif
-
-}
-
-void OpenGLTexture::byteswapSurface(Graphics::Surface *surface) {
-	for (int y = 0; y < surface->h; y++) {
-		for (int x = 0; x < surface->w; x++) {
-			if (surface->format.bytesPerPixel == 4) {
-				uint32 *pixel = (uint32 *) (surface->getBasePtr(x, y));
-				*pixel = SWAP_BYTES_32(*pixel);
-			} else if (surface->format.bytesPerPixel == 2) {
-				uint16 *pixel = (uint16 *) (surface->getBasePtr(x, y));
-				*pixel = SWAP_BYTES_16(*pixel);
-			} else {
-				error("Unexpected bytes per pixedl %d", surface->format.bytesPerPixel);
-			}
-		}
-	}
 }
 
 } // End of namespace Myst3

--- a/engines/myst3/gfx_opengl_texture.h
+++ b/engines/myst3/gfx_opengl_texture.h
@@ -39,8 +39,6 @@ public:
 	void update(const Graphics::Surface *surface) override;
 	void updatePartial(const Graphics::Surface *surface, const Common::Rect &rect) override;
 
-	static void byteswapSurface(Graphics::Surface *surface);
-
 	GLuint id;
 	GLuint internalFormat;
 	GLuint sourceFormat;

--- a/engines/myst3/gfx_tinygl_texture.cpp
+++ b/engines/myst3/gfx_tinygl_texture.cpp
@@ -35,7 +35,7 @@ TinyGLTexture::TinyGLTexture(const Graphics::Surface *surface) {
 		sourceFormat = TGL_UNSIGNED_INT_8_8_8_8_REV;
 	} else if (format.bytesPerPixel == 2) {
 		internalFormat = TGL_RGB;
-		sourceFormat = TGL_UNSIGNED_BYTE; // UNSIGNED_SHORT_5_6_5 not provided
+		sourceFormat = TGL_UNSIGNED_SHORT_5_6_5;
 	} else
 		error("Unknown pixel format");
 

--- a/engines/myst3/gfx_tinygl_texture.cpp
+++ b/engines/myst3/gfx_tinygl_texture.cpp
@@ -32,7 +32,8 @@ TinyGLTexture::TinyGLTexture(const Graphics::Surface *surface) {
 
 	if (format.bytesPerPixel == 4) {
 		internalFormat = TGL_RGBA;
-		sourceFormat = TGL_UNSIGNED_INT_8_8_8_8_REV;
+
+		sourceFormat = TGL_UNSIGNED_BYTE;
 	} else if (format.bytesPerPixel == 2) {
 		internalFormat = TGL_RGB;
 		sourceFormat = TGL_UNSIGNED_SHORT_5_6_5;

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1306,7 +1306,11 @@ Graphics::Surface *Myst3Engine::loadTexture(uint16 id) {
 	Graphics::Surface *s = new Graphics::Surface();
 	s->create(width, height, Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0));
 
-	data->read(s->getPixels(), height * s->pitch);
+	uint32 remain = height * s->pitch / 4;
+	uint32 *pixel = (uint32 *) s->getPixels();
+	while (remain--) {
+		*(pixel++) = data->readUint32LE();
+	}
 	delete data;
 
 	// ARGB => RGBA

--- a/engines/myst3/state.cpp
+++ b/engines/myst3/state.cpp
@@ -479,7 +479,11 @@ void GameState::StateData::syncWithSaveGame(Common::Serializer &s) {
 	}
 	assert(thumbnail && thumbnail->w == kThumbnailWidth && thumbnail->h == kThumbnailHeight);
 
-	s.syncBytes((byte *)thumbnail->getPixels(), kThumbnailWidth * kThumbnailHeight * 4);
+	uint32 remain = kThumbnailWidth * kThumbnailHeight;
+	uint32 *pixel = (uint32 *) thumbnail->getPixels();
+	while (remain--) {
+		s.syncAsUint32LE(*(pixel++));
+	}
 }
 
 void GameState::StateData::resizeThumbnail(Graphics::Surface *small) const {

--- a/graphics/pixelbuffer.cpp
+++ b/graphics/pixelbuffer.cpp
@@ -90,10 +90,10 @@ void PixelBuffer::copyBuffer(int thisFrom, int otherFrom, int length, const Pixe
 	if (buf._format == _format) {
 		memcpy(_buffer + thisFrom * _format.bytesPerPixel, buf._buffer + otherFrom * _format.bytesPerPixel, length * _format.bytesPerPixel);
 	} else {
-		uint8 r, g, b;
+		uint8 r, g, b, a;
 		for (int i = 0; i < length; ++i) {
-			buf.getRGBAt(i + otherFrom, r, g, b);
-			setPixelAt(i + thisFrom, r, g, b);
+			buf.getARGBAt(i + otherFrom, a, r, g, b);
+			setPixelAt(i + thisFrom, a, r, g, b);
 		}
 	}
 }

--- a/graphics/pixelbuffer.cpp
+++ b/graphics/pixelbuffer.cpp
@@ -83,7 +83,7 @@ void PixelBuffer::free() {
 }
 
 void PixelBuffer::clear(int length) {
-	memset(_buffer, 0, length);
+	memset(_buffer, 0, length * _format.bytesPerPixel);
 }
 
 void PixelBuffer::copyBuffer(int thisFrom, int otherFrom, int length, const PixelBuffer &buf) {

--- a/graphics/pixelbuffer.cpp
+++ b/graphics/pixelbuffer.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "graphics/pixelbuffer.h"
+#include "graphics/surface.h"
 
 namespace Graphics {
 
@@ -39,6 +40,13 @@ PixelBuffer::PixelBuffer(const PixelFormat &format, int buffersize, DisposeAfter
 PixelBuffer::PixelBuffer(const PixelFormat &format, byte *buffer)
 	: _buffer(buffer),
 	  _format(format),
+	  _dispose(DisposeAfterUse::NO) {
+
+}
+
+PixelBuffer::PixelBuffer(Graphics::Surface &surface)
+	: _buffer((byte *) surface.getPixels()),
+	  _format(surface.format),
 	  _dispose(DisposeAfterUse::NO) {
 
 }

--- a/graphics/pixelbuffer.h
+++ b/graphics/pixelbuffer.h
@@ -124,17 +124,22 @@ public:
 	inline void setPixelAt(int pixel, uint32 value) {
 		switch (_format.bytesPerPixel) {
 		case 2:
-			((uint16 *) _buffer)[pixel] = TO_LE_16((uint16) value);
+			((uint16 *) _buffer)[pixel] = value;
 			return;
 		case 3:
 			pixel *= 3;
-			value = TO_LE_32(value);
+#if defined(SCUMM_BIG_ENDIAN)
+			_buffer[pixel + 0] = (value >> 16) & 0xFF;
+			_buffer[pixel + 1] = (value >> 8) & 0xFF;
+			_buffer[pixel + 2] = value & 0xFF;
+#elif defined(SCUMM_LITTLE_ENDIAN)
 			_buffer[pixel + 0] = value & 0xFF;
 			_buffer[pixel + 1] = (value >> 8) & 0xFF;
 			_buffer[pixel + 2] = (value >> 16) & 0xFF;
+#endif
 			return;
 		case 4:
-			((uint32 *) _buffer)[pixel] = TO_LE_32(value);
+			((uint32 *) _buffer)[pixel] = value;
 			return;
 		}
 		error("setPixelAt: Unhandled bytesPerPixel %i", _format.bytesPerPixel);
@@ -202,7 +207,7 @@ public:
 	inline uint32 getValueAt(int i) const {
 		switch (_format.bytesPerPixel) {
 		case 2:
-			return FROM_LE_16(((uint16 *) _buffer)[i]);
+			return ((uint16 *) _buffer)[i];
 		case 3:
 			i *= 3;
 #if defined(SCUMM_BIG_ENDIAN)
@@ -211,7 +216,7 @@ public:
 			return _buffer[i + 0] | (_buffer[i + 1] << 8) | (_buffer[i + 2] << 16);
 #endif
 		case 4:
-			return FROM_LE_32(((uint32 *) _buffer)[i]);
+			return ((uint32 *) _buffer)[i];
 		}
 		error("getValueAt: Unhandled bytesPerPixel %i", _format.bytesPerPixel);
 	}

--- a/graphics/pixelbuffer.h
+++ b/graphics/pixelbuffer.h
@@ -29,6 +29,7 @@
 
 #include "graphics/colormasks.h"
 #include "graphics/pixelformat.h"
+#include "graphics/surface.h"
 
 namespace Graphics {
 
@@ -71,6 +72,13 @@ public:
 	 * @param buffer The raw buffer containing the pixels.
 	 */
 	PixelBuffer(const Graphics::PixelFormat &format, byte *buffer);
+	/**
+	 * Construct a PixelBuffer, using an already allocated byffer belonging to
+	 * an existing Surface.
+	 *
+	 * @param surface The Surface to use.
+	 */
+	PixelBuffer(Graphics::Surface &surface);
 	/**
 	 * Copy constructor.
 	 * The internal buffer will NOT be duplicated, it will be shared between the instances.

--- a/graphics/tinygl/gl.h
+++ b/graphics/tinygl/gl.h
@@ -589,6 +589,8 @@ enum {
 	TGL_UNSIGNED_SHORT_5_6_5_REV    = 0x8364,
 	TGL_UNSIGNED_INT_8_8_8_8        = 0x8035,
 	TGL_UNSIGNED_INT_8_8_8_8_REV    = 0x8367,
+	TGL_UNSIGNED_SHORT_5_5_5_1      = 0x8034,
+	TGL_UNSIGNED_SHORT_1_5_5_5_REV  = 0x8366,
 
 	// Utility
 	TGL_VENDOR                      = 0x1F00,

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -32,6 +32,58 @@
 
 #include "graphics/tinygl/zgl.h"
 
+struct tglColorAssociation {
+	Graphics::PixelFormat pf;
+	TGLuint format;
+	TGLuint type;
+};
+
+// Declare endian-independent versions of endian-dependent types
+#if defined(SCUMM_LITLE_ENDIAN)
+#	define _TGL_UNSIGNED_INT_8_8_8_8	TGL_UNSIGNED_INT_8_8_8_8
+#	define _TGL_UNSIGNED_SHORT_5_5_5_1	TGL_UNSIGNED_SHORT_5_5_5_1
+#	define _TGL_UNSIGNED_SHORT_5_6_5	TGL_UNSIGNED_SHORT_5_6_5
+#	define _TGL_UNSIGNED_INT_8_8_8_8_REV	TGL_UNSIGNED_INT_8_8_8_8_REV
+#	define _TGL_UNSIGNED_SHORT_1_5_5_5_REV	TGL_UNSIGNED_SHORT_1_5_5_5_REV
+#	define _TGL_UNSIGNED_SHORT_5_6_5_REV	TGL_UNSIGNED_SHORT_5_6_5_REV
+#else
+#	define _TGL_UNSIGNED_INT_8_8_8_8	TGL_UNSIGNED_INT_8_8_8_8_REV
+#	define _TGL_UNSIGNED_SHORT_5_5_5_1	TGL_UNSIGNED_SHORT_1_5_5_5_REV
+#	define _TGL_UNSIGNED_SHORT_5_6_5	TGL_UNSIGNED_SHORT_5_6_5_REV
+#	define _TGL_UNSIGNED_INT_8_8_8_8_REV	TGL_UNSIGNED_INT_8_8_8_8
+#	define _TGL_UNSIGNED_SHORT_1_5_5_5_REV	TGL_UNSIGNED_SHORT_5_5_5_1
+#	define _TGL_UNSIGNED_SHORT_5_6_5_REV	TGL_UNSIGNED_SHORT_5_6_5
+#endif
+
+// When there are multiple possible types for a given PixelFormat, always put
+// TGL_UNSIGNED_BYTE before other variants to be consistent with OpenGLES
+// support.
+static const struct tglColorAssociation colorAssociationList[] = {
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), TGL_RGBA, TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), TGL_RGBA, _TGL_UNSIGNED_INT_8_8_8_8},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), TGL_RGBA, _TGL_UNSIGNED_INT_8_8_8_8_REV},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24), TGL_BGRA, TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24), TGL_BGRA, _TGL_UNSIGNED_INT_8_8_8_8},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0), TGL_BGRA, _TGL_UNSIGNED_INT_8_8_8_8_REV},
+	{Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),  TGL_RGB,  TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),  TGL_BGR,  TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15), TGL_RGBA, _TGL_UNSIGNED_SHORT_5_5_5_1},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0),  TGL_RGBA, _TGL_UNSIGNED_SHORT_1_5_5_5_REV},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15), TGL_BGRA, _TGL_UNSIGNED_SHORT_5_5_5_1},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 1, 6, 11, 0),  TGL_BGRA, _TGL_UNSIGNED_SHORT_1_5_5_5_REV},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0),  TGL_RGB,  _TGL_UNSIGNED_SHORT_5_6_5},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),  TGL_BGR,  _TGL_UNSIGNED_SHORT_5_6_5},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),  TGL_BGR,  _TGL_UNSIGNED_SHORT_5_6_5_REV},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0),  TGL_RGB,  _TGL_UNSIGNED_SHORT_5_6_5_REV}
+};
+#define COLOR_ASSOCIATION_LIST_LENGTH (sizeof(colorAssociationList) / sizeof(*colorAssociationList))
+#undef _TGL_UNSIGNED_INT_8_8_8_8
+#undef _TGL_UNSIGNED_SHORT_5_5_5_1
+#undef _TGL_UNSIGNED_SHORT_5_6_5
+#undef _TGL_UNSIGNED_INT_8_8_8_8_REV
+#undef _TGL_UNSIGNED_SHORT_5_5_5_1_REV
+#undef _TGL_UNSIGNED_SHORT_5_6_5_REV
+
 namespace TinyGL {
 
 static GLTexture *find_texture(GLContext *c, unsigned int h) {
@@ -112,6 +164,15 @@ void glopBindTexture(GLContext *c, GLParam *p) {
 	c->current_texture = t;
 }
 
+static inline const Graphics::PixelFormat formatType2PixelFormat(TGLuint format,  TGLuint type) {
+	for (unsigned int i = 0; i < COLOR_ASSOCIATION_LIST_LENGTH; i++) {
+		if (colorAssociationList[i].format == format &&
+		    colorAssociationList[i].type == type)
+			return colorAssociationList[i].pf;
+	}
+	error("TinyGL texture: format 0x%04x and type 0x%04x combination not supported", format, type);
+}
+
 void glopTexImage2D(GLContext *c, GLParam *p) {
 	int target = p[1].i;
 	int level = p[2].i;
@@ -130,23 +191,6 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 		error("tglTexImage2D: invalid level");
 	if (border != 0)
 		error("tglTexImage2D: invalid border");
-	Graphics::PixelFormat sourceFormat;
-	switch (format) {
-		case TGL_RGBA:
-			sourceFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-			break;
-		case TGL_RGB:
-			sourceFormat = Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
-			break;
-		case TGL_BGRA:
-			sourceFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24);
-			break;
-		case TGL_BGR:
-			sourceFormat = Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
-			break;
-		default:
-			error("tglTexImage2D: Pixel format not handled.");
-	}
 
 	Graphics::PixelFormat pf;
 	switch (format) {
@@ -175,7 +219,7 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 		DisposeAfterUse::NO
 	);
 	if (pixels != NULL) {
-		Graphics::PixelBuffer src(sourceFormat, pixels);
+		Graphics::PixelBuffer src(formatType2PixelFormat(format, type), pixels);
 		if (width != c->_textureSize || height != c->_textureSize) {
 			Graphics::PixelBuffer src_conv(pf, width * height, DisposeAfterUse::YES);
 			src_conv.copyBuffer(

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -123,9 +123,13 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 	int type = p[8].i;
 	byte *pixels = (byte *)p[9].p;
 	GLImage *im;
-	byte *pixels1;
-	bool do_free_after_rgb2rgba = false;
 
+	if (target != TGL_TEXTURE_2D)
+		error("tglTexImage2D: target not handled");
+	if (level < 0 || level >= MAX_TEXTURE_LEVELS)
+		error("tglTexImage2D: invalid level");
+	if (border != 0)
+		error("tglTexImage2D: invalid border");
 	Graphics::PixelFormat sourceFormat;
 	switch (format) {
 		case TGL_RGBA:
@@ -165,68 +169,41 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 		default:
 			break;
 	}
-	int bytes = pf.bytesPerPixel;
-
-	// Simply unpack RGB into RGBA with 255 for Alpha.
-	// FIXME: This will need additional checks when we get around to adding 24/32-bit backend.
-	if (target == TGL_TEXTURE_2D && level == 0 && components == 3 && border == 0 && pixels != NULL) {
-		if (format == TGL_RGB || format == TGL_BGR) {
-			Graphics::PixelBuffer temp(pf, width * height, DisposeAfterUse::NO);
-			Graphics::PixelBuffer pixPtr(sourceFormat, pixels);
-
-			for (int i = 0; i < width * height; ++i) {
-				uint8 r, g, b;
-				pixPtr.getRGBAt(i, r, g, b);
-				temp.setPixelAt(i, 255, r, g, b);
-			}
-			pixels = temp.getRawBuffer();
-			do_free_after_rgb2rgba = true;
-		}
-	} else if ((format != TGL_RGBA &&
-		    format != TGL_RGB &&
-		    format != TGL_BGR &&
-		    format != TGL_BGRA) ||
-		    (type != TGL_UNSIGNED_BYTE &&
-		     type != TGL_UNSIGNED_INT_8_8_8_8_REV)) {
-		error("tglTexImage2D: combination of parameters not handled");
-	}
-
-	pixels1 = new byte[c->_textureSize * c->_textureSize * bytes];
+	Graphics::PixelBuffer internal(
+		pf,
+		c->_textureSize * c->_textureSize,
+		DisposeAfterUse::NO
+	);
 	if (pixels != NULL) {
+		Graphics::PixelBuffer src(sourceFormat, pixels);
 		if (width != c->_textureSize || height != c->_textureSize) {
+			Graphics::PixelBuffer src_conv(pf, width * height, DisposeAfterUse::YES);
+			src_conv.copyBuffer(
+				0,
+				width * height,
+				src
+			);
 			// we use interpolation for better looking result
-			gl_resizeImage(pixels1, c->_textureSize, c->_textureSize, pixels, width, height);
-			width = c->_textureSize;
-			height = c->_textureSize;
+			gl_resizeImage(
+				internal.getRawBuffer(), c->_textureSize, c->_textureSize,
+				src_conv.getRawBuffer(), width, height
+			);
 		} else {
-			memcpy(pixels1, pixels, c->_textureSize * c->_textureSize * bytes);
+			internal.copyBuffer(
+				0,
+				c->_textureSize * c->_textureSize,
+				src
+			);
 		}
-#if defined(SCUMM_BIG_ENDIAN)
-		if (type == TGL_UNSIGNED_INT_8_8_8_8_REV) {
-			for (int y = 0; y < height; y++) {
-				for (int x = 0; x < width; x++) {
-					uint32 offset = (y * width + x) * 4;
-					byte *data = pixels1 + offset;
-					WRITE_BE_UINT32(data, READ_LE_UINT32(data));
-				}
-			}
-		}
-#endif
 	}
 
 	c->current_texture->versionNumber++;
 	im = &c->current_texture->images[level];
-	im->xsize = width;
-	im->ysize = height;
+	im->xsize = c->_textureSize;
+	im->ysize = c->_textureSize;
 	if (im->pixmap)
 		im->pixmap.free();
-	im->pixmap = Graphics::PixelBuffer(pf, pixels1);
-
-	if (do_free_after_rgb2rgba) {
-		// pixels as been assigned to tmp.getRawBuffer() which was created with
-		// DisposeAfterUse::NO, therefore delete[] it
-		delete[] pixels;
-	}
+	im->pixmap = internal;
 }
 
 // TODO: not all tests are done

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -148,6 +148,7 @@ void glInitTextures(GLContext *c) {
 	// textures
 	c->texture_2d_enabled = 0;
 	c->current_texture = find_texture(c, 0);
+	c->texture_internal_pf = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
 }
 
 void glopBindTexture(GLContext *c, GLParam *p) {
@@ -192,36 +193,15 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 	if (border != 0)
 		error("tglTexImage2D: invalid border");
 
-	Graphics::PixelFormat pf;
-	switch (format) {
-		case TGL_RGBA:
-		case TGL_RGB:
-#if defined(SCUMM_BIG_ENDIAN)
-			pf = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#elif defined(SCUMM_LITTLE_ENDIAN)
-			pf = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
-			break;
-		case TGL_BGRA:
-		case TGL_BGR:
-#if defined(SCUMM_BIG_ENDIAN)
-			pf = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 0, 8, 16);
-#elif defined(SCUMM_LITTLE_ENDIAN)
-			pf = Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24);
-#endif
-			break;
-		default:
-			break;
-	}
 	Graphics::PixelBuffer internal(
-		pf,
+		c->texture_internal_pf,
 		c->_textureSize * c->_textureSize,
 		DisposeAfterUse::NO
 	);
 	if (pixels != NULL) {
 		Graphics::PixelBuffer src(formatType2PixelFormat(format, type), pixels);
 		if (width != c->_textureSize || height != c->_textureSize) {
-			Graphics::PixelBuffer src_conv(pf, width * height, DisposeAfterUse::YES);
+			Graphics::PixelBuffer src_conv(c->texture_internal_pf, width * height, DisposeAfterUse::YES);
 			src_conv.copyBuffer(
 				0,
 				width * height,

--- a/graphics/tinygl/zblit.cpp
+++ b/graphics/tinygl/zblit.cpp
@@ -45,18 +45,16 @@ public:
 
 	void loadData(const Graphics::Surface &surface, uint32 colorKey, bool applyColorKey) {
 		const Graphics::PixelFormat textureFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
+		int size = surface.w * surface.h;
 		_surface.create(surface.w, surface.h, textureFormat);
 		Graphics::PixelBuffer buffer(surface.format, (byte *)const_cast<void *>(surface.getPixels()));
 		Graphics::PixelBuffer dataBuffer(textureFormat, (byte *)const_cast<void *>(_surface.getPixels()));
-		dataBuffer.copyBuffer(0, 0, surface.w * surface.h, buffer);
+		dataBuffer.copyBuffer(0, 0, size, buffer);
 		if (applyColorKey) {
-			for (int x = 0;  x < surface.w; x++) {
-				for (int y = 0; y < surface.h; y++) {
-					uint32 pixel = buffer.getValueAt(y * surface.w + x);
-					if (pixel == colorKey) {
-						// Color keyed pixels become transparent white.
-						dataBuffer.setPixelAt(y * surface.w + x, 0, 255, 255, 255); 
-					}
+			for (int x = 0; x < size; x++) {
+				if (buffer.getValueAt(x) == colorKey) {
+					// Color keyed pixels become transparent white.
+					dataBuffer.setPixelAt(x, 0, 255, 255, 255);
 				}
 			}
 		}

--- a/graphics/tinygl/zblit.cpp
+++ b/graphics/tinygl/zblit.cpp
@@ -44,7 +44,7 @@ public:
 	BlitImage() : _isDisposed(false), _version(0), _binaryTransparent(false), _refcount(1) { }
 
 	void loadData(const Graphics::Surface &surface, uint32 colorKey, bool applyColorKey) {
-		const Graphics::PixelFormat textureFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
+		const Graphics::PixelFormat textureFormat = TinyGL::gl_get_context()->texture_internal_pf;
 		int size = surface.w * surface.h;
 		_surface.create(surface.w, surface.h, textureFormat);
 		Graphics::PixelBuffer buffer(surface.format, (byte *)const_cast<void *>(surface.getPixels()));

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -278,6 +278,7 @@ struct GLContext {
 	// textures
 	GLTexture *current_texture;
 	int texture_2d_enabled;
+	Graphics::PixelFormat texture_internal_pf;
 
 	// shared state
 	GLSharedState shared_state;


### PR DESCRIPTION
I decided to rely more on `PixelBuffer` (and hence on `PixelFormat`) for colorspace conversions.

With these changes, MYST3, GRIM and EMI look correct on residualvm runnning in a powerpc chroot (using qemu-user-static for VM-less emulation) both in 16 and 32 bits modes. ~~MYST is not correct yet.~~

Overall, the rules I decided to follow are:
- When reading from disk, use endian-converting read functions.
- Everywhere else, move `PixelBuffer`s around as they contain their own `PixelFormat`, and pixels are nothing without a format.

This means `SCUMM_BIG_ENDIAN` and `SCUMM_LITTLE_ENDIAN` should ideally not be seen in engines. They do appear in tinygl now because multi-byte opengl texture formats (`INT` & `SHORT`) are endian-based.

Special attention points for the review:
- MYST: ~~I only enabled UNSIGNED_SHORT_5_6_5 because I noticed it was disabled for lack of support. I do not know where such textures appears in-game~~ (found: movie subtitles). ~~On big-endian, the menu and intro video look fine, but in-game is mixed up. I did not do much because I am much less familiar with this engine than GRIM, and because MYST is extremely slow in my powerpc chroot for some reason (like 1 fps).~~ (MYST fixed)
- MYST: save games were created with endian-dependent screenshot thumbnail. I consider little-endian to be the only save games ever actually created. This way savegames should be portable. At least I confirm their screenshot is :) .
- GRAPHICS: I apply several changes directly in /graphics folder. Do these apply to scummvm ? Should I submit there first ?
- TINYGL textures: Now creating a texture is likely slower as resizing code became more flexible. But I think this is not an issue as code is much simpler, avoid pixel format issues, and creating textures *should* be a rare-ish operation (am I right on this assumption ?).
- TINYGL: "components" is now an unused local, which causes a warning. I feel this is legitimate: TinyGL should really take this into account. Should I silence this warning (ex: by just doing some checks on the value, as was done before) ?

/cc @bgK for myst change and @raziel- for native PPC testing