### PR TITLE
COMMON: Fix gcc warnings in get_float on big-endian

### DIFF
--- a/common/endian.h
+++ b/common/endian.h
@@ -609,23 +609,7 @@ inline uint32 READ_BE_UINT24(const void *ptr) {
 #endif
 
 // ResidualVM specific:
-#if defined(SCUMM_BIG_ENDIAN)
-
 inline float get_float(const char *data) {
-	const unsigned char *udata = reinterpret_cast<const unsigned char *>(data);
-	unsigned char fdata[4];
-	fdata[0] = udata[3];
-	fdata[1] = udata[2];
-	fdata[2] = udata[1];
-	fdata[3] = udata[0];
-	return *(reinterpret_cast<const float *>(fdata));
+	return (float)FROM_LE_32(*data);
 }
-
-#else
-
-inline float get_float(const char *data) {
-	return *(reinterpret_cast<const float *>(data));
-}
-#endif
-
 #endif


### PR DESCRIPTION
I am not famliar enough with C++ to tell whether reinterpret_cast is required here.

At least, disassembling `Grim::EMIModel::loadMesh` (one of the call sites) on ppc32 binary with `--enable-optimizations`, I see this:
```
     ed8:       48 00 00 01     bl      ed8 <Grim::EMIModel::loadMesh(Common::SeekableReadStream*)+0x108>
                        ed8: R_PPC_REL24        Common::String::operator=(Common::String const&)
     edc:       89 41 00 48     lbz     r10,72(r1)
     ee0:       55 49 c0 3e     rotlwi  r9,r10,24
     ee4:       51 49 42 1e     rlwimi  r9,r10,8,8,15
     ee8:       51 49 46 3e     rlwimi  r9,r10,8,24,31
     eec:       91 21 00 5c     stw     r9,92(r1)
     ef0:       3d 20 43 30     lis     r9,17200
     ef4:       91 21 00 58     stw     r9,88(r1)
     ef8:       81 3f 00 00     lwz     r9,0(r31)
     efc:       80 7e 00 90     lwz     r3,144(r30)
     f00:       80 89 ff dc     lwz     r4,-36(r9)
     f04:       3d 20 00 00     lis     r9,0
                        f06: R_PPC_ADDR16_HA    .rodata._ZN4Math10MatrixTypeILi3ELi1EE14readFromStreamEPN6Common10ReadStreamE.cst8
```

I am PPC-asm illiterate, and what I make out of this is:
- ed8 is `_meshName = nameString;`
- byte-swap is done by 3 instructions (ee0 to ee8), which seems optimal
- eec stores the attribute
- ...and the rest leats to ReadStream, which is likely `_center->readFromStream(data);`