### PR TITLE
STARK: Use high-res video when low-res is not available

### DIFF
--- a/engines/stark/ui/world/fmvscreen.cpp
+++ b/engines/stark/ui/world/fmvscreen.cpp
@@ -54,13 +54,30 @@ FMVScreen::~FMVScreen() {
 	delete _surfaceRenderer;
 }
 
-void FMVScreen::play(Common::String name) {
+void FMVScreen::play(const Common::String &name) {
+	Common::SeekableReadStream *stream;
+
+	// Play the low-resolution video, if possible
 	if (!StarkSettings->getBoolSetting(Settings::kHighFMV) && StarkSettings->hasLowResFMV()) {
-		name.erase(name.size() - 4);
-		name += "_lo_res.bbb";
+		Common::String lowResName = name;
+		lowResName.erase(lowResName.size() - 4);
+		lowResName += "_lo_res.bbb";
+
+		stream = StarkArchiveLoader->getExternalFile(lowResName, "Global/");
+		if (stream) {
+			_decoder->loadStream(stream);
+			if (!_decoder->isVideoLoaded()) {
+				error("Could not open %s", lowResName.c_str());
+			}
+			_decoder->start();
+			return;
+		} else {
+			debug("Could not open %s", lowResName.c_str());
+		}
 	}
 
-	Common::SeekableReadStream *stream = StarkArchiveLoader->getExternalFile(name, "Global/");
+	// Play the original video
+	stream = StarkArchiveLoader->getExternalFile(name, "Global/");
 	if (!stream) {
 		warning("Could not open %s", name.c_str());
 		return;

--- a/engines/stark/ui/world/fmvscreen.cpp
+++ b/engines/stark/ui/world/fmvscreen.cpp
@@ -55,7 +55,7 @@ FMVScreen::~FMVScreen() {
 }
 
 void FMVScreen::play(const Common::String &name) {
-	Common::SeekableReadStream *stream;
+	Common::SeekableReadStream *stream = nullptr;
 
 	// Play the low-resolution video, if possible
 	if (!StarkSettings->getBoolSetting(Settings::kHighFMV) && StarkSettings->hasLowResFMV()) {
@@ -64,24 +64,21 @@ void FMVScreen::play(const Common::String &name) {
 		lowResName += "_lo_res.bbb";
 
 		stream = StarkArchiveLoader->getExternalFile(lowResName, "Global/");
-		if (stream) {
-			_decoder->loadStream(stream);
-			if (!_decoder->isVideoLoaded()) {
-				error("Could not open %s", lowResName.c_str());
-			}
-			_decoder->start();
-			return;
-		} else {
+		if (!stream) {
 			debug("Could not open %s", lowResName.c_str());
 		}
 	}
 
 	// Play the original video
-	stream = StarkArchiveLoader->getExternalFile(name, "Global/");
+	if (!stream) {
+		stream = StarkArchiveLoader->getExternalFile(name, "Global/");
+	}
+
 	if (!stream) {
 		warning("Could not open %s", name.c_str());
 		return;
 	}
+
 	_decoder->loadStream(stream);
 	if (!_decoder->isVideoLoaded()) {
 		error("Could not open %s", name.c_str());

--- a/engines/stark/ui/world/fmvscreen.h
+++ b/engines/stark/ui/world/fmvscreen.h
@@ -48,7 +48,7 @@ class FMVScreen : public SingleWindowScreen {
 public:
 	FMVScreen(Gfx::Driver *gfx, Cursor *cursor);
 	virtual ~FMVScreen();
-	void play(Common::String name);
+	void play(const Common::String &name);
 	void stop();
 
 protected:


### PR DESCRIPTION
Related to https://github.com/residualvm/residualvm/issues/1423

When the *High Quality Videos* setting is unchecked but the low-resolution video cannot be found, the original high-resolution video, if it exists, will be played instead.

This is done in case some versions of TLJ have inconsistent videos.