### PR TITLE
STARK: Fix not matching mouse hints

### DIFF
--- a/engines/stark/resources/item.cpp
+++ b/engines/stark/resources/item.cpp
@@ -379,7 +379,7 @@ void ItemVisual::setPosition2D(const Common::Point &position) {
 }
 
 Common::String ItemVisual::getHotspotTitle(uint32 hotspotIndex) {
-	PATTable *table = findChildWithIndex<PATTable>(hotspotIndex);
+	PATTable *table = findChildWithOrder<PATTable>(hotspotIndex);
 	Common::String title;
 	if (table) {
 		title = table->getName();


### PR DESCRIPTION
There was not proper text hints in some scenes for objects and background because of wrong index.