### PR TITLE
Support fullscreen on RPI (using framebuffer)

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -476,10 +476,14 @@ void OpenGLSdlGraphicsManager::showOverlay() {
 	_overlayBackground = nullptr;
 
 	if (g_engine) {
+		if (_frameBuffer)
+			_frameBuffer->detach();
 		// If there is a game running capture the screen, so that it can be shown "below" the overlay.
 		_overlayBackground = new OpenGL::TiledSurface(_overlayWidth, _overlayHeight, _overlayFormat);
 		Graphics::Surface *background = _overlayBackground->getBackingSurface();
 		glReadPixels(0, 0, background->w, background->h, GL_RGBA, GL_UNSIGNED_BYTE, background->getPixels());
+		if (_frameBuffer)
+			_frameBuffer->attach();
 	}
 }
 

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -50,6 +50,7 @@ void Context::reset() {
 	packedDepthStencilSupported = false;
 	unpackSubImageSupported = false;
 	framebufferObjectMultisampleSupported = false;
+	OESDepth24 = false;
 	multisampleMaxSamples = -1;
 }
 
@@ -96,7 +97,10 @@ void Context::initialize(ContextType contextType) {
 			EXTFramebufferMultisample = true;
 		} else if (token == "GL_EXT_framebuffer_blit") {
 			EXTFramebufferBlit = true;
+		} else if (token == "GL_OES_depth24") {
+			OESDepth24 = true;
 		}
+		
 	}
 
 	int glslVersion = getGLSLVersion();

--- a/graphics/opengl/context.h
+++ b/graphics/opengl/context.h
@@ -85,6 +85,9 @@ public:
 
 	/** Whether specifying a pitch when uploading to textures is available or not */
 	bool unpackSubImageSupported;
+	
+	/** Whether depth component 24 is supported or not */
+	bool OESDepth24;
 
 	int getGLSLVersion() const;
 };

--- a/graphics/opengl/framebuffer.cpp
+++ b/graphics/opengl/framebuffer.cpp
@@ -49,6 +49,7 @@
 
 #ifdef USE_GLES2
 #define GL_DEPTH24_STENCIL8 GL_DEPTH24_STENCIL8_OES
+#define GL_DEPTH_COMPONENT24 GL_DEPTH_COMPONENT24_OES
 #endif
 
 namespace OpenGL {
@@ -115,6 +116,9 @@ static void grabFramebufferObjectPointers() {
 static bool usePackedBuffer() {
 	return OpenGLContext.packedDepthStencilSupported;
 }
+static bool useDepthComponent24() {
+	return OpenGLContext.OESDepth24;
+}
 
 FrameBuffer::FrameBuffer(uint width, uint height) :
 		Texture(width, height) {
@@ -154,7 +158,7 @@ void FrameBuffer::init() {
 		glBindRenderbuffer(GL_RENDERBUFFER, 0);
 	} else {
 		glBindRenderbuffer(GL_RENDERBUFFER, _renderBuffers[0]);
-		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, _texWidth, _texHeight);
+		glRenderbufferStorage(GL_RENDERBUFFER, useDepthComponent24()?GL_DEPTH_COMPONENT24:GL_DEPTH_COMPONENT16, _texWidth, _texHeight);
 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _renderBuffers[0]);
 
 		glBindRenderbuffer(GL_RENDERBUFFER, _renderBuffers[1]);

--- a/graphics/opengl/framebuffer.cpp
+++ b/graphics/opengl/framebuffer.cpp
@@ -158,7 +158,7 @@ void FrameBuffer::init() {
 		glBindRenderbuffer(GL_RENDERBUFFER, 0);
 	} else {
 		glBindRenderbuffer(GL_RENDERBUFFER, _renderBuffers[0]);
-		glRenderbufferStorage(GL_RENDERBUFFER, useDepthComponent24()?GL_DEPTH_COMPONENT24:GL_DEPTH_COMPONENT16, _texWidth, _texHeight);
+		glRenderbufferStorage(GL_RENDERBUFFER, useDepthComponent24() ? GL_DEPTH_COMPONENT24 : GL_DEPTH_COMPONENT16, _texWidth, _texHeight);
 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _renderBuffers[0]);
 
 		glBindRenderbuffer(GL_RENDERBUFFER, _renderBuffers[1]);


### PR DESCRIPTION
Raspberry PI doesn't support 16 depth framebuffer. This patch uses 24 when capable (16 if not).
This resolve the problem and allow to run ResidualVM fullscreen on RPI platforms (with 3D acceleration).
