### PR TITLE
STARK: Action menu fix

### DIFF
--- a/engines/stark/ui/window.cpp
+++ b/engines/stark/ui/window.cpp
@@ -38,6 +38,12 @@ Window::Window(Gfx::Driver *gfx, Cursor *cursor) :
 Window::~Window() {
 }
 
+Common::Rect Window::getScaledPosition() const {
+  return Common::Rect(_gfx->scaleWidthOriginalToCurrent(Gfx::Driver::kGameViewportWidth),
+                      _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kGameViewportHeight));
+
+}
+
 void Window::render() {
 	if (!_visible) {
 		return;

--- a/engines/stark/ui/window.cpp
+++ b/engines/stark/ui/window.cpp
@@ -39,9 +39,8 @@ Window::~Window() {
 }
 
 Common::Rect Window::getScaledPosition() const {
-  return Common::Rect(_gfx->scaleWidthOriginalToCurrent(Gfx::Driver::kGameViewportWidth),
-                      _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kGameViewportHeight));
-
+        return Common::Rect(_gfx->scaleWidthOriginalToCurrent(_position.width()),
+                            _gfx->scaleHeightOriginalToCurrent(_position.height()));
 }
 
 void Window::render() {

--- a/engines/stark/ui/window.h
+++ b/engines/stark/ui/window.h
@@ -88,6 +88,8 @@ protected:
 	virtual void onDoubleClick(const Common::Point &pos) {}
 	virtual void onRender() = 0;
 
+        Common::Rect getScaledPosition() const;
+
 	Common::Point getRelativeMousePosition() const;
 
 	Gfx::Driver *_gfx;

--- a/engines/stark/ui/window.h
+++ b/engines/stark/ui/window.h
@@ -81,14 +81,15 @@ public:
 	/** Grab a screenshot of the window if it is visible */
 	Graphics::Surface *getScreenshot() const;
 
+        /** Get current scaled window position */
+        Common::Rect getScaledPosition() const;
+
 protected:
 	virtual void onMouseMove(const Common::Point &pos) {}
 	virtual void onClick(const Common::Point &pos) {}
 	virtual void onRightClick(const Common::Point &pos) {}
 	virtual void onDoubleClick(const Common::Point &pos) {}
 	virtual void onRender() = 0;
-
-        Common::Rect getScaledPosition() const;
 
 	Common::Point getRelativeMousePosition() const;
 

--- a/engines/stark/ui/world/actionmenu.cpp
+++ b/engines/stark/ui/world/actionmenu.cpp
@@ -69,29 +69,7 @@ void ActionMenu::open(Resources::ItemVisual *item, const Common::Point &itemRela
 
 	Common::Point screenMousePos = _cursor->getMousePosition(true);
 
-	// TODO: tidy up logic for preventing actionMenu overlapping viewport
-	Common::Rect viewportPosition = Common::Rect(_gfx->scaleWidthOriginalToCurrent(Gfx::Driver::kGameViewportWidth),
-						     _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kGameViewportHeight));
-
-	viewportPosition.translate(0, _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kTopBorderHeight));
-
-	_position = Common::Rect::center(screenMousePos.x, screenMousePos.y, 160, 111);
-
-	if (_position.top < 0) {
-	  _position.translate(0, 0 - _position.top);
-	}
-
-	if (_position.left < 0) {
-	  _position.translate(0 - _position.left, 0);
-	}
-
-	if (_position.bottom > viewportPosition.bottom) {
-	  _position.translate(0, viewportPosition.bottom - _position.bottom);
-	}
-
-	if (_position.right > viewportPosition.right) {
-	  _position.translate(viewportPosition.right - _position.right, 0);
-	}
+        _position = getPosition(screenMousePos);
 
 	_itemRelativePos = itemRelativePos;
 	_item = item;
@@ -119,6 +97,21 @@ void ActionMenu::open(Resources::ItemVisual *item, const Common::Point &itemRela
 void ActionMenu::close() {
 	_visible = false;
 	_item = nullptr;
+}
+
+Common::Rect ActionMenu::getPosition(const Common::Point &pos) {
+  Common::Rect screenWindow = getScaledPosition();
+  Common::Rect position = Common::Rect::center(pos.x, pos.y, 160, 111);
+
+  // offset screen by top border for correct boundary calculations
+  screenWindow.translate(0, _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kTopBorderHeight));
+
+  if (_position.top < 0) position.translate(0, 0 - _position.top);
+  if (_position.left < 0) position.translate(0 - _position.left, 0);
+  if (_position.bottom > screenWindow.bottom) position.translate(0, screenWindow.bottom - _position.bottom);
+  if (_position.right > screenWindow.right) position.translate(screenWindow.right - _position.right, 0);
+
+  return position;
 }
 
 void ActionMenu::onRender() {

--- a/engines/stark/ui/world/actionmenu.cpp
+++ b/engines/stark/ui/world/actionmenu.cpp
@@ -25,6 +25,8 @@
 #include "engines/stark/ui/cursor.h"
 #include "engines/stark/ui/world/inventorywindow.h"
 
+#include "engines/stark/gfx/driver.h"
+
 #include "engines/stark/resources/anim.h"
 #include "engines/stark/resources/item.h"
 #include "engines/stark/resources/knowledgeset.h"
@@ -66,7 +68,30 @@ void ActionMenu::open(Resources::ItemVisual *item, const Common::Point &itemRela
 	_visible = true;
 
 	Common::Point screenMousePos = _cursor->getMousePosition(true);
+
+	// TODO: tidy up logic for preventing actionMenu overlapping viewport
+	Common::Rect viewportPosition = Common::Rect(_gfx->scaleWidthOriginalToCurrent(Gfx::Driver::kGameViewportWidth),
+						     _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kGameViewportHeight));
+
+	viewportPosition.translate(0, _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kTopBorderHeight));
+
 	_position = Common::Rect::center(screenMousePos.x, screenMousePos.y, 160, 111);
+
+	if (_position.top < 0) {
+	  _position.translate(0, 0 - _position.top);
+	}
+
+	if (_position.left < 0) {
+	  _position.translate(0 - _position.left, 0);
+	}
+
+	if (_position.bottom > viewportPosition.bottom) {
+	  _position.translate(0, viewportPosition.bottom - _position.bottom);
+	}
+
+	if (_position.right > viewportPosition.right) {
+	  _position.translate(viewportPosition.right - _position.right, 0);
+	}
 
 	_itemRelativePos = itemRelativePos;
 	_item = item;

--- a/engines/stark/ui/world/actionmenu.cpp
+++ b/engines/stark/ui/world/actionmenu.cpp
@@ -22,7 +22,9 @@
 
 #include "engines/stark/ui/world/actionmenu.h"
 
+#include "engines/stark/ui/window.h"
 #include "engines/stark/ui/cursor.h"
+#include "engines/stark/ui/world/gamewindow.h"
 #include "engines/stark/ui/world/inventorywindow.h"
 
 #include "engines/stark/gfx/driver.h"
@@ -46,6 +48,8 @@ namespace Stark {
 
 ActionMenu::ActionMenu(Gfx::Driver *gfx, Cursor *cursor) :
 		Window(gfx, cursor) {
+	_gameWindow = nullptr;
+
 	_background = StarkStaticProvider->getUIElement(StaticProvider::kActionMenuBg);
 
 	_unscaled = true;
@@ -69,7 +73,7 @@ void ActionMenu::open(Resources::ItemVisual *item, const Common::Point &itemRela
 
 	Common::Point screenMousePos = _cursor->getMousePosition(true);
 
-        _position = getPosition(screenMousePos);
+	_position = getPosition(screenMousePos);
 
 	_itemRelativePos = itemRelativePos;
 	_item = item;
@@ -100,18 +104,16 @@ void ActionMenu::close() {
 }
 
 Common::Rect ActionMenu::getPosition(const Common::Point &pos) {
-  Common::Rect screenWindow = getScaledPosition();
-  Common::Rect position = Common::Rect::center(pos.x, pos.y, 160, 111);
+        Common::Rect position = Common::Rect::center(pos.x, pos.y, 160, 111);
 
-  // offset screen by top border for correct boundary calculations
-  screenWindow.translate(0, _gfx->scaleHeightOriginalToCurrent(Gfx::Driver::kTopBorderHeight));
+        Common::Rect screenPos = _gameWindow->getScaledPosition();
 
-  if (_position.top < 0) position.translate(0, 0 - _position.top);
-  if (_position.left < 0) position.translate(0 - _position.left, 0);
-  if (_position.bottom > screenWindow.bottom) position.translate(0, screenWindow.bottom - _position.bottom);
-  if (_position.right > screenWindow.right) position.translate(screenWindow.right - _position.right, 0);
+        if (position.top < 0) position.translate(0, 0 - position.top);
+        if (position.left < 0) position.translate(0 - position.left, 0);
+        if (position.bottom > screenPos.bottom) position.translate(0, screenPos.bottom - position.bottom);
+        if (position.right > screenPos.right) position.translate(screenPos.right - position.right, 0);
 
-  return position;
+        return position;
 }
 
 void ActionMenu::onRender() {
@@ -177,6 +179,10 @@ void ActionMenu::onClick(const Common::Point &pos) {
 			close();
 		}
 	}
+}
+
+void ActionMenu::setGameWindow(GameWindow *gameWindow) {
+	_gameWindow = gameWindow;
 }
 
 void ActionMenu::setInventory(InventoryWindow *inventory) {

--- a/engines/stark/ui/world/actionmenu.h
+++ b/engines/stark/ui/world/actionmenu.h
@@ -46,6 +46,7 @@ public:
 	void close();
 
 protected:
+        Common::Rect getPosition(const Common::Point &pos);
 	void onMouseMove(const Common::Point &pos) override;
 	void onClick(const Common::Point &pos) override;
 	void onRender() override;

--- a/engines/stark/ui/world/actionmenu.h
+++ b/engines/stark/ui/world/actionmenu.h
@@ -23,6 +23,7 @@
 #ifndef STARK_UI_ACTIONMENU_H
 #define STARK_UI_ACTIONMENU_H
 
+#include "engines/stark/ui/world/gamewindow.h"
 #include "engines/stark/ui/window.h"
 
 namespace Stark {
@@ -40,13 +41,16 @@ public:
 	ActionMenu(Gfx::Driver *gfx, Cursor *cursor);
 	~ActionMenu();
 
+	void setGameWindow(GameWindow *gameWindow);
+
 	void setInventory(InventoryWindow *inventory);
 
 	void open(Resources::ItemVisual *item, const Common::Point &itemRelativePos);
 	void close();
 
 protected:
-        Common::Rect getPosition(const Common::Point &pos);
+	Common::Rect getPosition(const Common::Point &pos);
+
 	void onMouseMove(const Common::Point &pos) override;
 	void onClick(const Common::Point &pos) override;
 	void onRender() override;
@@ -63,6 +67,8 @@ private:
 		uint32 action;
 		Common::Rect rect;
 	};
+
+	GameWindow *_gameWindow;
 
 	bool _fromInventory;
 	ActionButton _buttons[3];

--- a/engines/stark/ui/world/gamewindow.cpp
+++ b/engines/stark/ui/world/gamewindow.cpp
@@ -53,10 +53,20 @@ GameWindow::GameWindow(Gfx::Driver *gfx, Cursor *cursor, ActionMenu *actionMenu,
 	_visible = true;
 
 	_fadeRenderer = _gfx->createFadeRenderer();
+
+        _actionMenu->setGameWindow(this);
 }
 
 GameWindow::~GameWindow() {
 	delete _fadeRenderer;
+}
+
+Common::Rect GameWindow::getScaledPosition() const {
+        Common::Rect scaledPosition = Window::getScaledPosition();
+
+        scaledPosition.translate(0, Gfx::Driver::kTopBorderHeight);
+
+        return scaledPosition;
 }
 
 void GameWindow::onRender() {
@@ -148,7 +158,7 @@ void GameWindow::onClick(const Common::Point &pos) {
 
 	if (_objectUnderCursor) {
 		if (singlePossibleAction != -1) {
-			StarkGameInterface->itemDoActionAt(_objectUnderCursor, singlePossibleAction, _objectRelativePosition);
+                        StarkGameInterface->itemDoActionAt(_objectUnderCursor, singlePossibleAction, _objectRelativePosition);
 		} else if (selectedInventoryItem == -1) {
 			_actionMenu->open(_objectUnderCursor, _objectRelativePosition);
 		}

--- a/engines/stark/ui/world/gamewindow.h
+++ b/engines/stark/ui/world/gamewindow.h
@@ -42,6 +42,9 @@ public:
 	GameWindow(Gfx::Driver *gfx, Cursor *cursor, ActionMenu *actionMenu, InventoryWindow *inventory);
 	virtual ~GameWindow();
 
+        /** Get current scaled window position */
+        Common::Rect getScaledPosition() const;
+
 	/** Clear the location dependent state */
 	void reset();
 


### PR DESCRIPTION
Fix for #1397. 

Prevents the action menu from being partially rendered outside the game window by checking the cursor location and offsetting its position to force the action menu to render within the window boundaries.