### PR TITLE
MYST3: Turn roomID into an enum

### DIFF
--- a/engines/myst3/console.cpp
+++ b/engines/myst3/console.cpp
@@ -57,7 +57,7 @@ void Console::describeScript(const Common::Array<Opcode> &script) {
 
 bool Console::Cmd_Infos(int argc, const char **argv) {
 	uint16 nodeId = _vm->_state->getLocationNode();
-	uint32 roomId = _vm->_state->getLocationRoom();
+	RoomID roomId = (RoomID)_vm->_state->getLocationRoom();
 	uint32 ageID = _vm->_state->getLocationAge();
 
 	if (argc >= 2) {
@@ -178,12 +178,12 @@ bool Console::Cmd_Var(int argc, const char **argv) {
 }
 
 bool Console::Cmd_ListNodes(int argc, const char **argv) {
-	uint32 roomID = _vm->_state->getLocationRoom();
+	RoomID roomID = (RoomID)_vm->_state->getLocationRoom();
 	uint32 ageID = _vm->_state->getLocationAge();
 
 	if (argc == 2) {
 		RoomKey roomKey = _vm->_db->getRoomKey(argv[1]);
-		if (roomKey.roomID == 0 || roomKey.ageID == 0) {
+		if (roomKey.roomID == kNoRoom || roomKey.ageID == 0) {
 			debugPrintf("Unknown room name %s\n", argv[1]);
 			return true;
 		}
@@ -204,7 +204,7 @@ bool Console::Cmd_ListNodes(int argc, const char **argv) {
 
 bool Console::Cmd_Run(int argc, const char **argv) {
 	uint16 nodeId = _vm->_state->getLocationNode();
-	uint32 roomId = _vm->_state->getLocationRoom();
+	RoomID roomId = (RoomID)_vm->_state->getLocationRoom();
 	uint32 ageId = _vm->_state->getLocationAge();
 
 	if (argc >= 2) {

--- a/engines/myst3/database.cpp
+++ b/engines/myst3/database.cpp
@@ -372,70 +372,70 @@ NodeWalker::~NodeWalker() {
 }
 
 static const RoomData roomsXXXX[] = {
-		{ 101, "XXXX" }
+		{ kINIT, "XXXX" }
 };
 
 static const RoomData roomsINTR[] = {
-		{ 201, "INTR" }
+		{ kINTR, "INTR" }
 };
 
 static const RoomData roomsTOHO[] = {
-		{ 301, "TOHO" }
+		{ kTOHO, "TOHO" }
 };
 
 static const RoomData roomsTOHB[] = {
-		{ 401, "TOHB" }
+		{ kTOHB, "TOHB" }
 };
 
 static const RoomData roomsLE[] = {
-		{ 501, "LEIS" },
-		{ 502, "LEOS" },
-		{ 503, "LEET" },
-		{ 504, "LELT" },
-		{ 505, "LEMT" },
-		{ 506, "LEOF" }
+		{ kLEIS, "LEIS" },
+		{ kLEOS, "LEOS" },
+		{ kLEET, "LEET" },
+		{ kLELT, "LELT" },
+		{ kLEMT, "LEMT" },
+		{ kLEOF, "LEOF" }
 };
 
 static const RoomData roomsLI[] = {
-		{ 601, "LIDR" },
-		{ 602, "LISW" },
-		{ 603, "LIFO" },
-		{ 604, "LISP" },
-		{ 605, "LINE" }
+		{ kLIDR, "LIDR" },
+		{ kLISW, "LISW" },
+		{ kLIFO, "LIFO" },
+		{ kLISP, "LISP" },
+		{ kLINE, "LINE" }
 };
 
 static const RoomData roomsEN[] = {
-		{ 701, "ENSI" },
-		{ 703, "ENPP" },
-		{ 704, "ENEM" },
-		{ 705, "ENLC" },
-		{ 706, "ENDD" },
-		{ 707, "ENCH" },
-		{ 708, "ENLI" }
+		{ kENSI, "ENSI" },
+		{ kENPP, "ENPP" },
+		{ kENEM, "ENEM" },
+		{ kENLC, "ENLC" },
+		{ kENDD, "ENDD" },
+		{ kENCH, "ENCH" },
+		{ kENLI, "ENLI" }
 };
 
 static const RoomData roomsNA[] = {
-		{ 801, "NACH" }
+		{ kNACH, "NACH" }
 };
 
 static const RoomData roomsMENU[] = {
-		{ 901, "MENU" },
-		{ 902, "JRNL" },
-		{ 903, "DEMO" },
-		{ 904, "ATIX" }
+		{ kMENU, "MENU" },
+		{ kJRNL, "JRNL" },
+		{ kDEMO, "DEMO" },
+		{ kATIX, "ATIX" }
 };
 
 static const RoomData roomsMA[] = {
-		{ 1001, "MACA" },
-		{ 1002, "MAIS" },
-		{ 1003, "MALL" },
-		{ 1004, "MASS" },
-		{ 1005, "MAWW" },
-		{ 1006, "MATO" }
+		{ kMACA, "MACA" },
+		{ kMAIS, "MAIS" },
+		{ kMALL, "MALL" },
+		{ kMASS, "MASS" },
+		{ kMAWW, "MAWW" },
+		{ kMATO, "MATO" }
 };
 
 static const RoomData roomsLOGO[] = {
-		{ 1101, "LOGO" }
+		{ kLOGO, "LOGO" }
 };
 
 const AgeData Database::_ages[] = {
@@ -514,15 +514,15 @@ void Database::preloadCommonRooms() {
 		for (uint j = 0; j < age.roomCount; j++) {
 			const RoomData &room = age.rooms[j];
 
-			if (isCommonRoom(room.id, age.id)) {
+			if (isCommonRoom(static_cast<RoomID>(room.id), age.id)) {
 				Common::Array<NodePtr> nodes = readRoomScripts(&room);
-				_roomNodesCache.setVal(RoomKey(room.id, age.id), nodes);
+				_roomNodesCache.setVal(RoomKey(static_cast<RoomID>(room.id), age.id), nodes);
 			}
 		}
 	}
 }
 
-Common::Array<NodePtr> Database::getRoomNodes(uint32 roomID, uint32 ageID) const {
+Common::Array<NodePtr> Database::getRoomNodes(RoomID roomID, uint32 ageID) const {
 	Common::Array<NodePtr> nodes;
 
 	if (_roomNodesCache.contains(RoomKey(roomID, ageID))) {
@@ -535,7 +535,7 @@ Common::Array<NodePtr> Database::getRoomNodes(uint32 roomID, uint32 ageID) const
 	return nodes;
 }
 
-Common::Array<uint16> Database::listRoomNodes(uint32 roomID, uint32 ageID) {
+Common::Array<uint16> Database::listRoomNodes(RoomID roomID, uint32 ageID) {
 	Common::Array<NodePtr> nodes;
 	Common::Array<uint16> list;
 
@@ -548,7 +548,7 @@ Common::Array<uint16> Database::listRoomNodes(uint32 roomID, uint32 ageID) {
 	return list;
 }
 
-NodePtr Database::getNodeData(uint16 nodeID, uint32 roomID, uint32 ageID) {
+NodePtr Database::getNodeData(uint16 nodeID, RoomID roomID, uint32 ageID) {
 	Common::Array<NodePtr> nodes = getRoomNodes(roomID, ageID);
 
 	for (uint i = 0; i < nodes.size(); i++) {
@@ -578,7 +578,7 @@ void Database::initializeZipBitIndexTable() {
 	}
 }
 
-int32 Database::getNodeZipBitIndex(uint16 nodeID, uint32 roomID, uint32 ageID) {
+int32 Database::getNodeZipBitIndex(uint16 nodeID, RoomID roomID, uint32 ageID) {
 	if (!_roomZipBitIndex.contains(roomID)) {
 		error("Unable to find zip-bit index for room %d", roomID);
 	}
@@ -594,11 +594,11 @@ int32 Database::getNodeZipBitIndex(uint16 nodeID, uint32 roomID, uint32 ageID) {
 	error("Unable to find zip-bit index for node (%d, %d)", nodeID, roomID);
 }
 
-const RoomData *Database::findRoomData(uint32 roomID, uint32 ageID) const {
+const RoomData *Database::findRoomData(RoomID roomID, uint32 ageID) const {
 	for (uint i = 0; i < ARRAYSIZE(_ages); i++) {
 		if (_ages[i].id == ageID) {
 			for (uint j = 0; j < _ages[i].roomCount; j++) {
-				if (_ages[i].rooms[j].id == roomID) {
+				if (_ages[i].rooms[j].id == static_cast<uint16>(roomID)) {
 					return &_ages[i].rooms[j];
 				}
 			}
@@ -686,11 +686,11 @@ void Database::patchNodeScripts(const RoomData *room, Common::Array<NodePtr> &no
 	}
 }
 
-bool Database::isCommonRoom(uint32 roomID, uint32 ageID) const {
-	return roomID == 101 || roomID == 901 || roomID == 902;
+bool Database::isCommonRoom(RoomID roomID, uint32 ageID) const {
+	return roomID == kINIT || roomID == kMENU || roomID == kJRNL;
 }
 
-void Database::cacheRoom(uint32 roomID, uint32 ageID) {
+void Database::cacheRoom(RoomID roomID, uint32 ageID) {
 	if (_roomNodesCache.contains(RoomKey(roomID, ageID))) {
 		return;
 	}
@@ -710,7 +710,7 @@ void Database::cacheRoom(uint32 roomID, uint32 ageID) {
 	_roomNodesCache.setVal(RoomKey(roomID, ageID), readRoomScripts(currentRoomData));
 }
 
-Common::String Database::getRoomName(uint32 roomID, uint32 ageID) const {
+Common::String Database::getRoomName(RoomID roomID, uint32 ageID) const {
 	const RoomData *data = findRoomData(roomID, ageID);
 	return data->name;
 }
@@ -719,11 +719,11 @@ RoomKey Database::getRoomKey(const char *name) {
 	for (uint i = 0; i < ARRAYSIZE(_ages); i++)
 		for (uint j = 0; j < _ages[i].roomCount; j++) {
 			if (scumm_stricmp(_ages[i].rooms[j].name, name) == 0) {
-				return RoomKey(_ages[i].rooms[j].id, _ages[i].id);
+				return RoomKey(static_cast<RoomID>(_ages[i].rooms[j].id), _ages[i].id);
 			}
 		}
 
-	return RoomKey(0, 0);
+	return RoomKey(kNoRoom, 0);
 }
 
 uint32 Database::getAgeLabelId(uint32 ageID) {
@@ -864,7 +864,7 @@ void Database::patchLanguageMenu() {
 	//	op 194, runPuzzle1 ( 18 )
 	//	op 194, runPuzzle1 ( 19 )
 
-	NodePtr languageMenu = getNodeData(530, 901, 9);
+	NodePtr languageMenu = getNodeData(530, kMENU, 9);
 	languageMenu->hotspots[5].script[1].args[1] = getGameLanguageCode();
 }
 

--- a/engines/myst3/database.h
+++ b/engines/myst3/database.h
@@ -23,15 +23,18 @@
 #ifndef DATABASE_H_
 #define DATABASE_H_
 
-#include "common/scummsys.h"
+
 #include "engines/myst3/hotspot.h"
-#include "common/str.h"
+#include "engines/myst3/myst3.h" // RoomID enum
+
+#include "common/array.h"
+#include "common/hashmap.h"
 #include "common/language.h"
 #include "common/platform.h"
 #include "common/ptr.h"
-#include "common/array.h"
-#include "common/hashmap.h"
 #include "common/stream.h"
+#include "common/scummsys.h"
+#include "common/str.h"
 
 namespace Myst3 {
 
@@ -65,18 +68,18 @@ struct NodeData {
 typedef Common::SharedPtr<NodeData> NodePtr;
 
 struct RoomData {
-	uint32 id;
+	uint16 id;
 	const char *name;
 };
 
 struct RoomKey {
 	uint16 ageID;
-	uint16 roomID;
+	RoomID roomID;
 
-	RoomKey(uint16 room, uint16 age) : roomID(room), ageID(age) {};
+	RoomKey(RoomID room, uint16 age) : roomID(room), ageID(age) {};
 
 	bool operator==(const RoomKey &k) const {
-		return ageID == k.ageID && roomID == k.roomID;
+		return ageID == k.ageID && static_cast<uint16>(roomID) == k.roomID;
 	}
 };
 
@@ -126,24 +129,24 @@ public:
 	/**
 	 * Loads a room's nodes into the database cache
 	 */
-	void cacheRoom(uint32 roomID, uint32 ageID);
+	void cacheRoom(RoomID roomID, uint32 ageID);
 
 	/**
 	 * Tells if a room is a common room
 	 *
 	 * Common rooms are always in the cache
 	 */
-	bool isCommonRoom(uint32 roomID, uint32 ageID) const;
+	bool isCommonRoom(RoomID roomID, uint32 ageID) const;
 
 	/**
 	 * Returns a node's hotspots and scripts from the currently loaded room
 	 */
-	NodePtr getNodeData(uint16 nodeID, uint32 roomID, uint32 ageID);
+	NodePtr getNodeData(uint16 nodeID, RoomID roomID, uint32 ageID);
 
 	/**
 	 * Returns a node's zip id, as used by savestates
 	 */
-	int32 getNodeZipBitIndex(uint16 nodeID, uint32 roomID, uint32 ageID);
+	int32 getNodeZipBitIndex(uint16 nodeID, RoomID roomID, uint32 ageID);
 
 	/**
 	 * Returns the generic node init script
@@ -153,7 +156,7 @@ public:
 	/**
 	 * Returns the name of the currently loaded room
 	 */
-	Common::String getRoomName(uint32 roomID, uint32 ageID) const;
+	Common::String getRoomName(RoomID roomID, uint32 ageID) const;
 
 	/**
 	 * Returns the id of a room from its name
@@ -163,7 +166,7 @@ public:
 	/**
 	 * Returns the list of the nodes of a room
 	 */
-	Common::Array<uint16> listRoomNodes(uint32 roomID, uint32 ageID);
+	Common::Array<uint16> listRoomNodes(RoomID roomID, uint32 ageID);
 
 	/**
 	 * Returns an age's label id, to be used with AGES 1000 metadata
@@ -211,8 +214,8 @@ private:
 	Common::Array<RoomScripts> _roomScriptsIndex;
 	int32 _roomScriptsStartOffset;
 
-	const RoomData *findRoomData(uint32 roomID, uint32 ageID) const;
-	Common::Array<NodePtr> getRoomNodes(uint32 roomID, uint32 ageID) const;
+	const RoomData *findRoomData(RoomID roomID, uint32 ageID) const;
+	Common::Array<NodePtr> getRoomNodes(RoomID roomID, uint32 ageID) const;
 
 	Common::Array<NodePtr> readRoomScripts(const RoomData *room) const;
 	void preloadCommonRooms();

--- a/engines/myst3/hotspot.cpp
+++ b/engines/myst3/hotspot.cpp
@@ -151,7 +151,7 @@ int32 HotSpot::isZipDestinationAvailable(GameState *state) {
 	assert(isZip() && script.size() != 0);
 
 	uint16 node;
-	uint16 room = state->getLocationRoom();
+	RoomID room = static_cast<RoomID>(state->getLocationRoom());
 	uint32 age = state->getLocationAge();
 
 	// Get the zip destination from the script
@@ -164,7 +164,7 @@ int32 HotSpot::isZipDestinationAvailable(GameState *state) {
 	case 141:
 	case 143:
 		node = op.args[1];
-		room = op.args[0];
+		room = static_cast<RoomID>(op.args[0]);
 		break;
 	default:
 		error("Expected zip action");

--- a/engines/myst3/inventory.cpp
+++ b/engines/myst3/inventory.cpp
@@ -210,22 +210,22 @@ void Inventory::useItem(uint16 var) {
 	case 277: // Atrus
 		closeAllBooks();
 		_vm->_state->setJournalAtrusState(2);
-		openBook(9, 902, 100);
+		openBook(9, kJRNL, 100);
 		break;
 	case 279: // Saavedro
 		closeAllBooks();
 		_vm->_state->setJournalSaavedroState(2);
-		openBook(9, 902, 200);
+		openBook(9, kJRNL, 200);
 		break;
 	case 480: // Tomahna
 		closeAllBooks();
 		_vm->_state->setBookStateTomahna(2);
-		openBook(8, 801, 220);
+		openBook(8, kNACH, 220);
 		break;
 	case 481: // Releeshahn
 		closeAllBooks();
 		_vm->_state->setBookStateReleeshahn(2);
-		openBook(9, 902, 300);
+		openBook(9, kJRNL, 300);
 		break;
 	case 345:
 		_vm->dragSymbol(345, 1002);
@@ -252,15 +252,15 @@ void Inventory::closeAllBooks() {
 		_vm->_state->setBookStateReleeshahn(1);
 }
 
-void Inventory::openBook(uint16 age, uint16 room, uint16 node) {
+void Inventory::openBook(uint16 age, RoomID room, uint16 node) {
 	if (!_vm->_state->getBookSavedNode()) {
 		_vm->_state->setBookSavedAge(_vm->_state->getLocationAge());
-		_vm->_state->setBookSavedRoom(_vm->_state->getLocationRoom());
+		_vm->_state->setBookSavedRoom(static_cast<uint16>(_vm->_state->getLocationRoom()));
 		_vm->_state->setBookSavedNode(_vm->_state->getLocationNode());
 	}
 
 	_vm->_state->setLocationNextAge(age);
-	_vm->_state->setLocationNextRoom(room);
+	_vm->_state->setLocationNextRoom(static_cast<uint16>(room));
 	_vm->goToNode(node, kTransitionFade);
 }
 
@@ -269,7 +269,7 @@ void Inventory::addSaavedroChapter(uint16 var) {
 	_vm->_state->setJournalSaavedroState(2);
 	_vm->_state->setJournalSaavedroChapter(var - 285);
 	_vm->_state->setJournalSaavedroPageInChapter(0);
-	openBook(9, 902, 200);
+	openBook(9, kJRNL, 200);
 }
 
 void Inventory::loadFromState() {

--- a/engines/myst3/inventory.h
+++ b/engines/myst3/inventory.h
@@ -28,12 +28,12 @@
 #include "common/rect.h"
 
 #include "engines/myst3/gfx.h"
+#include "engines/myst3/myst3.h"
 
 #include "video/bink_decoder.h"
 
 namespace Myst3 {
 
-class Myst3Engine;
 class Texture;
 
 class Inventory : public Window {
@@ -94,7 +94,7 @@ private:
 
 	bool hasItem(uint16 var);
 
-	void openBook(uint16 age, uint16 room, uint16 node);
+	void openBook(uint16 age, RoomID room, uint16 node);
 	void closeAllBooks();
 };
 

--- a/engines/myst3/menu.cpp
+++ b/engines/myst3/menu.cpp
@@ -267,7 +267,7 @@ void Menu::updateMainMenu(uint16 action) {
 	case 4:
 		// Settings
 		_vm->_state->setMenuOptionsBack(1);
-		_vm->runScriptsFromNode(599, 0, 0);
+		_vm->runScriptsFromNode(599, kNoRoom, 0);
 		break;
 	case 5: {
 			// Asked to quit
@@ -305,7 +305,8 @@ Graphics::Surface *Menu::captureThumbnail() {
 }
 
 void Menu::goToNode(uint16 node) {
-	if (_vm->_state->getMenuSavedAge() == 0 && _vm->_state->getLocationRoom() != 901) {
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
+	if (_vm->_state->getMenuSavedAge() == 0 && room != kMENU) {
 		// Entering menu, save current location ...
 		_vm->_state->setMenuSavedAge(_vm->_state->getLocationAge());
 		_vm->_state->setMenuSavedRoom(_vm->_state->getLocationRoom());
@@ -336,7 +337,7 @@ void Menu::goToNode(uint16 node) {
 	}
 
 	_vm->_state->setLocationNextAge(9);
-	_vm->_state->setLocationNextRoom(901);
+	_vm->_state->setLocationNextRoom(static_cast<uint16>(kMENU));
 	_vm->goToNode(node, kTransitionNone);
 }
 
@@ -391,8 +392,8 @@ uint16 Menu::dialogSaveValue() {
 
 Common::String Menu::getAgeLabel(GameState *gameState) {
 	uint32 age = 0;
-	uint32 room = gameState->getLocationRoom();
-	if (room == 901)
+	RoomID room = static_cast<RoomID>(gameState->getLocationRoom());
+	if (room == kMENU)
 		age = gameState->getMenuSavedAge();
 	else
 		age = gameState->getLocationAge();
@@ -441,7 +442,8 @@ void Menu::setSaveLoadSpotItem(uint16 id, SpotItemFace *spotItem) {
 }
 
 bool Menu::isOpen() const {
-	return _vm->_state->getLocationAge() == 9 && _vm->_state->getLocationRoom() == 901;
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
+	return _vm->_state->getLocationAge() == 9 && room == kMENU;
 }
 
 Graphics::Surface *Menu::borrowSaveThumbnail() {
@@ -670,10 +672,10 @@ void PagingMenu::saveLoadErase() {
 
 void PagingMenu::draw() {
 	uint16 node = _vm->_state->getLocationNode();
-	uint16 room = _vm->_state->getLocationRoom();
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
 	uint16 age = _vm->_state->getLocationAge();
 
-	if (room != 901 || !(node == 200 || node == 300))
+	if (room != kMENU || !(node == 200 || node == 300))
 		return;
 
 	int16 page = _vm->_state->getMenuSaveLoadCurrentPage();
@@ -720,10 +722,10 @@ void PagingMenu::draw() {
 
 bool PagingMenu::handleInput(const Common::KeyState &e) {
 	uint16 node = _vm->_state->getLocationNode();
-	uint16 room = _vm->_state->getLocationRoom();
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
 	uint16 item = _vm->_state->getMenuSaveLoadSelectedItem();
 
-	if (room != 901 || node != 300 || item != 7)
+	if (room != kMENU || node != 300 || item != 7)
 		return false;
 
 	Common::String display = prepareSaveNameForDisplay(_saveName);
@@ -783,10 +785,10 @@ AlbumMenu::~AlbumMenu() {
 
 void AlbumMenu::draw() {
 	uint16 node = _vm->_state->getLocationNode();
-	uint16 room = _vm->_state->getLocationRoom();
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
 
 	// Load and save menus only
-	if (room != 901 || !(node == 200 || node == 300))
+	if (room != kMENU || !(node == 200 || node == 300))
 		return;
 
 	if (!_saveLoadAgeName.empty()) {
@@ -892,10 +894,10 @@ void AlbumMenu::loadMenuOpen() {
 
 void AlbumMenu::loadMenuSelect() {
 	uint16 node = _vm->_state->getLocationNode();
-	uint16 room = _vm->_state->getLocationRoom();
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
 
 	// Details are only updated on the load menu
-	if (room != 901 || node != 200)
+	if (room != kMENU || node != 200)
 		return;
 
 	int32 selectedSave = _vm->_state->getMenuSelectedSave();

--- a/engines/myst3/myst3.h
+++ b/engines/myst3/myst3.h
@@ -58,6 +58,44 @@ enum TransitionType {
 	kTransitionRightToLeft
 };
 
+enum RoomID {
+	kNoRoom = 0,
+	kINIT = 101, // XXXX
+	kINTR = 201,
+	kTOHO = 301,
+	kTOHB = 401,
+	kLEIS = 501,
+	kLEOS = 502,
+	kLEET = 503,
+	kLELT = 504,
+	kLEMT = 505,
+	kLEOF = 506,
+	kLIDR = 601,
+	kLISW = 602,
+	kLIFO = 603,
+	kLISP = 604,
+	kLINE = 605,
+	kENSI = 701,
+	kENPP = 703,
+	kENEM = 704,
+	kENLC = 705,
+	kENDD = 706,
+	kENCH = 707,
+	kENLI = 708,
+	kNACH = 801, // Narayan
+	kMENU = 901, // There is a kMenu already
+	kJRNL = 902,
+	kDEMO = 903,
+	kATIX = 904,
+	kMACA = 1001,
+	kMAIS = 1002, //Amateria ambient sound
+	kMALL = 1003, //Amateria movie counters
+	kMASS = 1004,
+	kMAWW = 1005,
+	kMATO = 1006,
+	kLOGO = 1101
+};
+
 class Archive;
 class Console;
 class Drawable;
@@ -134,7 +172,7 @@ public:
 	static Graphics::Surface *decodeJpeg(const DirectorySubEntry *jpegDesc);
 
 	void goToNode(uint16 nodeID, TransitionType transition);
-	void loadNode(uint16 nodeID, uint32 roomID = 0, uint32 ageID = 0);
+	void loadNode(uint16 nodeID, RoomID roomID = kNoRoom, uint32 ageID = 0);
 	void unloadNode();
 	void loadNodeCubeFaces(uint16 nodeID);
 	void loadNodeFrame(uint16 nodeID);
@@ -149,8 +187,8 @@ public:
 
 	void runNodeInitScripts();
 	void runNodeBackgroundScripts();
-	void runScriptsFromNode(uint16 nodeID, uint32 roomID = 0, uint32 ageID = 0);
-	void runBackgroundSoundScriptsFromNode(uint16 nodeID, uint32 roomID = 0, uint32 ageID = 0);
+	void runScriptsFromNode(uint16 nodeID, RoomID roomID = kNoRoom, uint32 ageID = 0);
+	void runBackgroundSoundScriptsFromNode(uint16 nodeID, RoomID roomID = kNoRoom, uint32 ageID = 0);
 	void runAmbientScripts(uint32 node);
 
 	void loadMovie(uint16 id, uint16 condition, bool resetCond, bool loop);

--- a/engines/myst3/script.cpp
+++ b/engines/myst3/script.cpp
@@ -2117,13 +2117,15 @@ void Script::changeNode(Context &c, const Opcode &cmd) {
 void Script::changeNodeRoom(Context &c, const Opcode &cmd) {
 	debugC(kDebugScript, "Opcode %d: Go to node %d room %d", cmd.op, cmd.args[0], cmd.args[1]);
 
-	_vm->loadNode(cmd.args[1], cmd.args[0]);
+	RoomID room = static_cast<RoomID>(cmd.args[0]);
+	_vm->loadNode(cmd.args[1], room);
 }
 
 void Script::changeNodeRoomAge(Context &c, const Opcode &cmd) {
 	debugC(kDebugScript, "Opcode %d: Go to node %d room %d age %d", cmd.op, cmd.args[2], cmd.args[1], cmd.args[0]);
 
-	_vm->loadNode(cmd.args[2], cmd.args[1], cmd.args[0]);
+	RoomID room = static_cast<RoomID>(cmd.args[1]);
+	_vm->loadNode(cmd.args[2], room, cmd.args[0]);
 }
 
 void Script::drawXTicks(Context &c, const Opcode &cmd) {
@@ -2438,8 +2440,9 @@ void Script::runScript(Context &c, const Opcode &cmd) {
 	debugC(kDebugScript, "Opcode %d: Run scripts from node %d", cmd.op, cmd.args[0]);
 
 	uint16 node = _vm->_state->valueOrVarValue(cmd.args[0]);
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
 
-	_vm->runScriptsFromNode(node, _vm->_state->getLocationRoom());
+	_vm->runScriptsFromNode(node, room);
 }
 
 void Script::runScriptWithVar(Context &c, const Opcode &cmd) {
@@ -2447,14 +2450,15 @@ void Script::runScriptWithVar(Context &c, const Opcode &cmd) {
 
 	_vm->_state->setVar(26, cmd.args[1]);
 	uint16 node = _vm->_state->valueOrVarValue(cmd.args[0]);
+	RoomID room = static_cast<RoomID>(_vm->_state->getLocationRoom());
 
-	_vm->runScriptsFromNode(node, _vm->_state->getLocationRoom());
+	_vm->runScriptsFromNode(node, room);
 }
 
 void Script::runCommonScript(Context &c, const Opcode &cmd) {
 	debugC(kDebugScript, "Opcode %d: Run common script %d", cmd.op, cmd.args[0]);
 
-	_vm->runScriptsFromNode(cmd.args[0], 101, 1);
+	_vm->runScriptsFromNode(cmd.args[0], kINIT, 1);
 }
 
 void Script::runCommonScriptWithVar(Context &c, const Opcode &cmd) {
@@ -2462,7 +2466,7 @@ void Script::runCommonScriptWithVar(Context &c, const Opcode &cmd) {
 
 	_vm->_state->setVar(26, cmd.args[1]);
 
-	_vm->runScriptsFromNode(cmd.args[0], 101, 1);
+	_vm->runScriptsFromNode(cmd.args[0], kINIT, 1);
 }
 
 void Script::runPuzzle1(Context &c, const Opcode &cmd) {
@@ -2804,7 +2808,7 @@ void Script::runSoundScriptNodeRoom(Context &c, const Opcode &cmd) {
 			cmd.op, cmd.args[1], cmd.args[0]);
 
 	int32 node = _vm->_state->valueOrVarValue(cmd.args[1]);
-	int32 room = _vm->_state->valueOrVarValue(cmd.args[0]);
+	RoomID room = static_cast<RoomID>(_vm->_state->valueOrVarValue(cmd.args[0]));
 	_vm->runBackgroundSoundScriptsFromNode(node, room);
 }
 
@@ -2813,7 +2817,7 @@ void Script::runSoundScriptNodeRoomAge(Context &c, const Opcode &cmd) {
 			cmd.op, cmd.args[2], cmd.args[1], cmd.args[0]);
 
 	int32 node = _vm->_state->valueOrVarValue(cmd.args[2]);
-	int32 room = _vm->_state->valueOrVarValue(cmd.args[1]);
+	RoomID room = static_cast<RoomID>(_vm->_state->valueOrVarValue(cmd.args[1]));
 	int32 age = _vm->_state->valueOrVarValue(cmd.args[0]);
 	_vm->runBackgroundSoundScriptsFromNode(node, room, age);
 }

--- a/engines/myst3/state.cpp
+++ b/engines/myst3/state.cpp
@@ -653,6 +653,10 @@ bool GameState::evaluate(int16 condition) {
 	}
 }
 
+int32 GameState::valueOrVarValue(RoomID value) {
+	return (int32)value;
+}
+
 int32 GameState::valueOrVarValue(int16 value) {
 	if (value < 0)
 		return getVar(-value);
@@ -776,7 +780,7 @@ void GameState::pauseEngine(bool pause) {
 	}
 }
 
-bool GameState::isZipDestinationAvailable(uint16 node, uint16 room, uint32 age) {
+bool GameState::isZipDestinationAvailable(uint16 node, RoomID room, uint32 age) {
 	int32 zipBitIndex = _db->getNodeZipBitIndex(node, room, age);
 
 	int32 arrayIndex = zipBitIndex / 32;
@@ -785,7 +789,7 @@ bool GameState::isZipDestinationAvailable(uint16 node, uint16 room, uint32 age) 
 	return (_data.zipDestinations[arrayIndex] & (1 << (zipBitIndex % 32))) != 0;
 }
 
-void GameState::markNodeAsVisited(uint16 node, uint16 room, uint32 age) {
+void GameState::markNodeAsVisited(uint16 node, RoomID room, uint32 age) {
 	int32 zipBitIndex = _db->getNodeZipBitIndex(node, room, age);
 
 	int32 arrayIndex = zipBitIndex / 32;

--- a/engines/myst3/state.h
+++ b/engines/myst3/state.h
@@ -59,6 +59,7 @@ public:
 	void setVar(uint16 var, int32 value);
 	bool evaluate(int16 condition);
 	int32 valueOrVarValue(int16 value);
+	int32 valueOrVarValue(RoomID value);
 
 	const Common::String describeVar(uint16 var);
 	const Common::String describeCondition(int16 condition);
@@ -331,8 +332,8 @@ public:
 	float getMinHeading() { return _data.minHeading; }
 	float getMaxHeading() { return _data.maxHeading; }
 
-	void markNodeAsVisited(uint16 node, uint16 room, uint32 age);
-	bool isZipDestinationAvailable(uint16 node, uint16 room, uint32 age);
+	void markNodeAsVisited(uint16 node, RoomID room, uint32 age);
+	bool isZipDestinationAvailable(uint16 node, RoomID room, uint32 age);
 
 	Common::String formatSaveTime();
 


### PR DESCRIPTION
I took the list of room ids in database.cpp and turned them into an enum in myt3.h.

I think the names could be better than what I currently have (from database.cpp). Like kAmateriaStart and kAmateria ... E.x., I don't even know for sure if kMAIS (room id 1002) is Amateria.

It crashes when I start up saying that No room with ID 101! That is in database.cpp, when it searches for all the rooms in the list. It doesn't find kMENU and I don't know why not. 

I am doing lots of static_casts between RoomID and uint16 since the getLocationRoom() and setLocationRoom() are out of my control and I think they are uin16 so some cast(s) is not going correctly.