### PR TITLE
MYST3: Add Saving from GMM

### DIFF
--- a/engines/myst3/menu.cpp
+++ b/engines/myst3/menu.cpp
@@ -444,6 +444,10 @@ bool Menu::isOpen() const {
 	return _vm->_state->getLocationAge() == 9 && _vm->_state->getLocationRoom() == 901;
 }
 
+void Menu::generateSaveThumbnail() {
+	_saveThumbnail.reset(captureThumbnail());
+}
+
 Graphics::Surface *Menu::borrowSaveThumbnail() {
 	return _saveThumbnail.get();
 }
@@ -452,6 +456,7 @@ PagingMenu::PagingMenu(Myst3Engine *vm) :
 		Menu(vm),
 		_saveDrawCaret(false),
 		_saveCaretCounter(0) {
+			_saveName = "Saved Game"; // Save name in the original
 }
 
 PagingMenu::~PagingMenu() {
@@ -609,8 +614,8 @@ void PagingMenu::saveMenuChangePage() {
 void PagingMenu::saveMenuSave() {
 	if (_saveName.empty())
 		return;
-
 	Common::String fileName = _saveName;
+
 	if (!fileName.hasSuffix(".M3S") && !fileName.hasSuffix(".m3s"))
 		fileName += ".M3S";
 

--- a/engines/myst3/menu.h
+++ b/engines/myst3/menu.h
@@ -73,6 +73,12 @@ public:
 	Graphics::Surface *captureThumbnail();
 
 	/**
+	 * Capture and save a thumbnail
+	 * thumbnail can be obtain from borrowSaveThumbnail()
+	 */
+	void generateSaveThumbnail();
+
+	/**
 	 * Get the current save thumbnail
 	 *
 	 * Only valid while the menu is open

--- a/engines/myst3/myst3.h
+++ b/engines/myst3/myst3.h
@@ -122,7 +122,9 @@ public:
 	bool canSaveGameStateCurrently() override;
 	bool canLoadGameStateCurrently() override;
 	void tryAutoSaving();
+	void saveGame(Common::String &saveName);
 	Common::Error loadGameState(int slot) override;
+	Common::Error saveGameState(int slot, const Common::String &desc) override;	
 	Common::Error loadGameState(Common::String fileName, TransitionType transition);
 
 	const DirectorySubEntry *getFileDescription(const Common::String &room, uint32 index, uint16 face,


### PR DESCRIPTION
The save dialogue can be opened by F5.
The in game menu can still be opened
by pressing escape.

The Menu object internally manage a thumbnail
for saved games. But now a function has been
added to Menu to have a new thumbnail generated.

A saveGame function has been added to Myst3
that just grabs this already generated thumbnail.