### PR TITLE
Improve joystick usage

### DIFF
--- a/backends/events/sdl/resvm-sdl-events.cpp
+++ b/backends/events/sdl/resvm-sdl-events.cpp
@@ -25,24 +25,62 @@
 #if defined(SDL_BACKEND)
 
 #include "resvm-sdl-events.h"
+#include "graphics/cursorman.h"
+#include "engines/engine.h"
+
+// The maximum index of the joystick button to convert in mouse event
+#define JOY_TO_MOUSE_BUTTONS 1
 
 bool ResVmSdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
-	event.type = Common::EVENT_JOYBUTTON_DOWN;
-	event.joystick.button = ev.jbutton.button;
-	return true;
+	// Engine doesn't support joystick -> emulate mouse events
+	if (g_engine)
+		if (!g_engine->hasFeature(Engine::kSupportsJoystick))
+			return SdlEventSource::handleJoyButtonDown(ev, event);
+	
+	// If mouse cursor is visible, emulates standard buttons of joystick as mouse
+	if (CursorMan.isVisible() && (ev.jbutton.button < JOY_TO_MOUSE_BUTTONS)) {
+		return SdlEventSource::handleJoyButtonDown(ev, event);
+	}
+	else {
+		event.type = Common::EVENT_JOYBUTTON_DOWN;
+		event.joystick.button = ev.jbutton.button;
+		return true;
+	}
 }
 
 bool ResVmSdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
-	event.type = Common::EVENT_JOYBUTTON_UP;
-	event.joystick.button = ev.jbutton.button;
-	return true;
+	// Engine doesn't support joystick -> emulate mouse events
+	if (g_engine)
+		if (!g_engine->hasFeature(Engine::kSupportsJoystick))
+			return SdlEventSource::handleJoyButtonUp(ev, event);
+	
+	// If mouse cursor is visible, emulates standard buttons of joystick as mouse
+	if (CursorMan.isVisible() && (ev.jbutton.button < JOY_TO_MOUSE_BUTTONS)) {
+		return SdlEventSource::handleJoyButtonUp(ev, event);
+	}
+	else {
+		event.type = Common::EVENT_JOYBUTTON_UP;
+		event.joystick.button = ev.jbutton.button;
+		return true;
+	}
 }
 
 bool ResVmSdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
-	event.type = Common::EVENT_JOYAXIS_MOTION;
-	event.joystick.axis = ev.jaxis.axis;
-	event.joystick.position = ev.jaxis.value;
-	return true;
+	// Engine doesn't support joystick -> emulate mouse events
+	if (g_engine)
+			if (!g_engine->hasFeature(Engine::kSupportsJoystick))
+				return SdlEventSource::handleJoyAxisMotion(ev, event);
+	
+	// If mouse cursor is visible, emulates joystick movements as mouse
+	if (CursorMan.isVisible()) {
+		return SdlEventSource::handleJoyAxisMotion(ev, event);
+	}
+	else {
+		event.type = Common::EVENT_JOYAXIS_MOTION;
+		event.joystick.axis = ev.jaxis.axis;
+		event.joystick.position = ev.jaxis.value;
+		return true;
+	}
 }
 
 #endif

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -118,6 +118,12 @@ protected:
 	virtual bool handleKbdMouse(Common::Event &event);
 
 	//@}
