### PR TITLE
MYST3: fix Polish version detection and subtitles

### DIFF
--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -115,7 +115,7 @@ static const Myst3GameDescription gameDescriptions[] = {
 	MYST3ENTRY(Common::DE_DEU, "GERMAN.m3u",   "1b2fa162a951fa4ed65617dd3f0c8a53", 0, kLocMulti2) // #1323, andrews05
 	MYST3ENTRY(Common::IT_ITA, "ITALIAN.m3u",  "906645a87ac1cbbd2b88c277c2b4fda2", 0, kLocMulti2) // #1323, andrews05
 	MYST3ENTRY(Common::ES_ESP, "SPANISH.m3u",  "28003569d9536cbdf6020aee8e9bcd15", 0, kLocMulti2) // #1323, goodoldgeorge
-	MYST3ENTRY(Common::PL_POL, "POLISH.m3u",   "00000000000000000000000000000000", 0, kLocMulti2)
+	MYST3ENTRY(Common::PL_POL, "POLISH.m3u",   "8075e4e822e100ec79a5842a530dbe24", 0, kLocMulti2)
 
 	// Russian release (Russian only) (1.2)
 	MYST3ENTRY(Common::RU_RUS, "ENGLISH.m3t",  "57d36d8610043fda554a0708d71d2681", 0, kLocMonolingual)

--- a/engines/myst3/subtitles.cpp
+++ b/engines/myst3/subtitles.cpp
@@ -257,7 +257,7 @@ const char *FontSubtitles::getCodePage(uint32 gdiCharset) {
 			{ 186, "cp1257" }, // BALTIC_CHARSET
 			{ 204, "cp1251" }, // RUSSIAN_CHARSET
 			{ 222, "cp874"  }, // THAI_CHARSET
-			{ 238, "cp1250" }  // EASTEUROPE_CHARSET
+			{ 238, "mac-centraleurope" }  // EASTEUROPE_CHARSET
 	};
 
 	for (uint i = 0; i < ARRAYSIZE(codepages); i++) {


### PR DESCRIPTION
Hi,
I added a checksum for the Polish version of Myst 3 (4 CD Play-It version, it's actually dual-language) and fixed encoding of the subtitles (which also eliminates crashes). This version is not using windows-1250 encoding but rather a MacOS Central European one.

Some images:
[Subtitles before encoding fix](https://gs.smuglo.li/file/49c43f3c615e5117bc72851b6e4b0cbc1c58e2a44e7587ad3bf5cd97c64a3781.png)
[Subtitles leading to crashes](https://gs.smuglo.li/file/9dd6a2f8cee8f2e4761dbede9a85406a5ec23675806c4212174005b0ac9e1c40.png)
[With fixed encoding](https://gs.smuglo.li/file/9efb1940aecf4b3ad5cc815ff9151634a94189711882a1ce2872fcc58eb7e950.png)

