### PR TITLE
GRIM: Switch iris renderer to regular rendering

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1917,10 +1917,11 @@ void GfxOpenGL::irisAroundRegion(int x1, int y1, int x2, int y2) {
 		fx1, fy1
 	};
 
-	glEnableClientState(GL_VERTEX_ARRAY);
-	glVertexPointer(2, GL_FLOAT, 0, points);
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 10);
-	glDisableClientState(GL_VERTEX_ARRAY);
+	glBegin(GL_TRIANGLE_STRIP);
+	for (int i = 0 ;i < 10; ++i) {
+		glVertex2fv(points+2*i);
+	}
+	glEnd();
 
 	glColor3f(1.0f, 1.0f, 1.0f);
 	glEnable(GL_DEPTH_TEST);


### PR DESCRIPTION
It seems that glVertexPointer is not supposed to work with a direct pointer passed in. It does work in every case, other than the intel integrated driver. On windows it crashes and on linux it just doesn't for the frames that make this call.

This was added by @somaen as an optimization, but I think it's more safe to just revert it so we don't cause crashes.

This (probably, I can't get my laptop to stop using the nvidia driver) fixes #1377 and maybe #723 and #720.