### PR TITLE
SDL: Only recreate SDL2 window when necessary

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -155,11 +155,7 @@ void OpenGLSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, bool
 	initializeOpenGLContext();
 	_surfaceRenderer = OpenGL::createBestSurfaceRenderer();
 
-#ifdef SCUMM_BIG_ENDIAN
-	_overlayFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	_overlayFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	_overlayFormat = OpenGL::Texture::getRGBAPixelFormat();
 	_overlayScreen = new OpenGL::TiledSurface(effectiveWidth, effectiveHeight, _overlayFormat);
 
 	_overlayWidth = effectiveWidth;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -254,7 +254,7 @@ bool OpenGLSdlGraphicsManager::createScreen(uint effectiveWidth, uint effectiveH
 		if (_fullscreen)
 			sdlflags |= SDL_WINDOW_FULLSCREEN;
 
-		if (_window->createWindow(effectiveWidth, effectiveHeight, sdlflags)) {
+		if (_window->createOrUpdateWindow(effectiveWidth, effectiveHeight, sdlflags)) {
 			_glContext = SDL_GL_CreateContext(_window->getSDLWindow());
 			if (_glContext) {
 				break;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -57,6 +57,9 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(SdlEventSource *sdlEventSourc
 
 OpenGLSdlGraphicsManager::~OpenGLSdlGraphicsManager() {
 	closeOverlay();
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	deinitializeRenderer();
+#endif
 }
 
 bool OpenGLSdlGraphicsManager::hasFeature(OSystem::Feature f) {
@@ -97,6 +100,12 @@ void OpenGLSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) 
 void OpenGLSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, bool fullscreen, bool accel3d) {
 	assert(accel3d);
 	closeOverlay();
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	// Clear the GL context when going from / to the launcher
+	SDL_GL_DeleteContext(_glContext);
+	_glContext = nullptr;
+#endif
 
 	_engineRequestedWidth = gameWidth;
 	_engineRequestedHeight = gameHeight;
@@ -520,10 +529,6 @@ void OpenGLSdlGraphicsManager::closeOverlay() {
 	_frameBuffer = nullptr;
 
 	OpenGL::Context::destroy();
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	deinitializeRenderer();
-#endif
 }
 
 void OpenGLSdlGraphicsManager::warpMouse(int x, int y) {

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -63,6 +63,9 @@ bool OpenGLSdlGraphicsManager::hasFeature(OSystem::Feature f) {
 	return
 		(f == OSystem::kFeatureFullscreenMode) ||
 		(f == OSystem::kFeatureOpenGL) ||
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
+#endif
 		(f == OSystem::kFeatureVSync) ||
 		(f == OSystem::kFeatureAspectRatioCorrection) ||
 		(f == OSystem::kFeatureOverlaySupportsAlpha && _overlayFormat.aBits() > 3);
@@ -77,46 +80,35 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) {
 	}
 }
 
+void OpenGLSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
+	switch (f) {
+		case OSystem::kFeatureFullscreenMode:
+			if (_fullscreen != enable) {
+				_fullscreen = enable;
+				createOrUpdateScreen();
+			}
+			break;
+		default:
+			ResVmSdlGraphicsManager::setFeatureState(f, enable);
+			break;
+	}
+}
+
 void OpenGLSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, bool fullscreen, bool accel3d) {
 	assert(accel3d);
 	closeOverlay();
 
+	_engineRequestedWidth = gameWidth;
+	_engineRequestedHeight = gameHeight;
 	_antialiasing = ConfMan.getInt("antialiasing");
 	_fullscreen = fullscreen;
 	_lockAspectRatio = ConfMan.getBool("aspect_ratio");
 	_vsync = ConfMan.getBool("vsync");
 
-	bool engineSupportsArbitraryResolutions = g_engine && g_engine->hasFeature(Engine::kSupportsArbitraryResolutions);
-
-	// Select how the game screen is going to be drawn
-	GameRenderTarget gameRenderTarget = selectGameRenderTarget(_fullscreen, true, engineSupportsArbitraryResolutions,
-	                                                           _capabilities.openGLFrameBuffer, _lockAspectRatio);
-
-	// Choose the effective window size or fullscreen mode
-	uint effectiveWidth;
-	uint effectiveHeight;
-	if (_fullscreen && canUsePreferredResolution(gameRenderTarget, engineSupportsArbitraryResolutions)) {
-		Common::Rect fullscreenResolution = getPreferredFullscreenResolution();
-		effectiveWidth = fullscreenResolution.width();
-		effectiveHeight = fullscreenResolution.height();
-	} else {
-		effectiveWidth = gameWidth;
-		effectiveHeight = gameHeight;
-	}
-
-	// Compute the rectangle where to draw the game inside the effective screen
-	_gameRect = computeGameRect(gameRenderTarget, gameWidth, gameHeight, effectiveWidth, effectiveHeight);
-
-	if (!createScreen(effectiveWidth, effectiveHeight, gameRenderTarget)) {
-		warning("Error: %s", SDL_GetError());
-		g_system->quit();
-	}
+	createOrUpdateScreen();
 
 	int glflag;
 	const GLubyte *str;
-
-	// apply atribute again for sure based on SDL docs
-	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
 	str = glGetString(GL_VENDOR);
 	debug("INFO: OpenGL Vendor: %s", str);
@@ -138,18 +130,47 @@ void OpenGLSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, bool
 	debug("INFO: OpenGL Double Buffer: %d", glflag);
 	SDL_GL_GetAttribute(SDL_GL_STENCIL_SIZE, &glflag);
 	debug("INFO: OpenGL Stencil buffer bits: %d", glflag);
-
 #ifdef USE_GLEW
 	debug("INFO: GLEW Version: %s", glewGetString(GLEW_VERSION));
+#endif
+#ifdef USE_OPENGL_SHADERS
+	debug("INFO: GLSL version: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
+#endif
+}
+
+void OpenGLSdlGraphicsManager::createOrUpdateScreen() {
+	bool engineSupportsArbitraryResolutions = g_engine && g_engine->hasFeature(Engine::kSupportsArbitraryResolutions);
+
+	// Select how the game screen is going to be drawn
+	GameRenderTarget gameRenderTarget = selectGameRenderTarget(_fullscreen, true, engineSupportsArbitraryResolutions,
+	                                                           _capabilities.openGLFrameBuffer, _lockAspectRatio);
+
+	// Choose the effective window size or fullscreen mode
+	uint effectiveWidth;
+	uint effectiveHeight;
+	if (_fullscreen && canUsePreferredResolution(gameRenderTarget, engineSupportsArbitraryResolutions)) {
+		Common::Rect fullscreenResolution = getPreferredFullscreenResolution();
+		effectiveWidth = fullscreenResolution.width();
+		effectiveHeight = fullscreenResolution.height();
+	} else {
+		effectiveWidth = _engineRequestedWidth;
+		effectiveHeight = _engineRequestedHeight;
+	}
+
+	// Compute the rectangle where to draw the game inside the effective screen
+	_gameRect = computeGameRect(gameRenderTarget, _engineRequestedWidth, _engineRequestedHeight, effectiveWidth, effectiveHeight);
+
+	if (!createOrUpdateGLContext(effectiveWidth, effectiveHeight, gameRenderTarget)) {
+		warning("Error: %s", SDL_GetError());
+		g_system->quit();
+	}
+
+#ifdef USE_GLEW
 	GLenum err = glewInit();
 	if (err != GLEW_OK) {
 		warning("Error: %s", glewGetErrorString(err));
 		g_system->quit();
 	}
-#endif
-
-#ifdef USE_OPENGL_SHADERS
-	debug("INFO: GLSL version: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
 #endif
 
 	initializeOpenGLContext();
@@ -167,7 +188,7 @@ void OpenGLSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, bool
 #if !defined(AMIGAOS)
 	if (gameRenderTarget == kFramebuffer) {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		_frameBuffer = createFramebuffer(gameWidth, gameHeight);
+		_frameBuffer = createFramebuffer(_engineRequestedWidth, _engineRequestedHeight);
 		_frameBuffer->attach();
 	}
 #endif
@@ -205,8 +226,8 @@ OpenGLSdlGraphicsManager::OpenGLPixelFormat::OpenGLPixelFormat(uint screenBytesP
 
 }
 
-bool OpenGLSdlGraphicsManager::createScreen(uint effectiveWidth, uint effectiveHeight,
-                                            GameRenderTarget gameRenderTarget) {
+bool OpenGLSdlGraphicsManager::createOrUpdateGLContext(uint effectiveWidth, uint effectiveHeight,
+                                                       GameRenderTarget gameRenderTarget) {
 	// Build a list of OpenGL pixel formats usable by ResidualVM
 	Common::Array<OpenGLPixelFormat> pixelFormats;
 	if (_antialiasing > 0 && gameRenderTarget == kScreen) {
@@ -251,12 +272,31 @@ bool OpenGLSdlGraphicsManager::createScreen(uint effectiveWidth, uint effectiveH
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		uint32 sdlflags = SDL_WINDOW_OPENGL;
-		if (_fullscreen)
+		if (_fullscreen) {
+			// On Linux/X11, when toggling to fullscreen, the window manager saves
+			// the window size to be able to restore it when going back to windowed mode.
+			// If the user configured ResidualVM to start in fullscreen mode, we first
+			// create a window and then toggle it to fullscreen to give the window manager
+			// a chance to save the window size. That way if the user switches back
+			// to windowed mode, the window manager has a window size to apply instead
+			// of leaving the window at the fullscreen resolution size.
+			if (!_window->getSDLWindow()) {
+				_window->createOrUpdateWindow(effectiveWidth, effectiveHeight, sdlflags);
+			}
+
 			sdlflags |= SDL_WINDOW_FULLSCREEN;
+		}
 
 		if (_window->createOrUpdateWindow(effectiveWidth, effectiveHeight, sdlflags)) {
-			_glContext = SDL_GL_CreateContext(_window->getSDLWindow());
+			// Get the current GL context from SDL in case the previous one
+			// was destroyed because the window was recreated.
+			_glContext = SDL_GL_GetCurrentContext();
+			if (!_glContext) {
+				_glContext = SDL_GL_CreateContext(_window->getSDLWindow());
+			}
+
 			if (_glContext) {
+				assert(SDL_GL_GetCurrentWindow() == _window->getSDLWindow());
 				break;
 			}
 		}
@@ -520,8 +560,6 @@ void OpenGLSdlGraphicsManager::transformMouseCoordinates(Common::Point &point) {
 void OpenGLSdlGraphicsManager::deinitializeRenderer() {
 	SDL_GL_DeleteContext(_glContext);
 	_glContext = nullptr;
-
-	_window->destroyWindow();
 }
 #endif // SDL_VERSION_ATLEAST(2, 0, 0)
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -45,6 +45,7 @@ public:
 	// GraphicsManager API - Features
 	virtual bool hasFeature(OSystem::Feature f) override;
 	virtual bool getFeatureState(OSystem::Feature f) override;
+	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 
 	// GraphicsManager API - Graphics mode
 	virtual void setupScreen(uint gameWidth, uint gameHeight, bool fullscreen, bool accel3d) override;
@@ -99,7 +100,9 @@ protected:
 	 * When unable to create a context with anti-aliasing this tries without.
 	 * When unable to create a context with the desired pixel depth this tries lower values.
 	 */
-	bool createScreen(uint effectiveWidth, uint effectiveHeight, GameRenderTarget gameRenderTarget);
+	bool createOrUpdateGLContext(uint effectiveWidth, uint effectiveHeight, GameRenderTarget gameRenderTarget);
+
+	void createOrUpdateScreen();
 
 	int _antialiasing;
 	bool _vsync;

--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -40,7 +40,9 @@ ResVmSdlGraphicsManager::ResVmSdlGraphicsManager(SdlEventSource *source, SdlWind
 		_overlayWidth(0),
 		_overlayHeight(0),
 		_screenChangeCount(0),
-		_capabilities(capabilities) {
+		_capabilities(capabilities),
+		_engineRequestedWidth(0),
+		_engineRequestedHeight(0)  {
 	ConfMan.registerDefault("fullscreen_res", "desktop");
 	ConfMan.registerDefault("aspect_ratio", true);
 	ConfMan.registerDefault("vsync", true);
@@ -157,9 +159,6 @@ void ResVmSdlGraphicsManager::resetGraphicsScale() {
 
 void ResVmSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
 	switch (f) {
-		case OSystem::kFeatureFullscreenMode:
-			_fullscreen = enable;
-			break;
 		case OSystem::kFeatureAspectRatioCorrection:
 			_lockAspectRatio = enable;
 			break;

--- a/backends/graphics/sdl/resvm-sdl-graphics.h
+++ b/backends/graphics/sdl/resvm-sdl-graphics.h
@@ -127,6 +127,7 @@ protected:
 
 	bool _fullscreen;
 	bool _lockAspectRatio;
+	uint _engineRequestedWidth, _engineRequestedHeight;
 
 	int _screenChangeCount;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -390,7 +390,7 @@ SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, 
 		createWindowFlags |= SDL_WINDOW_FULLSCREEN;
 	}
 
-	if (!_window->createWindow(width, height, createWindowFlags)) {
+	if (!_window->createOrUpdateWindow(width, height, createWindowFlags)) {
 		return nullptr;
 	}
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -51,37 +51,63 @@ SurfaceSdlGraphicsManager::~SurfaceSdlGraphicsManager() {
 
 bool SurfaceSdlGraphicsManager::hasFeature(OSystem::Feature f) {
 	return
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
+#endif
 		(f == OSystem::kFeatureFullscreenMode);
+}
+
+void SurfaceSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
+	switch (f) {
+		case OSystem::kFeatureFullscreenMode:
+			if (_fullscreen != enable) {
+				_fullscreen = enable;
+				createOrUpdateScreen();
+			}
+			break;
+		default:
+			ResVmSdlGraphicsManager::setFeatureState(f, enable);
+			break;
+	}
 }
 
 void SurfaceSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, bool fullscreen, bool accel3d) {
 	assert(!accel3d);
 	closeOverlay();
 
+	_engineRequestedWidth = gameWidth;
+	_engineRequestedHeight = gameHeight;
 	_fullscreen = fullscreen;
 	_lockAspectRatio = ConfMan.getBool("aspect_ratio");
 
-	bool engineSupportsArbitraryResolutions = g_engine && g_engine->hasFeature(Engine::kSupportsArbitraryResolutions);
+	createOrUpdateScreen();
 
-	// Select how the game screen is going to be drawn
-	GameRenderTarget gameRenderTarget = selectGameRenderTarget(_fullscreen, false, engineSupportsArbitraryResolutions,
-	                                                           false, _lockAspectRatio);
+	SDL_PixelFormat *f = _screen->format;
+	_subScreen = SDL_CreateRGBSurface(SDL_SWSURFACE, gameWidth, gameHeight, f->BitsPerPixel, f->Rmask, f->Gmask, f->Bmask, f->Amask);
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_SetSurfaceBlendMode(_subScreen, SDL_BLENDMODE_NONE);
+#endif // SDL_VERSION_ATLEAST(2, 0, 0)
+}
+
+void SurfaceSdlGraphicsManager::createOrUpdateScreen() {
 	// Choose the effective window size or fullscreen mode
 	uint effectiveWidth;
 	uint effectiveHeight;
-	if (_fullscreen && canUsePreferredResolution(gameRenderTarget, engineSupportsArbitraryResolutions)) {
+	if (_fullscreen && _lockAspectRatio) {
 		Common::Rect fullscreenResolution = getPreferredFullscreenResolution();
 		effectiveWidth = fullscreenResolution.width();
 		effectiveHeight = fullscreenResolution.height();
 	} else {
-		effectiveWidth = gameWidth;
-		effectiveHeight = gameHeight;
+		effectiveWidth = _engineRequestedWidth;
+		effectiveHeight = _engineRequestedHeight;
 	}
 
-	// Compute the rectangle where to draw the game inside the effective screen
-	_gameRect = computeGameRect(gameRenderTarget, gameWidth, gameHeight, effectiveWidth, effectiveHeight);
-
+	// The game is centered inside the effective screen
+	_gameRect = Math::Rect2d(
+			Math::Vector2d((effectiveWidth - _engineRequestedWidth) / 2, (effectiveHeight - _engineRequestedHeight) / 2),
+			Math::Vector2d((effectiveWidth + _engineRequestedWidth) / 2, (effectiveHeight + _engineRequestedHeight) / 2)
+	);
 
 	uint32 sdlflags = SDL_SWSURFACE;
 	if (_fullscreen)
@@ -114,22 +140,10 @@ void SurfaceSdlGraphicsManager::setupScreen(uint gameWidth, uint gameHeight, boo
 	_screenFormat = _overlayFormat;
 
 	_screenChangeCount++;
-
-	if (gameRenderTarget == kSubScreen) {
-		_subScreen = SDL_CreateRGBSurface(SDL_SWSURFACE, gameWidth, gameHeight, f->BitsPerPixel, f->Rmask, f->Gmask, f->Bmask, f->Amask);
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-		SDL_SetSurfaceBlendMode(_subScreen, SDL_BLENDMODE_NONE);
-#endif // SDL_VERSION_ATLEAST(2, 0, 0)
-	}
 }
 
 Graphics::PixelBuffer SurfaceSdlGraphicsManager::getScreenPixelBuffer() {
-	if (_subScreen) {
-		return Graphics::PixelBuffer(_screenFormat, (byte *)_subScreen->pixels);
-	}
-
-	return Graphics::PixelBuffer(_screenFormat, (byte *)_screen->pixels);
+	return Graphics::PixelBuffer(_screenFormat, (byte *)_subScreen->pixels);
 }
 
 void SurfaceSdlGraphicsManager::drawSideTextures() {
@@ -161,14 +175,13 @@ void SurfaceSdlGraphicsManager::drawOverlay() {
 }
 
 void SurfaceSdlGraphicsManager::updateScreen() {
-	if (_subScreen) {
-		SDL_Rect dstrect;
-		dstrect.x = _gameRect.getTopLeft().getX();
-		dstrect.y = _gameRect.getTopLeft().getY();
-		dstrect.w = _gameRect.getWidth();
-		dstrect.h = _gameRect.getHeight();
-		SDL_BlitSurface(_subScreen, NULL, _screen, &dstrect);
-	}
+	SDL_Rect dstrect;
+	dstrect.x = _gameRect.getTopLeft().getX();
+	dstrect.y = _gameRect.getTopLeft().getY();
+	dstrect.w = _gameRect.getWidth();
+	dstrect.h = _gameRect.getHeight();
+	SDL_BlitSurface(_subScreen, NULL, _screen, &dstrect);
+
 	if (_overlayVisible) {
 		drawOverlay();
 	}
@@ -187,18 +200,12 @@ void SurfaceSdlGraphicsManager::updateScreen() {
 
 int16 SurfaceSdlGraphicsManager::getHeight() {
 	// ResidualVM specific
-	if (_subScreen)
-		return _subScreen->h;
-	else
-		return _overlayHeight;
+	return _subScreen->h;
 }
 
 int16 SurfaceSdlGraphicsManager::getWidth() {
 	// ResidualVM specific
-	if (_subScreen)
-		return _subScreen->w;
-	else
-		return _overlayWidth;
+	return _subScreen->w;
 }
 
 #pragma mark -
@@ -338,20 +345,18 @@ void SurfaceSdlGraphicsManager::closeOverlay() {
 
 void SurfaceSdlGraphicsManager::warpMouse(int x, int y) {
 	//ResidualVM specific
-	if (_subScreen) {
-		// Scale from game coordinates to screen coordinates
-		x = (x * _gameRect.getWidth()) / _subScreen->w;
-		y = (y * _gameRect.getHeight()) / _subScreen->h;
+	// Scale from game coordinates to screen coordinates
+	x = (x * _gameRect.getWidth()) / _subScreen->w;
+	y = (y * _gameRect.getHeight()) / _subScreen->h;
 
-		x += _gameRect.getTopLeft().getX();
-		y += _gameRect.getTopLeft().getY();
-	}
+	x += _gameRect.getTopLeft().getX();
+	y += _gameRect.getTopLeft().getY();
 
 	_window->warpMouseInWindow(x, y);
 }
 
 void SurfaceSdlGraphicsManager::transformMouseCoordinates(Common::Point &point) {
-	if (_overlayVisible || !_subScreen)
+	if (_overlayVisible)
 		return;
 
 	// Scale from screen coordinates to game coordinates
@@ -387,6 +392,17 @@ SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, 
 	createWindowFlags |= SDL_WINDOW_RESIZABLE;
 #endif
 	if ((flags & SDL_FULLSCREEN) != 0) {
+		// On Linux/X11, when toggling to fullscreen, the window manager saves
+		// the window size to be able to restore it when going back to windowed mode.
+		// If the user configured ResidualVM to start in fullscreen mode, we first
+		// create a window and then toggle it to fullscreen to give the window manager
+		// a chance to save the window size. That way if the user switches back
+		// to windowed mode, the window manager has a window size to apply instead
+		// of leaving the window at the fullscreen resolution size.
+		if (!_window->getSDLWindow()) {
+			_window->createOrUpdateWindow(width, height, createWindowFlags);
+		}
+
 		createWindowFlags |= SDL_WINDOW_FULLSCREEN;
 	}
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -47,6 +47,10 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 
 SurfaceSdlGraphicsManager::~SurfaceSdlGraphicsManager() {
 	closeOverlay();
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_window->destroyWindow();
+#endif
 }
 
 bool SurfaceSdlGraphicsManager::hasFeature(OSystem::Feature f) {
@@ -378,8 +382,6 @@ void SurfaceSdlGraphicsManager::deinitializeRenderer() {
 
 	SDL_DestroyRenderer(_renderer);
 	_renderer = nullptr;
-
-	_window->destroyWindow();
 }
 
 SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags) {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -37,6 +37,7 @@ public:
 
 	// GraphicsManager API - Features
 	virtual bool hasFeature(OSystem::Feature f) override;
+	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 
 	// GraphicsManager API - Graphics mode
 	virtual void setupScreen(uint gameWidth, uint gameHeight, bool fullscreen, bool accel3d) override;
@@ -76,6 +77,7 @@ protected:
 
 	SDL_Surface *_screen;
 	SDL_Surface *_subScreen;
+	void createOrUpdateScreen();
 
 	SDL_Surface *_overlayscreen;
 	bool _overlayDirty;

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -28,9 +28,14 @@
 
 #include "icons/residualvm.xpm"
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+static const uint32 fullscreenMask = SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_FULLSCREEN;
+#endif
+
 SdlWindow::SdlWindow()
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	: _window(nullptr), _inputGrabState(false), _windowCaption("ResidualVM")
+	: _window(nullptr), _inputGrabState(false), _windowCaption("ResidualVM"),
+	_lastFlags(0), _lastX(SDL_WINDOWPOS_UNDEFINED), _lastY(SDL_WINDOWPOS_UNDEFINED)
 #endif
 	{
 }
@@ -199,25 +204,83 @@ SDL_Surface *copySDLSurface(SDL_Surface *src) {
 	return res;
 }
 
-bool SdlWindow::createWindow(int width, int height, uint32 flags) {
-	destroyWindow();
-
+bool SdlWindow::createOrUpdateWindow(int width, int height, uint32 flags) {
 	if (_inputGrabState) {
 		flags |= SDL_WINDOW_INPUT_GRABBED;
 	}
 
-	_window = SDL_CreateWindow(_windowCaption.c_str(), SDL_WINDOWPOS_UNDEFINED,
-	                           SDL_WINDOWPOS_UNDEFINED, width, height, flags);
+	// SDL_WINDOW_RESIZABLE can also be updated without recreating the window
+	// starting with SDL 2.0.5, but it is not treated as updateable here
+	// because:
+	// 1. It is currently only changed in conjunction with the SDL_WINDOW_OPENGL
+	//    flag, so the window will always be recreated anyway when changing
+	//    resizability; and
+	// 2. Users (particularly on Windows) will sometimes swap older SDL DLLs
+	//    to avoid bugs, which would be impossible if the feature was enabled
+	//    at compile time using SDL_VERSION_ATLEAST.
+	const uint32 updateableFlagsMask = fullscreenMask | SDL_WINDOW_INPUT_GRABBED;
+
+	const uint32 oldNonUpdateableFlags = _lastFlags & ~updateableFlagsMask;
+	const uint32 newNonUpdateableFlags = flags & ~updateableFlagsMask;
+
+	if (!_window || oldNonUpdateableFlags != newNonUpdateableFlags) {
+		destroyWindow();
+		_window = SDL_CreateWindow(_windowCaption.c_str(), _lastX,
+								   _lastY, width, height, flags);
+		if (_window) {
+			setupIcon();
+		}
+	} else {
+		const uint32 fullscreenFlags = flags & fullscreenMask;
+
+		if (fullscreenFlags) {
+			SDL_DisplayMode fullscreenMode;
+			fullscreenMode.w = width;
+			fullscreenMode.h = height;
+			fullscreenMode.driverdata = nullptr;
+			fullscreenMode.format = 0;
+			fullscreenMode.refresh_rate = 0;
+			SDL_SetWindowDisplayMode(_window, &fullscreenMode);
+		} else {
+			SDL_SetWindowSize(_window, width, height);
+		}
+
+		SDL_SetWindowFullscreen(_window, fullscreenFlags);
+		SDL_SetWindowGrab(_window, (flags & SDL_WINDOW_INPUT_GRABBED) ? SDL_TRUE : SDL_FALSE);
+	}
+
 	if (!_window) {
 		return false;
 	}
-	setupIcon();
+
+#if defined(MACOSX)
+	// macOS windows with the flag SDL_WINDOW_FULLSCREEN_DESKTOP exiting their fullscreen space
+	// ignore the size set by SDL_SetWindowSize while they were in fullscreen mode.
+	// Instead, they revert back to their previous windowed mode size.
+	// This is a bug in SDL2: https://bugzilla.libsdl.org/show_bug.cgi?id=3719.
+	// TODO: Remove the call to SDL_SetWindowSize below once the SDL bug is fixed.
+
+	// In some cases at this point there may be a pending SDL resize event with the old size.
+	// This happens for example if we destroyed the window, or when switching between windowed
+	// and fullscreen modes. If we changed the window size here, this pending event will have the
+	// old (and incorrect) size. To avoid any issue we call SDL_SetWindowSize() to generate another
+	// resize event (SDL_WINDOWEVENT_SIZE_CHANGED) so that the last resize event we receive has
+	// the correct size. This fixes for exmample bug #9971: SDL2: Fullscreen to RTL launcher resolution
+	SDL_SetWindowSize(_window, width, height);
+#endif
+
+	_lastFlags = flags;
 
 	return true;
 }
 
 void SdlWindow::destroyWindow() {
-	SDL_DestroyWindow(_window);
-	_window = nullptr;
+	if (_window) {
+		if (!(_lastFlags & fullscreenMask)) {
+			SDL_GetWindowPosition(_window, &_lastX, &_lastY);
+		}
+		SDL_DestroyWindow(_window);
+		_window = nullptr;
+	}
 }
 #endif

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -81,14 +81,14 @@ public:
 	SDL_Window *getSDLWindow() const { return _window; }
 
 	/**
-	 * Creates a new SDL window (and destroys the old one).
+	 * Creates or updates the SDL window.
 	 *
 	 * @param width   Width of the window.
 	 * @param height  Height of the window.
 	 * @param flags   SDL flags passed to SDL_CreateWindow
 	 * @return true on success, false otherwise
 	 */
-	bool createWindow(int width, int height, uint32 flags);
+	bool createOrUpdateWindow(int width, int height, uint32 flags);
 
 	/**
 	 * Destroys the current SDL window.
@@ -99,6 +99,15 @@ protected:
 	SDL_Window *_window;
 
 private:
+	uint32 _lastFlags;
+
+	/**
+	 * Switching between software and OpenGL modes requires the window to be
+	 * destroyed and recreated. These properties store the position of the last
+	 * window so the new window will be created in the same place.
+	 */
+	int _lastX, _lastY;
+
 	bool _inputGrabState;
 	Common::String _windowCaption;
 #endif

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -54,6 +54,7 @@
 //#include "graphics/cursorman.h" // ResidualVM
 #include "graphics/opengl/context.h" // ResidualVM specific
 #endif
+#include "graphics/renderer.h" // ResidualVM specific
 
 #include <time.h>	// for getTimeAndDate()
 
@@ -405,7 +406,13 @@ void OSystem_SDL::setupScreen(uint screenW, uint screenH, bool fullscreen, bool 
 }
 
 void OSystem_SDL::launcherInitSize(uint w, uint h) {
-	setupScreen(w, h, false, false);
+	Common::String rendererConfig = ConfMan.get("renderer");
+	Graphics::RendererType desiredRendererType = Graphics::parseRendererTypeCode(rendererConfig);
+	Graphics::RendererType matchingRendererType = Graphics::getBestMatchingAvailableRendererType(desiredRendererType);
+
+	bool fullscreen = ConfMan.getBool("fullscreen");
+
+	setupScreen(w, h, fullscreen, matchingRendererType != Graphics::kRendererTypeTinyGL);
 }
 // End of ResidualVM specific code
 

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -289,7 +289,7 @@ static void setupGraphics(OSystem &system) {
 		system.setGraphicsMode(ConfMan.get("gfx_mode").c_str());
 
 		system.initSize(320, 200);
-		system.launcherInitSize(640, 400); //ResidualVM specific
+		system.launcherInitSize(640, 480); //ResidualVM specific
 
 		if (ConfMan.hasKey("aspect_ratio"))
 			system.setFeatureState(OSystem::kFeatureAspectRatioCorrection, ConfMan.getBool("aspect_ratio"));

--- a/common/system.h
+++ b/common/system.h
@@ -332,6 +332,19 @@ public:
 		kFeatureVSync,
 
 		/**
+		 * When a backend supports this feature, it guarantees the graphics
+		 * context is not destroyed when switching to and from fullscreen.
+		 *
+		 * For OpenGL that means the context is kept with all of its content:
+		 * texture, programs...
+		 *
+		 * For TinyGL that means the backbuffer surface is kept.
+		 *
+		 * ResidualVM specific
+		 */
+		kFeatureFullscreenToggleKeepsContext,
+
+		/**
 		 * The presence of this feature indicates whether the displayLogFile()
 		 * call is supported.
 		 *

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -414,7 +414,7 @@ void GUIErrorMessage(const Common::String &msg) {
 	g_system->beginGFXTransaction();
 		initCommonGFX(false);
 		g_system->initSize(320, 200);
-		g_system->launcherInitSize(640, 400);//ResidualVM specific
+		g_system->launcherInitSize(640, 480);//ResidualVM specific
 	if (g_system->endGFXTransaction() == OSystem::kTransactionSuccess) {
 		GUI::MessageDialog dialog(msg);
 		dialog.runModal();

--- a/engines/grim/gfx_base.cpp
+++ b/engines/grim/gfx_base.cpp
@@ -48,7 +48,7 @@ namespace Grim {
 GfxBase::GfxBase() :
 		_renderBitmaps(true), _renderZBitmaps(true), _shadowModeActive(false),
 		_currentPos(0, 0, 0), _dimLevel(0.0f),
-		_screenWidth(0), _screenHeight(0), _isFullscreen(false),
+		_screenWidth(0), _screenHeight(0),
 		_scaleW(1.0f), _scaleH(1.0f), _currentShadowArray(nullptr),
 		_shadowColorR(255), _shadowColorG(255), _shadowColorB(255) {
 			for (unsigned int i = 0; i < _numSpecialtyTextures; i++) {

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -93,12 +93,7 @@ public:
 	* @return true if supports shaders, false otherwise
 	*/
 	virtual bool supportsShaders() = 0;
-	/**
-	 * Query whether the current context is fullscreen.
-	 *
-	 * @return true if fullscreen, false otherwise
-	 */
-	virtual bool isFullscreen() { return _isFullscreen; }
+
 	virtual uint getScreenWidth() { return _screenWidth; }
 	virtual uint getScreenHeight() { return _screenHeight; }
 
@@ -285,7 +280,6 @@ protected:
 	static const int _gameWidth = 640;
 	float _scaleW, _scaleH;
 	int _screenWidth, _screenHeight;
-	bool _isFullscreen;
 	Shadow *_currentShadowArray;
 	unsigned char _shadowColorR;
 	unsigned char _shadowColorG;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -134,7 +134,6 @@ byte *GfxOpenGL::setupScreen(int screenW, int screenH, bool fullscreen) {
 	_scaleW = _screenWidth / (float)_gameWidth;
 	_scaleH = _screenHeight / (float)_gameHeight;
 
-	_isFullscreen = g_system->getFeatureState(OSystem::kFeatureFullscreenMode);
 	_useDepthShader = false;
 	_useDimShader = false;
 

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -411,7 +411,6 @@ byte *GfxOpenGLS::setupScreen(int screenW, int screenH, bool fullscreen) {
 	_scaleW = _screenWidth / (float)_gameWidth;
 	_scaleH = _screenHeight / (float)_gameHeight;
 
-	_isFullscreen = g_system->getFeatureState(OSystem::kFeatureFullscreenMode);
 #ifdef USE_GLES2
 	g_system->setFeatureState(OSystem::kFeatureVirtControls, true);
 #endif

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -86,8 +86,6 @@ byte *GfxTinyGL::setupScreen(int screenW, int screenH, bool fullscreen) {
 	_scaleW = _screenWidth / (float)_gameWidth;
 	_scaleH = _screenHeight / (float)_gameHeight;
 
-	_isFullscreen = g_system->getFeatureState(OSystem::kFeatureFullscreenMode);
-
 	g_system->showMouse(!fullscreen);
 
 	g_system->setWindowCaption("ResidualVM: Software 3D Renderer");

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -197,7 +197,7 @@ protected:
 	void cameraPostChangeHandle(int num);
 	void buildActiveActorsList();
 	void savegameCallback();
-	GfxBase *createRenderer(int screenW, int screenH);
+	GfxBase *createRenderer(int screenW, int screenH, bool fullscreen);
 	void playAspyrLogo();
 	virtual LuaBase *createLua();
 	virtual void updateNormalMode();

--- a/engines/myst3/cursor.cpp
+++ b/engines/myst3/cursor.cpp
@@ -170,9 +170,11 @@ void Cursor::lockPosition(bool lock) {
 	}
 }
 
-void Cursor::updatePosition(Common::Point &mouse) {
+void Cursor::updatePosition(const Common::Point &mouse) {
 	if (!_lockedAtCenter) {
 		_position = mouse;
+	} else {
+		_position = _vm->_scene->getCenter();
 	}
 }
 

--- a/engines/myst3/cursor.h
+++ b/engines/myst3/cursor.h
@@ -51,7 +51,7 @@ public:
 	 * @return
 	 */
 	Common::Point getPosition(bool scaled = true);
-	void updatePosition(Common::Point &mouse);
+	void updatePosition(const Common::Point &mouse);
 
 	void getDirection(float &pitch, float &heading);
 

--- a/engines/myst3/gfx.cpp
+++ b/engines/myst3/gfx.cpp
@@ -219,6 +219,16 @@ Renderer *createRenderer(OSystem *system) {
 	error("Unable to create a '%s' renderer", rendererConfig.c_str());
 }
 
+void Renderer::toggleFullscreen() {
+	if (!_system->hasFeature(OSystem::kFeatureFullscreenToggleKeepsContext)) {
+		warning("Unable to toggle the fullscreen state because the current backend would destroy the graphics context");
+		return;
+	}
+
+	bool oldFullscreen = _system->getFeatureState(OSystem::kFeatureFullscreenMode);
+	_system->setFeatureState(OSystem::kFeatureFullscreenMode, !oldFullscreen);
+}
+
 void Renderer::renderDrawable(Drawable *drawable, Window *window) {
 	if (drawable->isConstrainedToWindow()) {
 		selectTargetWindow(window, drawable->is3D(), drawable->isScaled());

--- a/engines/myst3/gfx.h
+++ b/engines/myst3/gfx.h
@@ -113,6 +113,7 @@ public:
 
 	virtual void init() = 0;
 	virtual void clear() = 0;
+	void toggleFullscreen();
 
 	/**
 	 *  Swap the buffers, making the drawn screen visible
@@ -172,6 +173,8 @@ public:
 	static const int kBottomBorderHeight = 90;
 	static const int kFrameHeight = 360;
 
+	void computeScreenViewport();
+
 protected:
 	OSystem *_system;
 	Texture *_font;
@@ -188,7 +191,6 @@ protected:
 	Math::AABB _cubeFacesAABB[6];
 
 	Common::Rect getFontCharacterRect(uint8 character);
-	void computeScreenViewport();
 
 	Math::Matrix4 makeProjectionMatrix(float fov) const;
 };

--- a/engines/myst3/inventory.h
+++ b/engines/myst3/inventory.h
@@ -60,6 +60,8 @@ public:
 	/** Change the cursor when it is hovering an item */
 	void updateCursor();
 
+	void reflow();
+
 	uint16 hoveredItem();
 	void useItem(uint16 var);
 
@@ -91,7 +93,6 @@ private:
 	void initializeTexture();
 
 	bool hasItem(uint16 var);
-	void reflow();
 
 	void openBook(uint16 age, uint16 room, uint16 node);
 	void closeAllBooks();

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1179,25 +1179,18 @@ void Myst3Engine::playSimpleMovie(uint16 id, bool fullframe, bool refreshAmbient
 
 	_drawables.push_back(&movie);
 
-	bool skip = false;
-
-	while (!skip && !shouldQuit() && !movie.endOfVideo()) {
+	while (!shouldQuit() && !movie.endOfVideo()) {
 		movie.update();
 
 		// Process events
-		Common::Event event;
-		while (getEventManager()->pollEvent(event))
-			if (event.type == Common::EVENT_MOUSEMOVE) {
-				if (_state->getViewType() == kCube)
-					_scene->updateCamera(event.relMouse);
+		processInput(true);
 
-				_cursor->updatePosition(event.mouse);
-
-			} else if (event.type == Common::EVENT_KEYDOWN) {
-				if (event.kbd.keycode == Common::KEYCODE_SPACE
-						|| event.kbd.keycode == Common::KEYCODE_ESCAPE)
-					skip = true;
-			}
+		// Handle skipping
+		if (_inputSpacePressed || _inputEscapePressed) {
+			// Consume the escape key press so the menu does not open
+			_inputEscapePressedNotConsumed = false;
+			break;
+		}
 
 		drawFrame();
 	}

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -473,8 +473,12 @@ void Myst3Engine::processInput(bool lookOnly) {
 				break;
 			case Common::KEYCODE_RETURN:
 			case Common::KEYCODE_KP_ENTER:
-				_inputEnterPressed = true;
-				shouldInteractWithHoveredElement = true;
+				if (event.kbd.hasFlags(Common::KBD_ALT)) {
+					_gfx->toggleFullscreen();
+				} else {
+					_inputEnterPressed = true;
+					shouldInteractWithHoveredElement = true;
+				}
 				break;
 			case Common::KEYCODE_SPACE:
 				_inputSpacePressed = true;
@@ -517,6 +521,10 @@ void Myst3Engine::processInput(bool lookOnly) {
 			default:
 				break;
 			}
+		} else if (event.type == Common::EVENT_SCREEN_CHANGED) {
+			_gfx->computeScreenViewport();
+			_cursor->updatePosition(_eventMan->getMousePos());
+			_inventory->reflow();
 		}
 	}
 

--- a/engines/stark/gfx/driver.cpp
+++ b/engines/stark/gfx/driver.cpp
@@ -56,6 +56,16 @@ const Graphics::PixelFormat Driver::getRGBAPixelFormat() {
 #endif
 }
 
+void Driver::toggleFullscreen() const {
+	if (!g_system->hasFeature(OSystem::kFeatureFullscreenToggleKeepsContext)) {
+		warning("Unable to toggle the fullscreen state because the current backend would destroy the graphics context");
+		return;
+	}
+
+	bool oldFullscreen = g_system->getFeatureState(OSystem::kFeatureFullscreenMode);
+	g_system->setFeatureState(OSystem::kFeatureFullscreenMode, !oldFullscreen);
+}
+
 void Driver::computeScreenViewport() {
 	int32 screenWidth = g_system->getWidth();
 	int32 screenHeight = g_system->getHeight();

--- a/engines/stark/gfx/driver.h
+++ b/engines/stark/gfx/driver.h
@@ -49,6 +49,12 @@ public:
 
 	virtual void init() = 0;
 
+	/**
+	 * Toggle between windowed mode and fullscreen when spported by the backend.
+	 */
+	void toggleFullscreen() const;
+
+	void computeScreenViewport();
 	virtual void setScreenViewport(bool noScaling) = 0; // deprecated
 
 	virtual void setViewport(Common::Rect rect, bool noScaling) = 0;
@@ -135,7 +141,6 @@ public:
 	static const int32 kGameViewportWidth = 640;
 
 protected:
-	void computeScreenViewport();
 	static void flipVertical(Graphics::Surface *s);
 
 	Common::Rect _screenViewport;

--- a/engines/stark/services/userinterface.cpp
+++ b/engines/stark/services/userinterface.cpp
@@ -280,5 +280,9 @@ const Graphics::Surface *UserInterface::getGameWindowThumbnail() const {
 	return _gameWindowThumbnail;
 }
 
+void UserInterface::onScreenChanged() {
+	_dialogPanel->onScreenChanged();
+}
+
 } // End of namespace Stark
 

--- a/engines/stark/services/userinterface.h
+++ b/engines/stark/services/userinterface.h
@@ -122,6 +122,9 @@ public:
 	/** Was a player interaction with the world denied during this non interactive period? */
 	bool wasInteractionDenied() const;
 
+	/** The screen resolution just changed, rebuild resolution dependent data */
+	void onScreenChanged();
+
 	/** Grab a screenshot of the game screen and store it in the class context as a thumbnail */
 	void saveGameScreenThumbnail();
 

--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -227,6 +227,10 @@ void StarkEngine::processEvents() {
 				if (!skipped) {
 					_global->setFastForward();
 				}
+			} else if ((e.kbd.keycode == Common::KEYCODE_RETURN
+					|| e.kbd.keycode == Common::KEYCODE_KP_ENTER)
+					&& e.kbd.hasFlags(Common::KBD_ALT)) {
+				_gfx->toggleFullscreen();
 			}
 
 		} else if (e.type == Common::EVENT_LBUTTONUP) {
@@ -241,6 +245,10 @@ void StarkEngine::processEvents() {
 			_lastClickTime = _system->getMillis();
 		} else if (e.type == Common::EVENT_RBUTTONDOWN) {
 			_userInterface->handleRightClick();
+		} else if (e.type == Common::EVENT_SCREEN_CHANGED) {
+			_gfx->computeScreenViewport();
+			_fontProvider->initFonts();
+			_userInterface->onScreenChanged();
 		}
 	}
 }

--- a/engines/stark/ui/dialogpanel.cpp
+++ b/engines/stark/ui/dialogpanel.cpp
@@ -202,7 +202,7 @@ void DialogPanel::reset() {
 	delete _subtitleVisual;
 	_subtitleVisual = nullptr;
 
-	_options.clear();
+	clearOptions();
 
 	StarkDialogPlayer->reset();
 }
@@ -219,6 +219,13 @@ int DialogPanel::getHoveredOption(const Common::Point &pos) {
 
 void DialogPanel::scrollOptions(int increment) {
 	_firstVisibleOption = CLIP<int32>(_firstVisibleOption + increment, 0, _options.size() - 3);
+}
+
+void DialogPanel::onScreenChanged() {
+	if (_currentSpeech) {
+		updateSubtitleVisual();
+	}
+	updateDialogOptions();
 }
 
 } // End of namespace Stark

--- a/engines/stark/ui/dialogpanel.h
+++ b/engines/stark/ui/dialogpanel.h
@@ -49,6 +49,9 @@ public:
 	/** Abort the currently playing dialog */
 	void reset();
 
+	/** The screen resolution changed, rebuild the text textures accordingly */
+	void onScreenChanged();
+
 protected:
 	void onMouseMove(const Common::Point &pos) override;
 	void onClick(const Common::Point &pos) override;

--- a/graphics/opengl/texture.cpp
+++ b/graphics/opengl/texture.cpp
@@ -42,7 +42,7 @@ static T nextHigher2(T k) {
 	return k + 1;
 }
 
-static const Graphics::PixelFormat getRGBAPixelFormat() {
+const Graphics::PixelFormat Texture::getRGBAPixelFormat() {
 #ifdef SCUMM_BIG_ENDIAN
 	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
 #else
@@ -50,7 +50,7 @@ static const Graphics::PixelFormat getRGBAPixelFormat() {
 #endif
 }
 
-static const Graphics::PixelFormat get565PixelFormat() {
+const Graphics::PixelFormat Texture::get565PixelFormat() {
 	return Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
 }
 

--- a/graphics/opengl/texture.h
+++ b/graphics/opengl/texture.h
@@ -42,6 +42,9 @@ public:
 	uint getTexWidth() const { return _texWidth; }
 	uint getTexHeight() const { return _texHeight; }
 
+	static const Graphics::PixelFormat getRGBAPixelFormat();
+	static const Graphics::PixelFormat get565PixelFormat();
+
 protected:
 	bool _managedTexture;
 	GLuint _texture;


### PR DESCRIPTION
This pull request imports the changes from https://github.com/scummvm/scummvm/pull/937 and adapts them to ResidualVM.

With these changes and when building with SDL2, ResidualVM will keep the same window when going from the launcher to a game, and when toggling the fullscreen mode. That means the OpenGL context can be kept during those operations, making it easy to implement fullscreen toggling in Myst III and TLJ, and no longer requiring to save / restore the game in Grim.
The window will still be recreated when switching between software and OpenGL.

The notable changes are as follow:
* The default launcher size is now 640x480 instead of 640x400. This avoids resizing the window when starting a game in windowed mode from the launcher.
* The launcher can now be used in fullscreen mode.
* The launcher will now render in OpenGL mode if selected in the option screen. This avoids recreating the window when starting a game from the launcher.
* Myst III and TLJ now support fullscreen toggling (SDL2 only)
* Grim no longer saves / restores when going to / leaving fullscreen (SDL2 only)