### PR TITLE
TINYGL: Fix color clipping

### DIFF
--- a/graphics/tinygl/api.cpp
+++ b/graphics/tinygl/api.cpp
@@ -81,11 +81,6 @@ void tglColor4f(float r, float g, float b, float a) {
 	p[2].f = g;
 	p[3].f = b;
 	p[4].f = a;
-	// direct convertion to integer to go faster if no shading
-	p[5].ui = (unsigned int)(r * ZB_POINT_RED_MAX);
-	p[6].ui = (unsigned int)(g * ZB_POINT_GREEN_MAX);
-	p[7].ui = (unsigned int)(b * ZB_POINT_BLUE_MAX);
-	p[8].ui = (unsigned int)(a * ZB_POINT_ALPHA_MAX);
 	gl_add_op(p);
 }
 

--- a/graphics/tinygl/clip.cpp
+++ b/graphics/tinygl/clip.cpp
@@ -49,18 +49,10 @@ void gl_transform_to_viewport(GLContext *c, GLVertex *v) {
 	v->zp.y = (int)(v->pc.Y * winv * c->viewport.scale.Y + c->viewport.trans.Y);
 	v->zp.z = (int)(v->pc.Z * winv * c->viewport.scale.Z + c->viewport.trans.Z);
 	// color
-	if (c->lighting_enabled) {
-		v->zp.r = (int)(v->color.X * ZB_POINT_RED_MAX);
-		v->zp.g = (int)(v->color.Y * ZB_POINT_GREEN_MAX);
-		v->zp.b = (int)(v->color.Z * ZB_POINT_BLUE_MAX);
-		v->zp.a = (int)(v->color.W * ZB_POINT_ALPHA_MAX);
-	} else {
-		// no need to convert to integer if no lighting : take current color
-		v->zp.r = c->longcurrent_color[0];
-		v->zp.g = c->longcurrent_color[1];
-		v->zp.b = c->longcurrent_color[2];
-		v->zp.a = c->longcurrent_color[3];
-	}
+	v->zp.r = (int)(v->color.X * ZB_POINT_RED_MAX);
+	v->zp.g = (int)(v->color.Y * ZB_POINT_GREEN_MAX);
+	v->zp.b = (int)(v->color.Z * ZB_POINT_BLUE_MAX);
+	v->zp.a = (int)(v->color.W * ZB_POINT_ALPHA_MAX);
 
 	// texture
 	if (c->texture_2d_enabled) {

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -149,10 +149,6 @@ void glInit(void *zbuffer1, int textureSize) {
 
 	// default state
 	c->current_color = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
-	c->longcurrent_color[0] = 65535;
-	c->longcurrent_color[1] = 65535;
-	c->longcurrent_color[2] = 65535;
-	c->longcurrent_color[3] = 65535;
 
 	c->current_normal = Vector4(1.0f, 0.0f, 0.0f, 0.0f);
 

--- a/graphics/tinygl/vertex.cpp
+++ b/graphics/tinygl/vertex.cpp
@@ -54,10 +54,6 @@ void glopColor(GLContext *c, GLParam *p) {
 	c->current_color.Y = p[2].f;
 	c->current_color.Z = p[3].f;
 	c->current_color.W = p[4].f;
-	c->longcurrent_color[0] = p[5].ui;
-	c->longcurrent_color[1] = p[6].ui;
-	c->longcurrent_color[2] = p[7].ui;
-	c->longcurrent_color[3] = p[8].ui;
 
 	if (c->color_material_enabled) {
 		GLParam q[7];

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -463,7 +463,6 @@ RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() 
 
 	memcpy(state.viewportScaling, c->viewport.scale._v, sizeof(c->viewport.scale._v));
 	memcpy(state.viewportTranslation, c->viewport.trans._v, sizeof(c->viewport.trans._v));
-	memcpy(state.currentColor, c->longcurrent_color, sizeof(c->longcurrent_color));
 
 	return state;
 }
@@ -494,7 +493,6 @@ void RasterizationDrawCall::applyState(const RasterizationDrawCall::Rasterizatio
 
 	memcpy(c->viewport.scale._v, state.viewportScaling, sizeof(c->viewport.scale._v));
 	memcpy(c->viewport.trans._v, state.viewportTranslation, sizeof(c->viewport.trans._v));
-	memcpy(c->longcurrent_color, state.currentColor, sizeof(c->longcurrent_color));
 }
 
 void RasterizationDrawCall::execute(const Common::Rect &clippingRectangle, bool restoreState) const {
@@ -676,10 +674,6 @@ bool RasterizationDrawCall::RasterizationState::operator==(const RasterizationSt
 			alphaRefValue == other.alphaRefValue &&
 			texture == other.texture &&
 			shadowMaskBuf == other.shadowMaskBuf &&
-			currentColor[0] == other.currentColor[0] &&
-			currentColor[1] == other.currentColor[1] &&
-			currentColor[2] == other.currentColor[2] &&
-			currentColor[3] == other.currentColor[3] &&
 			viewportTranslation[0] == other.viewportTranslation[0] &&
 			viewportTranslation[1] == other.viewportTranslation[1] &&
 			viewportTranslation[2] == other.viewportTranslation[2] &&

--- a/graphics/tinygl/zdirtyrect.h
+++ b/graphics/tinygl/zdirtyrect.h
@@ -127,7 +127,6 @@ private:
 		int sfactor, dfactor;
 		int textureVersion;
 		int depthTestEnabled;
-		unsigned int currentColor[4];
 		float viewportTranslation[3];
 		float viewportScaling[3];
 		bool alphaTest;

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -331,7 +331,6 @@ struct GLContext {
 
 	// current vertex state
 	Vector4 current_color;
-	unsigned int longcurrent_color[4]; // precomputed integer color
 	Vector4 current_normal;
 	Vector4 current_tex_coord;
 	int current_edge_flag;


### PR DESCRIPTION
Is it the right decision to drop this optimisation ?

My arguments in favour are:
- I believe its effect should not be very visible on performance (textures are tinygl hotspot, and untextured, unlit scenes should be rare and fast enough already).
- Making GLVertex larger will increase use of the linear allocator used to efficiently store them in memory.