### PR TITLE
ANDROID: Limit mixer output sample rate

### DIFF
--- a/backends/platform/android/org/residualvm/residualvm/ResidualVM.java
+++ b/backends/platform/android/org/residualvm/residualvm/ResidualVM.java
@@ -244,6 +244,9 @@ public abstract class ResidualVM implements SurfaceHolder.Callback, Runnable {
 	final private void initAudio() throws Exception {
 		_sample_rate = AudioTrack.getNativeOutputSampleRate(
 									AudioManager.STREAM_MUSIC);
+		// Maximum supported resampler rate (see LinearRateConverter)
+		if (_sample_rate >= 131072)
+			_sample_rate = 131071;
 		_buffer_size = AudioTrack.getMinBufferSize(_sample_rate,
 									AudioFormat.CHANNEL_CONFIGURATION_STEREO,
 									AudioFormat.ENCODING_PCM_16BIT);


### PR DESCRIPTION
Fixes
  rate effect can only handle rates < 131072
error for example when starting grim intro video.