### PR TITLE
STARK: Fixing the text resized problem on diary index menu

### DIFF
--- a/engines/stark/services/userinterface.cpp
+++ b/engines/stark/services/userinterface.cpp
@@ -245,6 +245,7 @@ const Graphics::Surface *UserInterface::getGameWindowThumbnail() const {
 
 void UserInterface::onScreenChanged() {
 	_gameScreen->onScreenChanged();
+	_diaryIndexScreen->onScreenChanged();
 }
 
 void UserInterface::notifyInventoryItemEnabled(uint16 itemIndex) {

--- a/engines/stark/ui/menu/diaryindex.cpp
+++ b/engines/stark/ui/menu/diaryindex.cpp
@@ -102,9 +102,9 @@ void DiaryIndexScreen::open() {
 	}
 }
 
-// Douglas' change
 void DiaryIndexScreen::onScreenChanged() {
 	for (uint i = 1; i < _widgets.size(); i++) {
+		// Force the texture to be reset by changing the color
 		if (_widgets[i]->containsText()) {
 			_widgets[i]->setTextColor(_textColorHovered);
 			_widgets[i]->setTextColor(_textColorDefault);

--- a/engines/stark/ui/menu/diaryindex.cpp
+++ b/engines/stark/ui/menu/diaryindex.cpp
@@ -102,6 +102,16 @@ void DiaryIndexScreen::open() {
 	}
 }
 
+// Douglas' change
+void DiaryIndexScreen::onScreenChanged() {
+	for (uint i = 1; i < _widgets.size(); i++) {
+		if (_widgets[i]->containsText()) {
+			_widgets[i]->setTextColor(_textColorHovered);
+			_widgets[i]->setTextColor(_textColorDefault);
+		}
+	}
+}
+
 void DiaryIndexScreen::widgetTextColorHandler(StaticLocationWidget &widget, const Common::Point &mousePos) {
 	if (widget.isVisible()) {
 		uint32 textColor = widget.isMouseInside(mousePos) ? _textColorHovered : _textColorDefault;

--- a/engines/stark/ui/menu/diaryindex.cpp
+++ b/engines/stark/ui/menu/diaryindex.cpp
@@ -104,11 +104,8 @@ void DiaryIndexScreen::open() {
 
 void DiaryIndexScreen::onScreenChanged() {
 	for (uint i = 1; i < _widgets.size(); i++) {
-		// Force the texture to be reset by changing the color
-		if (_widgets[i]->containsText()) {
-			_widgets[i]->setTextColor(_textColorHovered);
-			_widgets[i]->setTextColor(_textColorDefault);
-		}
+		// The background image is intentionally ignored
+		_widgets[i]->resetTextTexture();
 	}
 }
 

--- a/engines/stark/ui/menu/diaryindex.h
+++ b/engines/stark/ui/menu/diaryindex.h
@@ -38,7 +38,7 @@ public:
 	// StaticLocationScreen API
 	void open() override;
 
-	// Douglas' Change
+	// Called when the screen resolution changes to reset the text textures
 	void onScreenChanged();
 
 private:

--- a/engines/stark/ui/menu/diaryindex.h
+++ b/engines/stark/ui/menu/diaryindex.h
@@ -38,6 +38,9 @@ public:
 	// StaticLocationScreen API
 	void open() override;
 
+	// Douglas' Change
+	void onScreenChanged();
+
 private:
 	void widgetTextColorHandler(StaticLocationWidget &widget, const Common::Point &mousePos);
 	void backHandler();

--- a/engines/stark/ui/menu/locationscreen.cpp
+++ b/engines/stark/ui/menu/locationscreen.cpp
@@ -211,6 +211,11 @@ void StaticLocationWidget::setTextColor(uint32 textColor) {
 	text->setColor(textColor);
 }
 
+// Douglas' change
+bool StaticLocationWidget::containsText() {
+	return _renderEntry->getText();
+}
+
 void StaticLocationWidget::onMouseMove(const Common::Point &mousePos) {
 	if (_onMouseMove) {
 		(*_onMouseMove)(*this, mousePos);

--- a/engines/stark/ui/menu/locationscreen.cpp
+++ b/engines/stark/ui/menu/locationscreen.cpp
@@ -211,8 +211,11 @@ void StaticLocationWidget::setTextColor(uint32 textColor) {
 	text->setColor(textColor);
 }
 
-bool StaticLocationWidget::containsText() {
-	return _renderEntry->getText();
+void StaticLocationWidget::resetTextTexture() {
+	VisualText *text = _renderEntry->getText();
+	if (text) {
+		text->resetTexture();
+	}
 }
 
 void StaticLocationWidget::onMouseMove(const Common::Point &mousePos) {

--- a/engines/stark/ui/menu/locationscreen.cpp
+++ b/engines/stark/ui/menu/locationscreen.cpp
@@ -211,7 +211,6 @@ void StaticLocationWidget::setTextColor(uint32 textColor) {
 	text->setColor(textColor);
 }
 
-// Douglas' change
 bool StaticLocationWidget::containsText() {
 	return _renderEntry->getText();
 }

--- a/engines/stark/ui/menu/locationscreen.h
+++ b/engines/stark/ui/menu/locationscreen.h
@@ -92,6 +92,9 @@ public:
 	 */
 	void setTextColor(uint32 textColor);
 
+	// Douglas' Changed
+	bool containsText();
+
 	/** Draw the widget */
 	void render();
 

--- a/engines/stark/ui/menu/locationscreen.h
+++ b/engines/stark/ui/menu/locationscreen.h
@@ -92,8 +92,8 @@ public:
 	 */
 	void setTextColor(uint32 textColor);
 
-	/** Check weather the widget can call setTextColor() */
-	bool containsText();
+	/** For widget with no text visual, this function does nothing */
+	void resetTextTexture();
 
 	/** Draw the widget */
 	void render();

--- a/engines/stark/ui/menu/locationscreen.h
+++ b/engines/stark/ui/menu/locationscreen.h
@@ -92,7 +92,7 @@ public:
 	 */
 	void setTextColor(uint32 textColor);
 
-	// Douglas' Changed
+	/** Check weather the widget can call setTextColor() */
 	bool containsText();
 
 	/** Draw the widget */

--- a/engines/stark/visual/text.cpp
+++ b/engines/stark/visual/text.cpp
@@ -139,4 +139,9 @@ void VisualText::render(const Common::Point &position) {
 	_surfaceRenderer->render(_texture, position);
 }
 
+void VisualText::resetTexture() {
+	freeTexture();
+	createTexture();
+}
+
 } // End of namespace Stark

--- a/engines/stark/visual/text.h
+++ b/engines/stark/visual/text.h
@@ -56,6 +56,7 @@ public:
 	void setFont(FontProvider::FontType type, int32 customFontIndex = -1);
 
 	void render(const Common::Point &position);
+	void resetTexture();
 
 private:
 	void createTexture();


### PR DESCRIPTION
Fix the issue #1402.

I want to change as less code as possible, which was a little bit hard since all the functions related to resetting text texture are encapsulated, so I did in an indirect way. I "forced" the render entry to reset the texture by changing the text color to another and then change it back. Also I had to add a function on StaticLocationWidget to check whether it is safe to call the setTextColor function.

Honestly all these are not that ideal from my perspective. It would be a lot more elegant if I can add some other functions or use friend function, but I am afraid that this will violate the original encapsulation.