### PR TITLE
DOCS: Multiple style improvements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ ResidualVM: A 3D game interpreter
   6. [ Configuration               ](#6-configuration)
   7. [ Troubleshooting             ](#7-troubleshooting-known-bugs-issues)
   8. [ Debugging                   ](#8-debugging)
-  9. [ Bug Reports                 ](#9-bug-reports)
+  9. [ Bug reports                 ](#9-bug-reports)
  10. [ Contact                     ](#10-contact)
 
 
 ## 1. What is ResidualVM?
-ResidualVM is a game engine reimplementation that allows you
-to play 3D adventure games such as Grim Fandango, Escape from Monkey
-Island, Myst III and The Longest Journey.
+ResidualVM is a game engine reimplementation that allows you to play 3D
+adventure games such as Grim Fandango, Escape from Monkey Island, Myst III
+and The Longest Journey.
 
 ResidualVM utilizes OpenGL for 3D graphics hardware acceleration.
 A software renderer is also included for machines without hardware OpenGL.
@@ -25,24 +25,24 @@ A software renderer is also included for machines without hardware OpenGL.
 
 ## 2. Current state
 At this point ResidualVM is fit for normal use, when playing supported
-games, it is however worth noting that you should still save early, and
-save often, as problems or dead-ends might still exist. (Grim Fandango
+games, it is however worth noting that you should still save early and
+save often, as problems or dead ends might still exist (Grim Fandango
 itself originally had a few unintentional ways to get the game stuck).
 
 ### 2.1. Which games does ResidualVM support? ###
 
-Currently ResidualVM supports Grim Fandango and Escape From Monkey Island,
+Currently ResidualVM supports Grim Fandango and Escape from Monkey Island,
 as well Myst III and The Longest Journey.
 
-#### 2.1.1. GrimE-games support ####
+#### 2.1.1. GrimE games support ####
 
 Game                             | Status
 -------------------------------- | -------------------------
 Grim Fandango                    | Completable with glitches
 Grim Fandango (demo)             | Completable with glitches
-Escape From Monkey Island        | Completable with glitches
-Escape From Monkey Island (demo) | Completable with glitches
-Escape From Monkey Island (PS2)  | Untested
+Escape from Monkey Island        | Completable with glitches
+Escape from Monkey Island (demo) | Completable with glitches
+Escape from Monkey Island (PS2)  | Untested
 
 #### 2.1.2. Other games support ####
 
@@ -63,35 +63,34 @@ http://wiki.residualvm.org/
 
 ### 3.1. Required files
 
-For both Grim Fandango and Escape from Monkey Island, you will need the original
-game files as well as the official update patch.
+For both Grim Fandango and Escape from Monkey Island, you will need the
+original game files as well as the official update patch.
 
 #### 3.1.1. Grim Fandango ####
 
 You will need to copy the data files from your Grim Fandango CDs into one
 directory. Specifically, you'll need:
-  * All of the .LAB files from both CDs
-  * A copy of the Grim Fandango 1.01 update EXE
+  * All of the `LAB` files from both CDs.
+  * A copy of the Grim Fandango 1.01 update EXE.
         The patch can be downloaded from:
         http://demos.residualvm.org/patches/gfupd101.exe
 
 #### 3.1.2. Escape from Monkey Island ####
 
-You will need to copy the data files from your Escape from Monkey Island CDs
-into one directory. Specifically, you'll need:
-  * All of the .M4B files from both CDs.
+You will need to copy the data files from your Escape from Monkey Island
+CDs into one directory. Specifically, you'll need:
+  * All of the `M4B` files from both CDs.
     One of the files is easy to miss:
-    local.m4b is located on CD1 in Monkey4/MonkeyInstall.
-        Note: The file voiceAll.m4b is repeated on both CDs. Use the
+    `local.m4b` is located on CD1 in `Monkey4/MonkeyInstall`.
+        Note: The file `voiceAll.m4b` is repeated on both CDs. Use the
               copy from the first CD, it contains all of the required
-              voice data
-  * The Textures directory, combined from both CDs. When copying, rename
-    the FullMonkeyMap.imt files to FullMonkeyMap1.imt and
-    FullMonkeyMap2.imt from CDs 1 and 2 respectively.
-  * The Movies directory from each CD
-  * A copy of the Escape from Monkey Monkey Island update EXE
+              voice data.
+  * The `Textures` directory, combined from both CDs. When copying,
+    rename the `FullMonkeyMap.imt` files to `FullMonkeyMap1.imt` and
+    `FullMonkeyMap2.imt` from CDs 1 and 2 respectively.
+  * The `Movies` directory from each CD.
+  * A copy of the Escape from Monkey Monkey Island update EXE.
     You will need a patch specific to the EMI version you're using:
-  * "EFMI Installer" if you have the Mac version of EMI.
 
 Language   | URL
 ---------- |---------------------------------------------------------
@@ -102,95 +101,103 @@ Spanish    | http://demos.residualvm.org/patches/MonkeyUpdate_ESP.exe
 French     | http://demos.residualvm.org/patches/MonkeyUpdate_FRA.exe
 Italian    | http://demos.residualvm.org/patches/MonkeyUpdate_ITA.exe
 
+  * "EFMI Installer" if you have the Mac version of EMI.
+
 #### 3.1.3. Escape from Monkey Island (PS2) ####
 
-You will need to copy the data files from your Escape from Monkey Island DVD
-into one directory. Specifically, you'll need:
-  * All of the m4b files from the DVD
-  * The Videos, demos, jambalay, lucre, melee and monkey directores
+You will need to copy the data files from your Escape from Monkey Island
+DVD into one directory. Specifically, you'll need:
+  * All of the `M4B` files from the DVD.
+  * The `Videos`, `demos`, `jambalay`, `lucre`, `melee` and `monkey`
+    directores.
 
 ### 3.2. Running the game ###
 
-1. Prepare the game directory as specified above
-2. Open ResidualVM
-3. Choose "Add Game"
-4. Select the folder you created in Step 1
-5. Click Start
+1. Prepare the game directory as specified above.
+2. Open ResidualVM.
+3. Click `Add Game...`.
+4. Select the directory you created in step 1.
+5. Click `Start`.
 
-If you want to play with software-rendering, see the configuration-section
-below, or use the ingame settings to disable 3D Acceleration.
+If you want to play with software rendering, see the configuration section
+below, or use the in-game settings to disable 3D acceleration.
 
 When launching the game for the first time, ResidualVM will perform a full
-integrity check of your game data files. This can take a bit of time, but it
-will not happen again on successive runs. This prevents bugs from incompatible
-game data, and helps us to find game variants that we're not aware of.
+integrity check of your game data files. This can take a bit of time, but
+it will not happen again on successive runs. This prevents bugs from
+incompatible game data and helps us to find game variants that we're not
+aware of.
 
-### 3.3. Default Keyboard-settings ###
+### 3.3. Default keyboard settings ###
 
-Key         | Binding
------------ | ---------------------------------------------
-e,u,p,i     | Examine, Use, Pickup, Inventory
-Arrow keys  | Movement
-Shift       | Hold to run
-Enter       | Selects items in inventory, conversation, etc
-Escape      | Skips cutscenes, exits certain screens
-.           | Skips dialogue
-q           | Exit Dialog Menu
-Ctrl + c    | Force Quit (from command-line)
-Alt + x     | Quit (ingame)
-Alt + enter | Switch between windowed-mode and fullscreen
-F1          | Menu
+Key             | Binding
+--------------- | ---------------------------------------------
+Arrow keys      | Movement
+`Shift`         | Hold to run
+`Enter`         | Selects items in inventory, conversation, etc
+`Escape`        | Skips cutscenes, exits certain screens
+`e`             | Examine
+`u`             | Use
+`p`             | Pickup
+`i`             | Inventory
+`q`             | Exit Dialog Menu
+`.`             | Skips dialogue
+`F1`            | Menu
+`Alt` + `x`     | Quit (in-game)
+`Ctrl` + `c`    | Force quit (from command line)
+`Alt` + `Enter` | Switch between windowed mode and fullscreen
 
 ### 3.4. Joystick/gamepad support ###
 
-If you want to use a joystick or gamepad for navigation, the joystick support
-of the engine needs to be enabled using one of the following two options:
-
-  * start residualvm with "--joystick" parameter
-  * add "joystick\_num=0" to the "[residualvm]" section of the configuration file
-    (see section 5.1. how to find the file)
+If you want to use a joystick or gamepad for navigation, the joystick
+support of the engine needs to be enabled using one of the following two
+options:
+  * start ResidualVM with `--joystick` parameter,
+  * add `joystick\_num=0` to the `[residualvm]` section of the
+    configuration file (see section 6.1. how to find it).
 
 
 ## 4. Running Myst III
 
 ### 4.1. Required files ###
 
-You will need these elements from your game CDs or DVD :
-  * M3Data directory
-  * Data directory
-  * The menu language file '[LANGUAGE].m3u' (DVD only)
-
-When using the CD version, you will need to merge the 'Data' directories from
-all four discs. Playing directly from the CDs is not supported.
+You will need to copy the data files from your Myst III CDs or DVD into
+one directory. Specifically, you'll need:
+  * The `M3Data` directory.
+  * The `Data` directory.
+  * The menu language file `[LANGUAGE].m3u` (DVD only).
 
 The game must be at least version 1.1. For most releases of the game, the
-update is already applied on the installation media, no action is required.
-Otherwise, ResidualVM asks for the update to be installed and refuses to run
-the game. The updates can be downloaded from
-http://demos.residualvm.org/patches/.
+update is already applied on the installation media and no action is
+required.
+Otherwise, ResidualVM asks for the update to be installed and refuses to
+run the game. The updates can be downloaded from
+http://demos.residualvm.org/patches/
 
-The DVD version is multilingual, you can change the in-game language from the
-game menu. However, you must choose the language of the menus by copying the
-appropriate files. You have to copy the menu language file from your chosen
-language folder on the disc. On the DVD, the menu language file can be named
-'language.m3u' or '[LANGUAGE].m3u' depending on the release. It should
-be copied to the 'M3Data/TEXT' folder. If the file is named 'language.m3u',
-it should be renamed to the explicit language e.g. ENGLISH.m3u for English.
+The DVD version is multilingual, you can change the in-game language from
+the game menu. However, you must choose the language of the menus by
+copying the appropriate files. You have to copy the menu language file
+from your chosen language directory on the disc. On the DVD, the menu
+language file can be named `language.m3u` or `[LANGUAGE].m3u` depending on
+the release. It should be copied to the `M3Data/TEXT` directory. If the
+file is named `language.m3u`, it should be renamed to the explicit
+language e.g. `ENGLISH.m3u` for English.
 
-The required files must be organized in the following manner to be recognized:
+The required files must be organized in the following manner to be
+recognized:
 
     ├── Data
     │   └── *.m3a
     └── M3Data
-        └── Various files and folders (including the DVD version's menu language file)
+        └── Various files and directories (including the DVD version's menu language file)
 
 ### 4.2. Running the game ###
 
-1. Copy the necessary files to a folder on your Hard Drive
-2. Open ResidualVM
-3. Choose "Add Game"
-4. Select the folder you created in step 1
-5. Click Start
+1. Prepare the game directory as specified above.
+2. Open ResidualVM.
+3. Click `Add Game...`.
+4. Select the directory you created in step 1.
+5. Click `Start`.
 
 ### 4.3. Input controls ###
 
@@ -198,13 +205,13 @@ The mouse is used to look around and interact with the ages.
 
 Available keyboard shortcuts:
 
-Key        | Binding
----------- | ------------------------------
-Escape     | Original Myst III Menu
-Ctrl + F5  | ResidualVM Menu
-Space      | Skip cutscenes, interact
-Ctrl + c   | Force Quit (from command-line)
-Ctrl + q   | Quit (ingame)
+Key           | Binding
+------------- | ------------------------------
+`Escape`      | Original Myst III menu
+`Space`       | Skip cutscenes, interact
+`Ctrl` + `F5` | ResidualVM menu
+`Ctrl` + `c`  | Force quit (from command line)
+`Ctrl` + `q`  | Quit (in-game)
 
 
 ## 5. Running The Longest Journey
@@ -214,26 +221,26 @@ Ctrl + q   | Quit (ingame)
 You will need to copy the data files from your The Longest Journey CDs,
 DVD or digital distributiion into one directory. Specifically, you'll
 need:
-  * 1a—79 directories (4f only for demo version)
-  * global directory
-  * static directory
-  * fonts directory (not critical, but recommended – see below)
-  * x.xarc and all the .ini files
-
-Steam version and demo from Steam are missing the fonts folder. The
-required fonts can be copied over from demo version obtained from
-different sources or a GOG or retail version.
+  * The `1a`—`79` directories (only `4f` for demo version).
+  * The `global` directory.
+  * The `static` directory.
+  * The `fonts` directory (not critical, but recommended – see below).
+  * `x.xarc` and all the `INI` files.
 
 The 2-CD and DVD versions have some of the data files packed in installer
 archives. The archives need to be unpacked before they can be used.
 
+Steam version and demo from Steam are missing the `fonts` directory.
+The required fonts can be copied over from demo version obtained from
+different sources or a GOG or retail version.
+
 ### 5.2. Running the game ###
 
-1. Copy the necessary files to a folder on your Hard Drive
-2. Open ResidualVM
-3. Choose "Add Game"
-4. Select the folder you created in step 1
-5. Click Start
+1. Prepare the game directory as specified above.
+2. Open ResidualVM.
+3. Click `Add Game...`.
+4. Select the directory you created in step 1.
+5. Click `Start`.
 
 ### 5.3. Input controls ###
 
@@ -241,201 +248,203 @@ The mouse is used to interact with objects and menu elements.
 
 Available keyboard shortcuts:
 
-Key         | Binding
------------ | -------------------------------------------------------------------------------------------
-Escape      | Skip video sequence or current line of dialogue, skip time if *Time Skip* option is enabled
-Ctrl + F5   | ResidualVM Menu
-Ctrl + c    | Force Quit (from command-line)
-Ctrl + q    | Quit (ingame)
-Alt + enter | Switch between windowed-mode and fullscreen
+Key             | Binding
+--------------- | -------------------------------------------------------------------------------------------
+`Escape`        | Skip video sequence or current line of dialogue, skip time if *Time Skip* option is enabled
+`Ctrl` + `F5`   | ResidualVM menu
+`Ctrl` + `c`    | Force quit (from command line)
+`Ctrl` + `q`    | Quit (in-game)
+`Alt` + `Enter` | Switch between windowed mode and fullscreen
 
 
 ## 6. Configuration
-Currently, not all the settings for ResidualVM are available through the GUI,
-if you have problems with getting anything to work, first try to pass the
-settings from the command line, then, if that doesn't work, try to change your
-configuration file manually.
+Currently, not all the settings for ResidualVM are available through the
+GUI, if you have problems with getting anything to work, first try to pass
+the settings from the command line, then, if that doesn't work, try to
+change your configuration file manually.
 
 ### 6.1. Location of configuration file ###
 
-By default, the configuration file is saved in, and loaded from:
+By default, the configuration file is saved in and loaded from:
 
 Operating System     | Location
--------------------- | ---------------------------------------------------------------------------
-Windows Vista/7/8/10 | \Users\username\AppData\Roaming\ResidualVM\residualvm.ini
-Windows 2000/XP      | \Documents and Settings\username\Application Data\ResidualVM\residualvm.ini
-Unix                 | ~/.residualvmrc
-Mac OS X             | ~/Library/Preferences/ResidualVM Preferences
-Others               | residualvm.ini in the current directory
+-------------------- | -----------------------------------------------------------------------------
+Windows Vista/7/8/10 | `\Users\username\AppData\Roaming\ResidualVM\residualvm.ini`
+Windows 2000/XP      | `\Documents and Settings\username\Application Data\ResidualVM\residualvm.ini`
+Linux                | `~/.config/residualvm/residualvm.ini`
+macOS/OS X           | `~/Library/Preferences/ResidualVM Preferences`
+Others               | `residualvm.ini` in the current directory
 
 ### 6.2. Interesting settings for GrimE games ###
 
-The following settings are currently available in the config-file,
-however some of them might not work with your current build. And
-some of them might make ResidualVM crash, or behave in weird ways.
+The following settings are currently available in the config file, however
+some of them might not work with your current build and some of them might
+make ResidualVM crash, or behave in weird ways.
 
-Setting        | Values            | Effect
--------------- | ----------------- | ---------------------------------------------------
-show_fps       | [true/false]      | If true, then ResidualVM will show the current FPS-rate, while you play.
-last_set       | [set-name]        | The set you were last on, ResidualVM will try to continue from there.
-last_save      | [save-number]     | The save you last saved, ResidualVM will have that selected the next time you try to load a game.
-use_arb_shaders| [true/false]      | If true, and if you are using the OpenGL renderer ResidualVM will use ARB shaders. While fast they may be incompatible with some graphics drivers.
-fullscreen_res | [desktop/WWWxHHH] | If set to "desktop" (the default), ResidualVM will use your desktop resolution in fullscreen mode. If set to a resolution such as "640x480" or "1280x720", that resolution will be used.
+Setting           | Values                   | Effect
+----------------- | ------------------------ | ---------------------------------------------------
+`show_fps`        | `true`/`false`           | If set to `true`, ResidualVM will show the current FPS rate while you play
+`last_set`        | set name                 | The set you were last on, ResidualVM will try to continue from there
+`last_save`       | save number              | The save you last saved, ResidualVM will have that selected the next time you try to load a game
+`use_arb_shaders` | `true`/`false`           | If set to `true` and if you are using the OpenGL renderer ResidualVM will use ARB shaders. While fast, they may be incompatible with some graphics drivers
+`fullscreen_res`  | `desktop`/width`x`height | If set to `desktop` (the default), ResidualVM will use your desktop resolution in fullscreen mode. If set to a resolution such as `640x480` or `1280x720`, that resolution will be used
 
 
-## 7. Troubleshooting, Known Bugs, Issues
-Grim Fandango had a few issues when it came out, and a few new and exciting
-issues when you try to run it on newer hardware. Some of these have been
-fixed in ResidualVM, but ResidualVM itself also has a few new issues that we
-know about:
-http://github.com/residualvm/residualvm/blob/master/KNOWN_BUGS
+## 7. Troubleshooting, known bugs, issues
+Grim Fandango had a few issues when it came out and a few new and
+exciting issues when you try to run it on newer hardware. Some of these
+have been fixed in ResidualVM, but ResidualVM itself also has a few new
+issues that we know about:
+https://github.com/residualvm/residualvm/blob/master/KNOWN_BUGS
 
-Look below for help with these issues, and if you can't find help here, try
-either the forums at our homepage, or IRC: #residualvm at freenode.
+Look below for help with these issues and if you can't find help here,
+try contacting us at [Contact](#10-contact) section.
 
 ### 7.1. I played a bit, but can't start a new game! ###
 
-This is because the last save and visited scene is stored in your configuration
-file, either delete grim-fandango from the ResidualVM-menu, and re-add it, or
-go to your configuration file, and clean out the last-save and last-set entries.
+This is because the last save and visited scene is stored in your
+configuration file, either delete your Grim Fandango entry from the
+ResidualVM menu and readd it, or go to your configuration file and clean
+out the `last_save` and `last_set` entries.
 
-### 7.2. My Save Games don't work any more ###
+### 7.2. My saved games don't work any more! ###
 
 Did you recently update to a newer build of ResidualVM?
-ResidualVM is still a work in progress, which means that the save format might
-change between builds. While attempts are made to keep save file compatibility,
-this isn't always possible.
+ResidualVM is still a work in progress, which means that the save format
+might change between builds. While attempts are made to keep save file
+compatibility, this isn't always possible.
 
 
 ## 8. Debugging
-WARNING: This section contains information about the various tools that
+**WARNING:** This section contains information about the various tools that
 are included for debugging ResidualVM, this should not be necessary for
 normal play at all! However, the curious might like to know how to access
 these tool. Please use at your own risk!
 
-To enter the debug console, press Ctrl + d. Use the `help` command to display
-a list of the available commands. To exit, press Esc or type `exit` or `quit`.
+To enter the debug console, press `Ctrl` + `d`. Use the `help` command to
+display a list of the available commands. To exit, press `Escape` or type
+`exit` or `quit`.
 
-Commands common to all engines are:
+Debug console commands common to all engines:
 
-Command           | Description
------------------ | -----------------------------------------------------------
-openlog           | Show the log of errors/warnings/information from the engine
-debuglevel        | List or change verbosity of debug output
-debugflag_list    | List the available debug flags and their status
-debugflag_enable  | Enable a given debugflag
-debugflag_disable | Disable a given debugflag
-md5               | Calculates MD5 checksum of a file
-md5mac            | Calculates MD5 checksum of a file (Mac format)
+Command             | Description
+------------------- | -----------------------------------------------------------
+`openlog`           | Show the log of errors/warnings/information from the engine
+`debuglevel`        | List or change verbosity of debug output
+`debugflag_list`    | List the available debug flags and their status
+`debugflag_enable`  | Enable a given debug flag
+`debugflag_disable` | Disable a given debug flag
+`md5`               | Calculates MD5 checksum of a file
+`md5mac`            | Calculates MD5 checksum of a file (Mac format)
 
+### 8.1. Debugging GrimE games ###
 
-### 8.1. Debugging GrimE Games ###
+The development console can be used to debug both Grim Fandango and Escape
+from Monkey Island.
 
-The development console can be used to debug both Grim Fandango and Escape From
-Monkey Island.
+Some of the useful debug console commands:
 
-Some of the useful commands are:
-
-Command       | Description
-------------- | -----------------------------------------------------------
-jump          | Jump to a section of the game
-lua_do        | Execute a lua command
-set_renderer  | Select a renderer (software, OpenGL or OpenGL with shaders)
+Command        | Description
+-------------- | -----------------------------------------------------------
+`jump`         | Jump to a section of the game
+`lua_do`       | Execute a lua command
+`set_renderer` | Select a renderer (software, OpenGL or OpenGL with shaders)
 
 The `jump` targets can be found at:
-  * http://wiki.residualvm.org/index.php/Grim_Fandango_Debug_Mode#jump_targets
-  * http://wiki.residualvm.org/index.php/Escape_From_Monkey_Island_Debug_Mode
+  * http://wiki.residualvm.org/index.php/Grim_Fandango_Debug_Mode#Jump_targets
+  * http://wiki.residualvm.org/index.php/Escape_From_Monkey_Island_Debug_Mode#Jump_targets
 
 ### 8.2. Debugging Grim Fandango ###
 
-Grim Fandango also includes a built in debug mode. To enable debug-keys and
-debug-mode, you will have to add the following line to your configuration file
-under the Grim Fandango-entry:
+Grim Fandango also includes a built in debug mode. To enable debug mode
+and debug keys, you will have to add the following line to your
+configuration file under the Grim Fandango entry:
 
-game_devel_mode=true
+`game_devel_mode=true`
 
 Development/debug keys from the original game:
 
-Key        | Binding
----------- | ------------------------------------
-Ctrl + e   | Enter lua string to execute
-Ctrl + g   | Jump to set
-Ctrl + i   | Toggle walk boxes
-Ctrl + l   | Toggle lighting
-Ctrl + n   | Display background name
-Ctrl + o   | Create a door
-Ctrl + p   | Execute patch file
-Ctrl + s   | Turn on cursor
-Ctrl + u   | Create a new object
-Ctrl + v   | Print the value of a variable
-Alt + n    | Next viewpoint
-Apt + p    | Prev viewpoint
-Alt + s    | Run lua script
-Shift + n  | Next set
-Shift + p  | Prev set
-Shift + o  | Toggle object names
-F3         | Toggle sector editor
-Home       | Go to default position in current set
-j          | Enter jump number
+Key           | Binding
+------------- | ------------------------------------
+`Ctrl` + `e`  | Enter lua string to execute
+`Ctrl` + `g`  | Jump to set
+`Ctrl` + `i`  | Toggle walk boxes
+`Ctrl` + `l`  | Toggle lighting
+`Ctrl` + `n`  | Display background name
+`Ctrl` + `o`  | Create a door
+`Ctrl` + `p`  | Execute patch file
+`Ctrl` + `s`  | Turn on cursor
+`Ctrl` + `u`  | Create a new object
+`Ctrl` + `v`  | Print the value of a variable
+`Alt` + `n`   | Next viewpoint
+`Alt` + `p`   | Prev viewpoint
+`Alt` + `s`   | Run lua script
+`Shift` + `n` | Next set
+`Shift` + `p` | Previous set
+`Shift` + `o` | Toggle object names
+`F3`          | Toggle sector editor
+`Home`        | Go to default position in current set
+`j`           | Enter jump number
 
-Note that these are only available after enabling debug-mode.
+Note that these are only available after enabling debug mode.
 
 ### 8.3. Debugging Myst III ###
 
 The most useful debug console commands are:
 
-Command     | Description
------------ | ------------------------------------------------------------
-dumpArchive | Extract a game archive
-infos       | Display the name of a node and show the associated scripts
-go          | Jump to a node
-var         | Display or alter the value of a variable from the game state
+Command       | Description
+------------- | ------------------------------------------------------------
+`dumpArchive` | Extract a game archive
+`infos`       | Display the name of a node and show the associated scripts
+`go`          | Jump to a node
+`var`         | Display or alter the value of a variable from the game state
 
 ### 8.4. Debugging The Longest Journey ###
 
 The debug console commands are:
 
-Command             | Description
-------------------- | --------------------------------------------------------
-changeChapter       | Change the current chapter
-changeKnowledge     | Change the value of some knowledge
-changeLocation      | Change the current location
-chapter             | Display the current chapter
-decompileScript     | Decompile a script
-dumpArchive         | Extract a game archive
-dumpGlobal          | Print the global level's resource sub-tree to stdout
-dumpKnowledge       | Print the current knowledge to stdout
-dumpLevel           | Print the current level's resource sub-tree to stdout
-dumpLocation        | Print the current location's resource sub-tree to stdout
-dumpRoot            | Print the resource tree root to stdout
-dumpStatic          | Print the static level's resource sub-tree to stdout
-enableInventoryItem | Enable a specific inventory item
-enableScript        | Enable or disable script
-forceScript         | Force the execution of a script
-listInventory       | List all inventory items in the game
-listLocations       | List all the locations in the game
-listScripts         | List all the scripts in current level
-location            | Display the current location
-testDecompiler      | Test decompilation of all the scripts in game
+Command               | Description
+--------------------- | --------------------------------------------------------
+`changeChapter`       | Change the current chapter
+`changeKnowledge`     | Change the value of some knowledge
+`changeLocation`      | Change the current location
+`chapter`             | Display the current chapter
+`decompileScript`     | Decompile a script
+`dumpArchive`         | Extract a game archive
+`dumpGlobal`          | Print the global level's resource sub-tree to stdout
+`dumpKnowledge`       | Print the current knowledge to stdout
+`dumpLevel`           | Print the current level's resource sub-tree to stdout
+`dumpLocation`        | Print the current location's resource sub-tree to stdout
+`dumpRoot`            | Print the resource tree root to stdout
+`dumpStatic`          | Print the static level's resource sub-tree to stdout
+`enableInventoryItem` | Enable a specific inventory item
+`enableScript`        | Enable or disable script
+`forceScript`         | Force the execution of a script
+`listInventory`       | List all inventory items in the game
+`listLocations`       | List all the locations in the game
+`listScripts`         | List all the scripts in current level
+`location`            | Display the current location
+`testDecompiler`      | Test decompilation of all the scripts in game
 
 
-## 9. Bug Reports
+## 9. Bug reports
 ResidualVM still has a few bugs, many might already have been reported,
 but should you find a new one, don't hesitate to report it.
 
-### 9.1. How, and where do I report bugs? ###
+### 9.1. How and where do I report bugs? ###
 
-You can report bugs at our github-issue-tracker:
-http://www.github.com/residualvm/residualvm/issues
+You can report bugs at our GitHub issue tracker:
+https://github.com/residualvm/residualvm/issues
 
 Please read the Wiki regarding how to report bugs properly first though:
 http://wiki.residualvm.org/index.php?title=Reporting_Bugs
 
 Remember to always have the following information in your bug reports:
-  * Information about the game (Escape from Monkey Island, PS2 version)
-  * Language of game (English, German, ...)
-  * Platform and Compiler (Win32, Linux, Mac OS X, ...)
-  * Bug details, including instructions on reproducing it
+  * Information about the game (e.g. *Escape from Monkey Island, PS2
+    version*).
+  * Language of game (*English*, *German*, *...*).
+  * Platform (*Windows*, *Linux*, *macOS*, *...*).
+  * Bug details, including instructions on reproducing it.
   * Preferably also a link to a save game right before the bug happened.
 
 


### PR DESCRIPTION
* Enforced 75 character limit more often.
* Changed some instances of big letters inside the the middle of the sentences (particularly headers), including *Escape From Monkey Island* in a few cases.
* Removed unneeded hyphens from the words that don't need it (and did the opposite for "in-game").
* Finished some sentences with the full stop, particularly in the lists, with the exception of tables, headers and sentences ending with URLs/IRC server name.
* Used `code` formatting for file and directory names, commands and keys, also removing the old single or double quotations or parentheses.
* Used more of *italics* in some parts and **bold** for **WARNING**.
* Standardized referencing filename extensions (INI, EXE, etc.) .
* Changed *folder* to *directory* to unify naming.
* Removed commas before "and".
* Changed Github's links from `http://www.` to `https://`.
* Added or changed OS X to macOS.
* Unified *Required files* sections among the games.
* Moved the "EFMI Installer" point below the table, as that made more sense for the earlier point about the patch.
* Changed some ordering of keybinding for GrimE games and separated  `e`, `u`, `p` and `i` keys.
* Updated mention of section number for the location of configuration file.
* Grouped global ResidualVM bindings together in Myst III input controls.
* Changed location of configuration file under Linux (was Unix, but since macOS is technically an Unix as well, someone should add a separate entry for other Unixes such as Android, *BSD or Solaris, as the patch might be different there), as it seems to changed.
* Replaced repeated mention of forums and IRC with a link to *Contact* section.
* Further clarified that these are *debug console commands* in a few remaining places.
* Fixed/added *Jump targets* links from the wiki.
* Clarified that the *Escape from Monkey Island, PS2 version* is an example, removed mention of compiler (example doesn't mention it and it is really that important thing to mention, knowing that a lot of people may not even have idea about the compiler when using prebuilt packages?) and changed Win32 to Windows, as that's more generic term and there's only one Windows version I think.
* Fixed other minor typos/style/formatting.