### PR TITLE
TINYGL: Resample texture during rendering

### DIFF
--- a/engines/myst3/gfx_tinygl_texture.cpp
+++ b/engines/myst3/gfx_tinygl_texture.cpp
@@ -35,7 +35,7 @@ TinyGLTexture::TinyGLTexture(const Graphics::Surface *surface) {
 		sourceFormat = TGL_UNSIGNED_INT_8_8_8_8_REV;
 	} else if (format.bytesPerPixel == 2) {
 		internalFormat = TGL_RGB;
-		sourceFormat = TGL_UNSIGNED_BYTE; // UNSIGNED_SHORT_5_6_5 not provided
+		sourceFormat = TGL_UNSIGNED_SHORT_5_6_5;
 	} else
 		error("Unknown pixel format");
 

--- a/graphics/module.mk
+++ b/graphics/module.mk
@@ -54,6 +54,7 @@ MODULE_OBJS := \
 	tinygl/select.o \
 	tinygl/specbuf.o \
 	tinygl/texture.o \
+	tinygl/texelbuffer.o \
 	tinygl/vertex.o \
 	tinygl/zbuffer.o \
 	tinygl/zline.o \

--- a/graphics/pixelbuffer.cpp
+++ b/graphics/pixelbuffer.cpp
@@ -87,7 +87,17 @@ void PixelBuffer::clear(int length) {
 }
 
 void PixelBuffer::copyBuffer(int thisFrom, int otherFrom, int length, const PixelBuffer &buf) {
-	if (buf._format == _format) {
+	if (buf._format.bytesPerPixel == _format.bytesPerPixel &&
+	    buf._format.rShift == _format.rShift &&
+	    buf._format.gShift == _format.gShift &&
+	    buf._format.bShift == _format.bShift &&
+	    buf._format.rLoss == _format.rLoss &&
+	    buf._format.gLoss == _format.gLoss &&
+	    buf._format.bLoss == _format.bLoss && (
+		_format.aLoss = 8 ||
+		buf._format.aLoss == _format.aLoss
+	    )
+	) {
 		memcpy(_buffer + thisFrom * _format.bytesPerPixel, buf._buffer + otherFrom * _format.bytesPerPixel, length * _format.bytesPerPixel);
 	} else {
 		uint8 r, g, b, a;

--- a/graphics/pixelbuffer.h
+++ b/graphics/pixelbuffer.h
@@ -124,17 +124,22 @@ public:
 	inline void setPixelAt(int pixel, uint32 value) {
 		switch (_format.bytesPerPixel) {
 		case 2:
-			((uint16 *) _buffer)[pixel] = TO_LE_16((uint16) value);
+			((uint16 *) _buffer)[pixel] = value;
 			return;
 		case 3:
 			pixel *= 3;
-			value = TO_LE_32(value);
+#if defined(SCUMM_BIG_ENDIAN)
+			_buffer[pixel + 0] = (value >> 16) & 0xFF;
+			_buffer[pixel + 1] = (value >> 8) & 0xFF;
+			_buffer[pixel + 2] = value & 0xFF;
+#elif defined(SCUMM_LITTLE_ENDIAN)
 			_buffer[pixel + 0] = value & 0xFF;
 			_buffer[pixel + 1] = (value >> 8) & 0xFF;
 			_buffer[pixel + 2] = (value >> 16) & 0xFF;
+#endif
 			return;
 		case 4:
-			((uint32 *) _buffer)[pixel] = TO_LE_32(value);
+			((uint32 *) _buffer)[pixel] = value;
 			return;
 		}
 		error("setPixelAt: Unhandled bytesPerPixel %i", _format.bytesPerPixel);
@@ -202,7 +207,7 @@ public:
 	inline uint32 getValueAt(int i) const {
 		switch (_format.bytesPerPixel) {
 		case 2:
-			return FROM_LE_16(((uint16 *) _buffer)[i]);
+			return ((uint16 *) _buffer)[i];
 		case 3:
 			i *= 3;
 #if defined(SCUMM_BIG_ENDIAN)
@@ -211,7 +216,7 @@ public:
 			return _buffer[i + 0] | (_buffer[i + 1] << 8) | (_buffer[i + 2] << 16);
 #endif
 		case 4:
-			return FROM_LE_32(((uint32 *) _buffer)[i]);
+			return ((uint32 *) _buffer)[i];
 		}
 		error("getValueAt: Unhandled bytesPerPixel %i", _format.bytesPerPixel);
 	}

--- a/graphics/tinygl/clip.cpp
+++ b/graphics/tinygl/clip.cpp
@@ -411,7 +411,7 @@ void gl_draw_triangle_fill(GLContext *c, GLVertex *p0, GLVertex *p1, GLVertex *p
 #ifdef TINYGL_PROFILE
 		count_triangles_textured++;
 #endif
-		c->fb->setTexture(c->current_texture->images[0].pixmap);
+		c->fb->setTexture(c->current_texture->images[0].pixmap, c->texture_wrap_s, c->texture_wrap_t);
 		if (c->current_shade_model == TGL_SMOOTH) {
 			c->fb->fillTriangleTextureMappingPerspectiveSmooth(&p0->zp, &p1->zp, &p2->zp);
 		} else {

--- a/graphics/tinygl/gl.h
+++ b/graphics/tinygl/gl.h
@@ -537,6 +537,8 @@ enum {
 	TGL_NEAREST                     = 0x2600,
 	TGL_REPEAT                      = 0x2901,
 	TGL_CLAMP                       = 0x2900,
+	TGL_CLAMP_TO_EDGE		= 0x812F,
+	TGL_MIRRORED_REPEAT		= 0x8370,
 	TGL_S                           = 0x2000,
 	TGL_T                           = 0x2001,
 	TGL_R                           = 0x2002,

--- a/graphics/tinygl/gl.h
+++ b/graphics/tinygl/gl.h
@@ -589,6 +589,8 @@ enum {
 	TGL_UNSIGNED_SHORT_5_6_5_REV    = 0x8364,
 	TGL_UNSIGNED_INT_8_8_8_8        = 0x8035,
 	TGL_UNSIGNED_INT_8_8_8_8_REV    = 0x8367,
+	TGL_UNSIGNED_SHORT_5_5_5_1      = 0x8034,
+	TGL_UNSIGNED_SHORT_1_5_5_5_REV  = 0x8366,
 
 	// Utility
 	TGL_VENDOR                      = 0x1F00,

--- a/graphics/tinygl/texelbuffer.cpp
+++ b/graphics/tinygl/texelbuffer.cpp
@@ -1,0 +1,225 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "graphics/tinygl/gl.h"
+#include "graphics/tinygl/zgl.h"
+#include "graphics/tinygl/zbuffer.h"
+#include "graphics/tinygl/texelbuffer.h"
+
+namespace Graphics {
+
+#define ZB_POINT_ST_UNIT (1 << ZB_POINT_ST_FRAC_BITS)
+#define ZB_POINT_ST_FRAC_MASK (ZB_POINT_ST_UNIT - 1)
+
+TexelBuffer::TexelBuffer(unsigned int width, unsigned int height, unsigned int textureSize) {
+	assert(width);
+	assert(height);
+	assert(textureSize);
+
+	_width = width;
+	_height = height;
+	_fracTextureUnit = textureSize << ZB_POINT_ST_FRAC_BITS;
+	_fracTextureMask = _fracTextureUnit - 1;
+	_widthRatio = (float) width / textureSize;
+	_heightRatio = (float) height / textureSize;
+}
+
+static inline unsigned int wrap(unsigned int wrap_mode, int coord, unsigned int _fracTextureUnit, unsigned int _fracTextureMask) {
+	switch (wrap_mode) {
+	case TGL_MIRRORED_REPEAT:
+		if (coord & _fracTextureUnit)
+			return _fracTextureMask - (coord & _fracTextureMask);
+		return coord & _fracTextureMask;
+	case TGL_CLAMP_TO_EDGE:
+		if (coord < 0)
+			return 0;
+		if ((unsigned int) coord > _fracTextureMask)
+			return _fracTextureMask;
+		return coord;
+	default:
+		// Fall through
+	case TGL_REPEAT:
+		return coord & _fracTextureMask;
+	}
+}
+
+void TexelBuffer::getARGBAt(
+	unsigned int wrap_s, unsigned int wrap_t,
+	int s, int t,
+	uint8 &a, uint8 &r, uint8 &g, uint8 &b
+) const {
+	unsigned int x, y;
+	x = wrap(wrap_s, s, _fracTextureUnit, _fracTextureMask) * _widthRatio;
+	y = wrap(wrap_t, t, _fracTextureUnit, _fracTextureMask) * _heightRatio;
+	getARGBAt(
+		(x >> ZB_POINT_ST_FRAC_BITS) + (y >> ZB_POINT_ST_FRAC_BITS) * _width,
+		x & ZB_POINT_ST_FRAC_MASK, y & ZB_POINT_ST_FRAC_MASK,
+		a, r, g, b
+	);
+}
+
+// Nearest: store texture in original size.
+NearestTexelBuffer::NearestTexelBuffer(const PixelBuffer &buf, unsigned int width, unsigned int height, unsigned int textureSize) : TexelBuffer(width, height, textureSize) {
+	unsigned int pixel_count = _width * _height;
+	_buf = PixelBuffer(buf.getFormat(), pixel_count, DisposeAfterUse::NO);
+	_buf.copyBuffer(0, pixel_count, buf);
+}
+
+NearestTexelBuffer::~NearestTexelBuffer() {
+	_buf.free();
+}
+
+void NearestTexelBuffer::getARGBAt(
+	unsigned int pixel,
+	unsigned int, unsigned int,
+	uint8 &a, uint8 &r, uint8 &g, uint8 &b
+) const {
+	_buf.getARGBAt(pixel, a, r, g, b);
+}
+
+// Bilinear: each texture coordinates corresponds to the 4 original image
+// pixels linear interpolation has to work on, so that they are near each
+// other in CPU data cache, and a single actual memory fetch happens. This
+// allows applying linear filtering at render time at a very low performance
+// cost. As we expect to work on small-ish textures (512*512 ?) the 4x memory
+// usage increase should be negligible.
+#define A_OFFSET (0 * 4)
+#define R_OFFSET (1 * 4)
+#define G_OFFSET (2 * 4)
+#define B_OFFSET (3 * 4)
+#define P00_OFFSET 0
+#define P01_OFFSET 1
+#define P10_OFFSET 2
+#define P11_OFFSET 3
+#define PIXEL_PER_TEXEL_SHIFT 2
+
+BilinearTexelBuffer::BilinearTexelBuffer(const PixelBuffer &buf, unsigned int width, unsigned int height, unsigned int textureSize) : TexelBuffer(width, height, textureSize) {
+	unsigned int pixel00_offset = 0, pixel11_offset, pixel01_offset, pixel10_offset;
+	uint8 *texel8;
+	uint32 *texel32;
+
+	texel32 = _texels = new uint32[_width * _height << PIXEL_PER_TEXEL_SHIFT];
+	for (unsigned int y = 0; y < _height; y++) {
+		for (unsigned int x = 0; x < _width; x++) {
+			texel8 = (uint8 *)texel32;
+			pixel11_offset = pixel00_offset + _width + 1;
+			buf.getARGBAt(
+				pixel00_offset,
+				*(texel8 + P00_OFFSET + A_OFFSET),
+				*(texel8 + P00_OFFSET + R_OFFSET),
+				*(texel8 + P00_OFFSET + G_OFFSET),
+				*(texel8 + P00_OFFSET + B_OFFSET)
+			);
+			if ((x + 1) == _width) {
+				pixel11_offset -= 1;
+				pixel01_offset = pixel00_offset;
+			} else
+				pixel01_offset = pixel00_offset + 1;
+			buf.getARGBAt(
+				pixel01_offset,
+				*(texel8 + P01_OFFSET + A_OFFSET),
+				*(texel8 + P01_OFFSET + R_OFFSET),
+				*(texel8 + P01_OFFSET + G_OFFSET),
+				*(texel8 + P01_OFFSET + B_OFFSET)
+			);
+			if ((y + 1) == _height) {
+				pixel11_offset -= _width;
+				pixel10_offset = pixel00_offset;
+			} else
+				pixel10_offset = pixel00_offset + _width;
+			buf.getARGBAt(
+				pixel10_offset,
+				*(texel8 + P10_OFFSET + A_OFFSET),
+				*(texel8 + P10_OFFSET + R_OFFSET),
+				*(texel8 + P10_OFFSET + G_OFFSET),
+				*(texel8 + P10_OFFSET + B_OFFSET)
+			);
+			buf.getARGBAt(
+				pixel11_offset,
+				*(texel8 + P11_OFFSET + A_OFFSET),
+				*(texel8 + P11_OFFSET + R_OFFSET),
+				*(texel8 + P11_OFFSET + G_OFFSET),
+				*(texel8 + P11_OFFSET + B_OFFSET)
+			);
+			texel32 += 1 << PIXEL_PER_TEXEL_SHIFT;
+			pixel00_offset++;
+		}
+	}
+}
+
+BilinearTexelBuffer::~BilinearTexelBuffer() {
+	delete[] _texels;
+}
+
+static inline int interpolate(int v00, int v01, int v10, int xf, int yf) {
+	return v00 + (((v01 - v00) * xf + (v10 - v00) * yf) >> ZB_POINT_ST_FRAC_BITS);
+}
+
+void BilinearTexelBuffer::getARGBAt(
+	unsigned int pixel,
+	unsigned int ds, unsigned int dt,
+	uint8 &a, uint8 &r, uint8 &g, uint8 &b
+) const {
+	unsigned int p00_offset, p01_offset, p10_offset;
+	uint8 *texel = (uint8 *)(_texels + (pixel << PIXEL_PER_TEXEL_SHIFT));
+	if ((ds + dt) > ZB_POINT_ST_UNIT) {
+		p00_offset = P11_OFFSET;
+		p10_offset = P01_OFFSET;
+		p01_offset = P10_OFFSET;
+		ds = ZB_POINT_ST_UNIT - ds;
+		dt = ZB_POINT_ST_UNIT - dt;
+	} else {
+		p00_offset = P00_OFFSET;
+		p10_offset = P10_OFFSET;
+		p01_offset = P01_OFFSET;
+	}
+	a = interpolate(
+		*(texel + p00_offset + A_OFFSET),
+		*(texel + p01_offset + A_OFFSET),
+		*(texel + p10_offset + A_OFFSET),
+		ds,
+		dt
+	);
+	r = interpolate(
+		*(texel + p00_offset + R_OFFSET),
+		*(texel + p01_offset + R_OFFSET),
+		*(texel + p10_offset + R_OFFSET),
+		ds,
+		dt
+	);
+	g = interpolate(
+		*(texel + p00_offset + G_OFFSET),
+		*(texel + p01_offset + G_OFFSET),
+		*(texel + p10_offset + G_OFFSET),
+		ds,
+		dt
+	);
+	b = interpolate(
+		*(texel + p00_offset + B_OFFSET),
+		*(texel + p01_offset + B_OFFSET),
+		*(texel + p10_offset + B_OFFSET),
+		ds,
+		dt
+	);
+}
+
+}

--- a/graphics/tinygl/texelbuffer.h
+++ b/graphics/tinygl/texelbuffer.h
@@ -1,0 +1,85 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef GRAPHICS_TEXELBUFFER_H
+#define GRAPHICS_TEXELBUFFER_H
+
+#include "graphics/pixelbuffer.h"
+
+namespace Graphics {
+
+class TexelBuffer {
+public:
+	TexelBuffer(unsigned int width, unsigned int height, unsigned int textureSize);
+	virtual ~TexelBuffer() {};
+
+	void getARGBAt(
+		unsigned int wrap_s, unsigned int wrap_t,
+		int s, int t,
+		uint8 &a, uint8 &r, uint8 &g, uint8 &b
+	) const;
+
+protected:
+	virtual void getARGBAt(
+		unsigned int pixel,
+		unsigned int ds, unsigned int dt,
+		uint8 &a, uint8 &r, uint8 &g, uint8 &b
+	) const = 0;
+	unsigned int _width, _height, _fracTextureUnit, _fracTextureMask;
+	float _widthRatio, _heightRatio;
+};
+
+class NearestTexelBuffer : public TexelBuffer {
+public:
+	NearestTexelBuffer(const PixelBuffer &buf, unsigned int width, unsigned int height, unsigned int textureSize);
+	~NearestTexelBuffer();
+
+protected:
+	void getARGBAt(
+		unsigned int pixel,
+		unsigned int, unsigned int,
+		uint8 &a, uint8 &r, uint8 &g, uint8 &b
+	) const override;
+
+private:
+	PixelBuffer _buf;
+};
+
+class BilinearTexelBuffer : public TexelBuffer {
+public:
+	BilinearTexelBuffer(const PixelBuffer &buf, unsigned int width, unsigned int height, unsigned int textureSize);
+	~BilinearTexelBuffer();
+
+protected:
+	void getARGBAt(
+		unsigned int pixel,
+		unsigned int ds, unsigned int dt,
+		uint8 &a, uint8 &r, uint8 &g, uint8 &b
+	) const override;
+
+private:
+	uint32 *_texels;
+};
+
+}
+
+#endif

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -32,6 +32,47 @@
 
 #include "graphics/tinygl/zgl.h"
 
+struct tglColorAssociation {
+	Graphics::PixelFormat pf;
+	TGLuint format;
+	TGLuint type;
+};
+
+static const struct tglColorAssociation colorAssociationList[] = {
+/*
+ * TGL_UNSIGNED_BYTE before other variants to provide OpenGLES-friendly formats
+ * when this table is used to look these up.
+ * Note: this does not matter at all for TinyGL, but this is to be consistent
+ * with future OpenGL equivalent for this code.
+ */
+// TODO: remove pixel endianness conversions from tinygl callers and enable
+//#if defined(SCUMM_LITTLE_ENDIAN)
+#if 1
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), TGL_RGBA, TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24), TGL_BGRA, TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),  TGL_RGB,  TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),  TGL_BGR,  TGL_UNSIGNED_BYTE},
+#else
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), TGL_RGBA, TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0), TGL_BGRA, TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),  TGL_RGB,  TGL_UNSIGNED_BYTE},
+	{Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),  TGL_BGR,  TGL_UNSIGNED_BYTE},
+#endif
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), TGL_RGBA, TGL_UNSIGNED_INT_8_8_8_8_REV},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), TGL_RGBA, TGL_UNSIGNED_INT_8_8_8_8},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24), TGL_BGRA, TGL_UNSIGNED_INT_8_8_8_8_REV},
+	{Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0), TGL_BGRA, TGL_UNSIGNED_INT_8_8_8_8},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15), TGL_RGBA, TGL_UNSIGNED_SHORT_1_5_5_5_REV},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0),  TGL_RGBA, TGL_UNSIGNED_SHORT_5_5_5_1},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15), TGL_BGRA, TGL_UNSIGNED_SHORT_1_5_5_5_REV},
+	{Graphics::PixelFormat(2, 5, 5, 5, 1, 1, 6, 11, 0),  TGL_BGRA, TGL_UNSIGNED_SHORT_5_5_5_1},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0),  TGL_RGB,  TGL_UNSIGNED_SHORT_5_6_5_REV},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),  TGL_BGR,  TGL_UNSIGNED_SHORT_5_6_5},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),  TGL_BGR,  TGL_UNSIGNED_SHORT_5_6_5_REV},
+	{Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0),  TGL_RGB,  TGL_UNSIGNED_SHORT_5_6_5}
+};
+#define COLOR_ASSOCIATION_LIST_LENGTH (sizeof(colorAssociationList) / sizeof(*colorAssociationList))
+
 namespace TinyGL {
 
 static GLTexture *find_texture(GLContext *c, unsigned int h) {
@@ -112,6 +153,15 @@ void glopBindTexture(GLContext *c, GLParam *p) {
 	c->current_texture = t;
 }
 
+static inline const Graphics::PixelFormat formatType2PixelFormat(TGLuint format,  TGLuint type) {
+	for (unsigned int i = 0; i < COLOR_ASSOCIATION_LIST_LENGTH; i++) {
+		if (colorAssociationList[i].format == format &&
+		    colorAssociationList[i].type == type)
+			return colorAssociationList[i].pf;
+	}
+	error("TinyGL texture: format 0x%04x and type 0x%04x combination not supported", format, type);
+}
+
 void glopTexImage2D(GLContext *c, GLParam *p) {
 	int target = p[1].i;
 	int level = p[2].i;
@@ -131,23 +181,6 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 		error("tglTexImage2D: invalid level");
 	if (border != 0)
 		error("tglTexImage2D: invalid border");
-	Graphics::PixelFormat sourceFormat;
-	switch (format) {
-		case TGL_RGBA:
-			sourceFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-			break;
-		case TGL_RGB:
-			sourceFormat = Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
-			break;
-		case TGL_BGRA:
-			sourceFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24);
-			break;
-		case TGL_BGR:
-			sourceFormat = Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
-			break;
-		default:
-			error("tglTexImage2D: Pixel format not handled.");
-	}
 
 	Graphics::PixelFormat pf;
 	switch (format) {
@@ -176,7 +209,7 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 		DisposeAfterUse::NO
 	);
 	if (pixels != NULL) {
-		Graphics::PixelBuffer src(sourceFormat, pixels);
+		Graphics::PixelBuffer src(formatType2PixelFormat(format, type), pixels);
 		if (width != c->_textureSize || height != c->_textureSize) {
 			Graphics::PixelBuffer src_conv(pf, width * height, DisposeAfterUse::YES);
 			src_conv.copyBuffer(

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -211,16 +211,10 @@ void glopTexImage2D(GLContext *c, GLParam *p) {
 	if (pixels != NULL) {
 		Graphics::PixelBuffer src(formatType2PixelFormat(format, type), pixels);
 		if (width != c->_textureSize || height != c->_textureSize) {
-			Graphics::PixelBuffer src_conv(pf, width * height, DisposeAfterUse::YES);
-			src_conv.copyBuffer(
-				0,
-				width * height,
-				src
-			);
 			// we use interpolation for better looking result
 			gl_resizeImage(
-				internal.getRawBuffer(), c->_textureSize, c->_textureSize,
-				src_conv.getRawBuffer(), width, height
+				internal, c->_textureSize, c->_textureSize,
+				src, width, height
 			);
 		} else {
 			internal.copyBuffer(

--- a/graphics/tinygl/zbuffer.cpp
+++ b/graphics/tinygl/zbuffer.cpp
@@ -306,8 +306,10 @@ void FrameBuffer::clearOffscreenBuffer(Buffer *buf) {
 	buf->used = false;
 }
 
-void FrameBuffer::setTexture(const Graphics::PixelBuffer &texture) {
+void FrameBuffer::setTexture(const Graphics::TexelBuffer *texture, unsigned int wraps, unsigned int wrapt) {
 	current_texture = texture;
+	wrapS = wraps;
+	wrapT = wrapt;
 }
 
 } // end of namespace TinyGL

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -30,6 +30,7 @@
 #define GRAPHICS_TINYGL_ZBUFFER_H_
 
 #include "graphics/pixelbuffer.h"
+#include "graphics/tinygl/texelbuffer.h"
 #include "graphics/tinygl/gl.h"
 #include "common/rect.h"
 
@@ -423,7 +424,7 @@ struct FrameBuffer {
 	void blitOffscreenBuffer(Buffer *buffer);
 	void selectOffscreenBuffer(Buffer *buffer);
 	void clearOffscreenBuffer(Buffer *buffer);
-	void setTexture(const Graphics::PixelBuffer &texture);
+	void setTexture(const Graphics::TexelBuffer *texture, unsigned int wraps, unsigned int wrapt);
 
 	template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, int kDrawLogic, bool kDepthWrite, bool enableAlphaTest, bool kEnableScissor, bool enableBlending>
 	void fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2);
@@ -481,9 +482,10 @@ struct FrameBuffer {
 
 	unsigned char *dctable;
 	int *ctable;
-	Graphics::PixelBuffer current_texture;
+	const Graphics::TexelBuffer *current_texture;
 	int _textureSize;
 	int _textureSizeMask;
+	unsigned int wrapS, wrapT;
 
 	FORCEINLINE bool isBlendingEnabled() const { return _blendingEnabled; }
 	FORCEINLINE void getBlendingFactors(int &sourceFactor, int &destinationFactor) const { sourceFactor = _sourceBlendingFactor; destinationFactor = _destinationBlendingFactor; }

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -453,6 +453,8 @@ RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() 
 	state.shadowMode = c->shadow_mode;
 	state.texture2DEnabled = c->texture_2d_enabled;
 	state.texture = c->current_texture;
+	state.wrapS = c->texture_wrap_s;
+	state.wrapT = c->texture_wrap_t;
 	state.shadowMaskBuf = c->fb->shadow_mask_buf;
 	state.depthFunction = c->fb->getDepthFunc();
 	state.depthWrite = c->fb->getDepthWrite();
@@ -489,6 +491,8 @@ void RasterizationDrawCall::applyState(const RasterizationDrawCall::Rasterizatio
 	c->shadow_mode = state.shadowMode;
 	c->texture_2d_enabled = state.texture2DEnabled;
 	c->current_texture = state.texture; 
+	c->texture_wrap_s = state.wrapS;
+	c->texture_wrap_t = state.wrapT;
 	c->fb->shadow_mask_buf = state.shadowMaskBuf;
 
 	memcpy(c->viewport.scale._v, state.viewportScaling, sizeof(c->viewport.scale._v));

--- a/graphics/tinygl/zdirtyrect.h
+++ b/graphics/tinygl/zdirtyrect.h
@@ -132,6 +132,7 @@ private:
 		bool alphaTest;
 		int alphaFunc, alphaRefValue;
 		TinyGL::GLTexture *texture;
+		unsigned int wrapS, wrapT;
 		unsigned char *shadowMaskBuf;
 
 		bool operator==(const RasterizationState &other) const;

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -39,6 +39,7 @@
 #include "graphics/tinygl/zmath.h"
 #include "graphics/tinygl/zblit.h"
 #include "graphics/tinygl/zdirtyrect.h"
+#include "graphics/tinygl/texelbuffer.h"
 
 namespace TinyGL {
 
@@ -173,7 +174,7 @@ struct GLVertex {
 };
 
 struct GLImage {
-	Graphics::PixelBuffer pixmap;
+	Graphics::TexelBuffer *pixmap;
 	int xsize, ysize;
 };
 
@@ -278,6 +279,10 @@ struct GLContext {
 	// textures
 	GLTexture *current_texture;
 	int texture_2d_enabled;
+	int texture_mag_filter;
+	int texture_min_filter;
+	unsigned int texture_wrap_s;
+	unsigned int texture_wrap_t;
 
 	// shared state
 	GLSharedState shared_state;

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -422,10 +422,10 @@ void free_texture(GLContext *c, int h);
 void free_texture(GLContext *c, GLTexture *t);
 
 // image_util.c
-void gl_resizeImage(unsigned char *dest, int xsize_dest, int ysize_dest,
-					unsigned char *src, int xsize_src, int ysize_src);
-void gl_resizeImageNoInterpolate(unsigned char *dest, int xsize_dest, int ysize_dest,
-								 unsigned char *src, int xsize_src, int ysize_src);
+void gl_resizeImage(Graphics::PixelBuffer &dest, int xsize_dest, int ysize_dest,
+		    const Graphics::PixelBuffer &src, int xsize_src, int ysize_src);
+void gl_resizeImageNoInterpolate(Graphics::PixelBuffer &dest, int xsize_dest, int ysize_dest,
+				 const Graphics::PixelBuffer &src, int xsize_src, int ysize_src);
 
 void tglIssueDrawCall(Graphics::DrawCall *drawCall);
 


### PR DESCRIPTION
~~Note: based on #1339.~~

Before this change, TINYGL resizes textures when they are uploaded to GL (`tglTexImage2D`) to the init-configured internal square texture size, and applies bilinear filtering at that time.

This has 2 effects:
- memory: most textures are smaller than (currently) requested internal texture size, so they use more memory once sent to TinyGL
- rendering: interpolation happens browsing original pixel grid by walking the resized pixel grid with borders adjusted to line up with the original image. Resulting texture will show re-sampling artifacts when rendered if it is not aligned to screen (...which is mostly visible for high-resolution original images)

Moving bilinear filtering to render time has potentially a large cost: it needs to read 3 texels for each rendered pixel, and reading texture already requires expensive fetches from RAM.

But this cost can be significantly reduced by relying on CPU data cache: each fetch from main memory actually loads several adjacent words in CPU cache, so accessing nearby bytes is cheap.

This is achieved by repacking the original texture, bringing the 4 possible involved texels (of which 3 will be used, choosing which depending on sampling offset) close to each other.

This again has an obvious cost: each texture takes 4 times its original size. But this cost is offset by being working on texture in its original size, saving lots of ram on smaller textures and should allow increasing internal texture resolution with less negative effects than before (but I did not try this much).

# Functional effect

This change allows implementing simply:

- `TGL_NEAREST` texture filtering (although texture sampler is still chosen at texture upload time, not at render time - I did not check what OpenGL is doing, but at least as of current MYST3 and GRIM engines this assumption is correct)
- `TGL_TEXTURE_WRAP_`{`S`,`T`}

# Visual effect
- ship textures in EMI (very visible in first puzzle, more subtle in shipyard)
- myst becomes a lot sharper, and I feel runs even much smoother. As it is uploading textures very often, old TinyGL code was resampling large (640x640) textures to 512x512 a lot, and probably often in vain as their polygon could be fully off-screen.

# Memory usage effect

[EDIT] Measures updated after fixing a per-`tglTexImage2D`-call memory leak (mostly affecting MYST3)

Game | Set | Before | After, `TGL_LINEAR` | After, `TGL_NEAREST`
---- | --- | ------ | ----------------- | ------------------
GRIM | cn | 78 MB | 67 MB | 58 MB
EMI | first puzzle | 91 MB | 91 MB | 81 MB
MYST3 | irrelevant ? | 82 MB | 103 MB | 71 MB

GRIM is an easy win, many textures are smaller than 256x256, so they were made needlessly large before.
EMI first puzzle is a tough one, as the moving ship in the background is a large texture.
Lastly, MYST is full of high-rez textures, larger than its requested 512x512 internal texture size, so it is a loss. But I believe it is a reasonable one compared to the visual and performance improvement.

# Performance effect

Despite the texel repacking trick, this has a mild negative impact on FPS, especially when disabling dirtyrects.

Here are my measurments, with `--engine-speed=0 --no-dirtyrects`

Game | Set | Before | After
---- | --- | ------ | -----
GRIM | mo | 540 fps | 510 fps
GRIM | cn | 185 fps | 160 fps
GRIM | bi | 165 fps | 150 fps
EMI | first puzzle | 110 fps | 78 fps

I believe this performance decrease to be reasonable. But I'm biased :) .

[EDIT] Not based on #1339 anymore