### PR TITLE
STARK: Add right-click dialog speech skipping

### DIFF
--- a/engines/stark/ui/world/dialogpanel.cpp
+++ b/engines/stark/ui/world/dialogpanel.cpp
@@ -63,7 +63,19 @@ DialogPanel::DialogPanel(Gfx::Driver *gfx, Cursor *cursor) :
 
 DialogPanel::~DialogPanel() {
 	clearOptions();
+	clearSubtitleVisual();
+}
+
+void DialogPanel::clearCurrentSpeech() {
+	if (_currentSpeech) {
+		_currentSpeech->stop();
+		_currentSpeech = nullptr;
+	}
+}
+
+void DialogPanel::clearSubtitleVisual() {
 	delete _subtitleVisual;
+	_subtitleVisual = nullptr;
 }
 
 void DialogPanel::clearOptions() {
@@ -109,8 +121,7 @@ void DialogPanel::onRender() {
 	if (!_currentSpeech || !_currentSpeech->isPlaying()) {
 		_currentSpeech = nullptr;
 
-		delete _subtitleVisual;
-		_subtitleVisual = nullptr;
+		clearSubtitleVisual();
 	}
 
 	// Update the dialog engine
@@ -143,7 +154,7 @@ void DialogPanel::onRender() {
 }
 
 void DialogPanel::updateSubtitleVisual() {
-	delete _subtitleVisual;
+	clearSubtitleVisual();
 
 	uint32 color = _otherColor;
 	if (_currentSpeech->characterIsApril())
@@ -193,15 +204,16 @@ void DialogPanel::onClick(const Common::Point &pos) {
 	}
 }
 
-void DialogPanel::reset() {
-	if (_currentSpeech) {
-		_currentSpeech->stop();
-		_currentSpeech = nullptr;
+void DialogPanel::onRightClick(const Common::Point &pos) {
+	if (_currentSpeech && _currentSpeech->isPlaying()) {
+		clearCurrentSpeech();
+		clearSubtitleVisual();
 	}
+}
 
-	delete _subtitleVisual;
-	_subtitleVisual = nullptr;
-
+void DialogPanel::reset() {
+	clearCurrentSpeech();
+	clearSubtitleVisual();
 	clearOptions();
 
 	StarkDialogPlayer->reset();

--- a/engines/stark/ui/world/dialogpanel.h
+++ b/engines/stark/ui/world/dialogpanel.h
@@ -55,10 +55,12 @@ public:
 protected:
 	void onMouseMove(const Common::Point &pos) override;
 	void onClick(const Common::Point &pos) override;
+	void onRightClick(const Common::Point &pos) override;
 	void onRender() override;
 
 private:
 	void updateSubtitleVisual();
+	void clearSubtitleVisual();
 	void updateDialogOptions();
 	void clearOptions();
 	int getHoveredOption(const Common::Point &pos);
@@ -79,6 +81,7 @@ private:
 	Common::Rect _scrollDownArrowRect;
 
 	Resources::Speech *_currentSpeech;
+	void clearCurrentSpeech();
 
 	uint32 _firstVisibleOption;
 	Common::Array<ClickText*> _options;


### PR DESCRIPTION
You can skip speech lines talked by game characters showed in dialogPanel with a mouse right-click