+ 
+	/**
+	 * Checks if mouse is locked or not.
+	 * Avoid to emulate a mouse movement from joystick if locked.
+	 */
+	bool isMouseLocked();
 
 	/**
 	 * Assigns the mouse coords to the mouse event. Furthermore notify the

--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -92,9 +92,11 @@ Math::Rect2d ResVmSdlGraphicsManager::computeGameRect(GameRenderTarget gameRende
 	switch (gameRenderTarget) {
 		case kScreen:
 			// The game occupies the whole screen
+			_eventSource->resetKeyboardEmulation(effectiveWidth - 1, effectiveHeight - 1);
 			return Math::Rect2d(Math::Vector2d(0, 0), Math::Vector2d(1, 1));
 		case kSubScreen:
 			// The game is centered on the screen
+			_eventSource->resetKeyboardEmulation(effectiveWidth - 1, effectiveHeight - 1);
 			return Math::Rect2d(
 					Math::Vector2d((effectiveWidth - gameWidth) / 2, (effectiveHeight - gameHeight) / 2),
 					Math::Vector2d((effectiveWidth + gameWidth) / 2, (effectiveHeight + gameHeight) / 2)
@@ -105,12 +107,14 @@ Math::Rect2d ResVmSdlGraphicsManager::computeGameRect(GameRenderTarget gameRende
 				float scale = MIN(effectiveHeight / float(gameHeight), effectiveWidth / float(gameWidth));
 				float scaledW = scale * (gameWidth / float(effectiveWidth));
 				float scaledH = scale * (gameHeight / float(effectiveHeight));
+				_eventSource->resetKeyboardEmulation(effectiveWidth - 1, effectiveHeight - 1);
 				return Math::Rect2d(
 						Math::Vector2d(0.5 - (0.5 * scaledW), 0.5 - (0.5 * scaledH)),
 						Math::Vector2d(0.5 + (0.5 * scaledW), 0.5 + (0.5 * scaledH))
 				);
 			} else {
 				// The game occupies the whole screen
+				_eventSource->resetKeyboardEmulation(effectiveWidth - 1, effectiveHeight - 1);
 				return Math::Rect2d(Math::Vector2d(0, 0), Math::Vector2d(1, 1));
 			}
 		default:

--- a/common/EventMapper.cpp
+++ b/common/EventMapper.cpp
@@ -25,6 +25,9 @@
 #include "common/system.h"
 #include "common/textconsole.h"
 
+// The index of the joystick button associated to virtual keyboard
+#define JOY_BUT_VKEYBOARD 6
+
 namespace Common {
 
 List<Event> DefaultEventMapper::mapEvent(const Event &ev, EventSource *source) {
@@ -37,11 +40,13 @@ List<Event> DefaultEventMapper::mapEvent(const Event &ev, EventSource *source) {
 
 	static uint32 vkeybdThen = 0;
 
-	if (ev.type == EVENT_MBUTTONDOWN) {
+	if ((ev.type == EVENT_MBUTTONDOWN) || 
+            ((ev.type == EVENT_JOYBUTTON_DOWN) && (ev.joystick.button == JOY_BUT_VKEYBOARD))) {
 		vkeybdThen = g_system->getMillis();
 	}
 
-	if (ev.type == EVENT_MBUTTONUP) {
+	if ((ev.type == EVENT_MBUTTONUP) || 
+            ((ev.type == EVENT_JOYBUTTON_UP) && (ev.joystick.button == JOY_BUT_VKEYBOARD))) {
 		if ((g_system->getMillis() - vkeybdThen) >= vkeybdTime) {
 			mappedEvent.type = EVENT_VIRTUAL_KEYBOARD;
 

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -139,7 +139,14 @@ public:
 		 * The engine will need to read the actual resolution used by the
 		 * backend using OSystem::getWidth and OSystem::getHeight.
 		 */
-		kSupportsArbitraryResolutions // ResidualVM specific
+		kSupportsArbitraryResolutions, // ResidualVM specific
+		
+		/**
+		 * Engine must receive joystick events because the game uses them.
+		 * For engines which have not this feature, joystick events are converted
+		 * to mouse events.
+		 */
+		kSupportsJoystick
 	};
 
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1378,7 +1378,8 @@ void GrimEngine::clearEventQueue() {
 bool GrimEngine::hasFeature(EngineFeature f) const {
 	return
 		(f == kSupportsRTL) ||
-		(f == kSupportsLoadingDuringRuntime);
+		(f == kSupportsLoadingDuringRuntime) ||
+		(f == kSupportsJoystick);
 }
 
 void GrimEngine::pauseEngineIntern(bool pause) {


### PR DESCRIPTION
Improve joystick usage:
- configuration of engines natively supporting joystick or not
- for first category (GrimE), supports a special button from joystick to open the virtual keyboard,
  then emulates mouse from joystick to select keyboard keys
- for second category (Myst3), reuses ScummVM code to emulate mouse from joystick.
  A modification was also needed to support relative movements (needed in Myst3 to support camera movements)