### PR TITLE
MYST3: Add Autosave Support

### DIFF
--- a/engines/myst3/menu.cpp
+++ b/engines/myst3/menu.cpp
@@ -209,7 +209,8 @@ int16 GamepadDialog::update() {
 
 Menu::Menu(Myst3Engine *vm) :
 		_vm(vm),
-		_saveLoadSpotItem(0) {
+		_saveLoadSpotItem(0),
+		_thumbnailValid(false) {
 }
 
 Menu::~Menu() {
@@ -295,6 +296,23 @@ void Menu::updateMainMenu(uint16 action) {
 	}
 }
 
+void Menu::saveThumbnail() {
+	// ... and capture the screen
+	Graphics::Surface *big = _vm->_gfx->getScreenshot();
+	Graphics::Surface *thumb = createThumbnail(big);
+	_vm->_state->setSaveThumbnail(thumb);
+	big->free();
+	delete big;
+}
+
+bool Menu::getThumbnailValid() {
+	return _thumbnailValid;
+}
+
+void Menu::setThumbnailValid(bool valid) {
+	_thumbnailValid = valid;
+}
+
 void Menu::goToNode(uint16 node) {
 	if (_vm->_state->getMenuSavedAge() == 0 && _vm->_state->getLocationRoom() != 901) {
 		// Entering menu, save current location ...
@@ -302,12 +320,8 @@ void Menu::goToNode(uint16 node) {
 		_vm->_state->setMenuSavedRoom(_vm->_state->getLocationRoom());
 		_vm->_state->setMenuSavedNode(_vm->_state->getLocationNode());
 
-		// ... and capture the screen
-		Graphics::Surface *big = _vm->_gfx->getScreenshot();
-		Graphics::Surface *thumb = createThumbnail(big);
-		_vm->_state->setSaveThumbnail(thumb);
-		big->free();
-		delete big;
+		saveThumbnail();
+		_thumbnailValid = true;
 
 		// Reset some sound variables
 		if (_vm->_state->getLocationAge() == 6 && _vm->_state->getSoundEdannaUnk587() == 1 && _vm->_state->getSoundEdannaUnk1031()) {
@@ -614,7 +628,7 @@ void PagingMenu::saveMenuSave() {
 	// Save the state and the thumbnail
 	Common::OutSaveFile *save = _vm->getSaveFileManager()->openForSaving(fileName);
 	_vm->_state->setSaveDescription(_saveName);
-	_vm->_state->save(save);
+	_vm->_state->save(save,false);
 	delete save;
 
 	// Do next action
@@ -953,7 +967,7 @@ void AlbumMenu::saveMenuSave() {
 	// Save the state and the thumbnail
 	Common::OutSaveFile *save = _vm->getSaveFileManager()->openForSaving(fileName);
 	_vm->_state->setSaveDescription(saveName);
-	_vm->_state->save(save);
+	_vm->_state->save(save,false);
 	delete save;
 
 	// Do next action

--- a/engines/myst3/menu.h
+++ b/engines/myst3/menu.h
@@ -63,6 +63,12 @@ public:
 
 	void updateMainMenu(uint16 action);
 	void goToNode(uint16 node);
+	/*
+	*  Grab a screenshot save it to state and free memory
+	*/
+	void saveThumbnail();
+	bool getThumbnailValid();
+	void setThumbnailValid(bool value);
 
 	virtual void saveLoadAction(uint16 action, uint16 item) = 0;
 	virtual void setSaveLoadSpotItem(uint16 id, SpotItemFace *spotItem);
@@ -72,6 +78,8 @@ protected:
 
 	SpotItemFace *_saveLoadSpotItem;
 	Common::String _saveLoadAgeName;
+
+	bool _thumbnailValid;
 
 	uint dialogIdFromType(DialogType type);
 	uint16 dialogConfirmValue();

--- a/engines/myst3/myst3.h
+++ b/engines/myst3/myst3.h
@@ -119,7 +119,10 @@ public:
 	uint32 getGameLocalizationType() const;
 	bool isWideScreenModEnabled() const;
 
+	bool canSaveGameStateCurrently() override; // Determines autosave saveability
 	bool canLoadGameStateCurrently() override;
+	bool canSaveCurrently() override; // Determines GMM saveability
+	void tryAutoSaving();
 	Common::Error loadGameState(int slot) override;
 	Common::Error loadGameState(Common::String fileName, TransitionType transition);
 
@@ -218,6 +221,8 @@ private:
 	bool _inputTildePressed;
 
 	bool _interactive;
+
+	uint32 _lastSaveTime;
 
 	uint32 _backgroundSoundScriptLastRoomId;
 

--- a/engines/myst3/state.h
+++ b/engines/myst3/state.h
@@ -53,7 +53,13 @@ public:
 
 	void newGame();
 	bool load(Common::InSaveFile *saveFile);
-	bool save(Common::OutSaveFile *saveFile);
+	bool save(Common::OutSaveFile *saveFile, bool autosave);
+
+	/*
+	* Autosaving will be enabled if The autosave file is an autosave or if The autosave file doesn't exist
+	* The autosave file name is version dependent (PC vs. Xbox)
+	*/
+	bool isAutoSaveAllowed(Common::InSaveFile *saveFile);
 
 	int32 getVar(uint16 var);
 	void setVar(uint16 var, int32 value);
@@ -338,6 +344,7 @@ public:
 	void setSaveThumbnail(Graphics::Surface *thumb);
 	Common::String formatSaveTime();
 	void setSaveDescription(const Common::String &description) { _data.saveDescription = description; }
+	const Common::String getSaveDescription() { return _data.saveDescription; }	
 
 	Common::Array<uint16> getInventory();
 	void updateInventory(const Common::Array<uint16> &items);
@@ -379,6 +386,7 @@ public:
 
 		uint8 saveHour;
 		uint8 saveMinute;
+		bool autoSave;
 
 		Common::String saveDescription;
 
@@ -397,7 +405,7 @@ private:
 	const Common::Platform _platform;
 	Database *_db;
 
-	static const uint32 kSaveVersion = 149;
+	static const uint32 kSaveVersion = 150;
 
 	StateData _data;
 


### PR DESCRIPTION
Autosave is enabled and saved to Autosave.M3S
if that file doesn't exist or is an autosave.

Autosave is done on exit or based on the save
interval specified in the config file.