### PR TITLE
STARK: Implement the video replay menu

### DIFF
--- a/engines/stark/module.mk
+++ b/engines/stark/module.mk
@@ -92,6 +92,7 @@ MODULE_OBJS := \
 	ui/menu/mainmenu.o \
 	ui/menu/settingsmenu.o \
 	ui/menu/saveloadmenu.o \
+	ui/menu/fmvmenu.o \
 	ui/window.o \
 	ui/world/actionmenu.o \
 	ui/world/button.o \

--- a/engines/stark/resources/sound.cpp
+++ b/engines/stark/resources/sound.cpp
@@ -251,5 +251,9 @@ void Sound::saveLoadCurrent(ResourceSerializer *serializer) {
 	}
 }
 
+void Sound::onEnginePause(bool pause) {
+	g_system->getMixer()->pauseHandle(_handle, pause);
+}
+
 } // End of namespace Resources
 } // End of namespace Stark

--- a/engines/stark/resources/sound.h
+++ b/engines/stark/resources/sound.h
@@ -67,6 +67,7 @@ public:
 	void onPreDestroy() override;
 	void onGameLoop() override;
 	void saveLoadCurrent(ResourceSerializer *serializer) override;
+	void onEnginePause(bool pause) override;
 
 	/** Start playing the sound */
 	void play();

--- a/engines/stark/services/diary.h
+++ b/engines/stark/services/diary.h
@@ -57,6 +57,11 @@ public:
 	/** Add a FMV entry to the list of movies available to play from the diary */
 	void addFMVEntry(const Common::String &filename, const Common::String &title, int gameDisc);
 
+	/** Get info of added FMV entries */
+	int countFMV() { return _fmvEntries.size(); }
+	Common::String &getFMVFilename(int index) { return _fmvEntries[index].filename; }
+	Common::String &getFMVTitle(int index) { return _fmvEntries[index].title; }
+
 	/** Start recording speech lines for a dialog */
 	void openDialog(const Common::String &title, const Common::String &characterName, int32 characterId);
 

--- a/engines/stark/services/diary.h
+++ b/engines/stark/services/diary.h
@@ -58,9 +58,9 @@ public:
 	void addFMVEntry(const Common::String &filename, const Common::String &title, int gameDisc);
 
 	/** Get info of added FMV entries */
-	int countFMV() { return _fmvEntries.size(); }
-	Common::String &getFMVFilename(int index) { return _fmvEntries[index].filename; }
-	Common::String &getFMVTitle(int index) { return _fmvEntries[index].title; }
+	uint countFMV() const { return _fmvEntries.size(); }
+	Common::String &getFMVFilename(uint index) { return _fmvEntries[index].filename; }
+	Common::String &getFMVTitle(uint index) { return _fmvEntries[index].title; }
 
 	/** Start recording speech lines for a dialog */
 	void openDialog(const Common::String &title, const Common::String &characterName, int32 characterId);

--- a/engines/stark/services/userinterface.cpp
+++ b/engines/stark/services/userinterface.cpp
@@ -39,6 +39,7 @@
 #include "engines/stark/ui/menu/mainmenu.h"
 #include "engines/stark/ui/menu/settingsmenu.h"
 #include "engines/stark/ui/menu/saveloadmenu.h"
+#include "engines/stark/ui/menu/fmvmenu.h"
 #include "engines/stark/ui/world/inventorywindow.h"
 #include "engines/stark/ui/world/fmvscreen.h"
 #include "engines/stark/ui/world/gamescreen.h"
@@ -54,6 +55,7 @@ UserInterface::UserInterface(Gfx::Driver *gfx) :
 		_settingsMenuScreen(nullptr),
 		_saveMenuScreen(nullptr),
 		_loadMenuScreen(nullptr),
+		_fmvMenuScreen(nullptr),
 		_exitGame(false),
 		_fmvScreen(nullptr),
 		_gameScreen(nullptr),
@@ -75,6 +77,7 @@ UserInterface::~UserInterface() {
 	delete _settingsMenuScreen;
 	delete _saveMenuScreen;
 	delete _loadMenuScreen;
+	delete _fmvMenuScreen;
 }
 
 void UserInterface::init() {
@@ -86,6 +89,7 @@ void UserInterface::init() {
 	_settingsMenuScreen = new SettingsMenuScreen(_gfx, _cursor);
 	_saveMenuScreen = new SaveMenuScreen(_gfx, _cursor);
 	_loadMenuScreen = new LoadMenuScreen(_gfx, _cursor);
+	_fmvMenuScreen = new FMVMenuScreen(_gfx, _cursor);
 	_fmvScreen = new FMVScreen(_gfx, _cursor);
 
 	_prevScreenNameStack.push(Screen::kScreenMainMenu);
@@ -202,6 +206,8 @@ Screen *UserInterface::getScreenByName(Screen::Name screenName) const {
 			return _saveMenuScreen;
 		case Screen::kScreenLoadMenu:
 			return _loadMenuScreen;
+		case Screen::kScreenFMVMenu:
+			return _fmvMenuScreen;
 		default:
 			error("Unhandled screen name '%d'", screenName);
 	}

--- a/engines/stark/services/userinterface.h
+++ b/engines/stark/services/userinterface.h
@@ -50,6 +50,7 @@ class MainMenuScreen;
 class SettingsMenuScreen;
 class SaveMenuScreen;
 class LoadMenuScreen;
+class FMVMenuScreen;
 class Cursor;
 class FMVScreen;
 
@@ -161,7 +162,7 @@ private:
 	SettingsMenuScreen *_settingsMenuScreen;
 	SaveMenuScreen *_saveMenuScreen;
 	LoadMenuScreen *_loadMenuScreen;
-
+	FMVMenuScreen *_fmvMenuScreen;
 	Screen *_currentScreen;
 	Common::Stack<Screen::Name> _prevScreenNameStack;
 

--- a/engines/stark/ui/menu/diaryindex.cpp
+++ b/engines/stark/ui/menu/diaryindex.cpp
@@ -72,7 +72,7 @@ void DiaryIndexScreen::open() {
 
 	_widgets.push_back(new StaticLocationWidget(
 			"Fmv",
-			nullptr,
+			CLICK_HANDLER(DiaryIndexScreen, fmvHandler),
 			MOVE_HANDLER(DiaryIndexScreen, widgetTextColorHandler)));
 
 	_widgets.push_back(new StaticLocationWidget(
@@ -111,6 +111,10 @@ void DiaryIndexScreen::widgetTextColorHandler(StaticLocationWidget &widget, cons
 
 void DiaryIndexScreen::settingsHandler() {
 	StarkUserInterface->changeScreen(Screen::kScreenSettingsMenu);
+}
+
+void DiaryIndexScreen::fmvHandler() {
+	StarkUserInterface->changeScreen(Screen::kScreenFMVMenu);
 }
 
 void DiaryIndexScreen::backHandler() {

--- a/engines/stark/ui/menu/fmvmenu.cpp
+++ b/engines/stark/ui/menu/fmvmenu.cpp
@@ -1,0 +1,79 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the AUTHORS
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "engines/stark/ui/menu/fmvmenu.h"
+
+#include "engines/stark/services/services.h"
+#include "engines/stark/services/userinterface.h"
+
+namespace Stark {
+
+FMVMenuScreen::FMVMenuScreen(Gfx::Driver *gfx, Cursor *cursor) :
+		StaticLocationScreen(gfx, cursor, "DiaryFMV", Screen::kScreenFMVMenu) {
+}
+
+FMVMenuScreen::~FMVMenuScreen() {
+}
+
+void FMVMenuScreen::open() {
+	StaticLocationScreen::open();
+
+	_widgets.push_back(new StaticLocationWidget(
+			"BGImage",
+			nullptr,
+			nullptr));
+
+	_widgets.push_back(new StaticLocationWidget(
+			"Return",
+			CLICK_HANDLER(FMVMenuScreen, backHandler),
+			nullptr));
+	_widgets.back()->setupSounds(0, 1);
+
+	_widgets.push_back(new StaticLocationWidget(
+			"Back",
+			CLICK_HANDLER(FMVMenuScreen, backHandler),
+			nullptr));
+	_widgets.back()->setupSounds(0, 1);
+
+	_widgets.push_back(new StaticLocationWidget(
+			"PreviousPage",
+			nullptr,
+			nullptr));
+	_widgets.back()->setupSounds(0, 1);
+
+	_widgets.push_back(new StaticLocationWidget(
+			"NextPage",
+			nullptr,
+			nullptr));
+	_widgets.back()->setupSounds(0, 1);
+
+	_widgets.push_back(new StaticLocationWidget(
+			"FormatRectangle",
+			nullptr,
+			nullptr));
+}
+
+void FMVMenuScreen::backHandler() {
+	StarkUserInterface->backPrevScreen();
+}
+
+} // End of namespace Stark

--- a/engines/stark/ui/menu/fmvmenu.cpp
+++ b/engines/stark/ui/menu/fmvmenu.cpp
@@ -36,7 +36,7 @@ namespace Stark {
 // Hard-coded parameters in case cannot retrieve the format rectangle
 Common::Point FMVMenuScreen::_formatRectPos(202, 61);
 int FMVMenuScreen::_fontHeight(16);
-int FMVMenuScreen::_fmvPerPage(18);
+uint FMVMenuScreen::_fmvPerPage(18);
 
 FMVMenuScreen::FMVMenuScreen(Gfx::Driver *gfx, Cursor *cursor) :
 		StaticLocationScreen(gfx, cursor, "DiaryFMV", Screen::kScreenFMVMenu),
@@ -157,18 +157,18 @@ void FMVMenuScreen::freeFMVWidgets() {
 	_fmvWidgets.clear();
 }
 
-void FMVMenuScreen::loadFMVWidgets(int page) {
-	int start = page * _fmvPerPage;
-	int end = start + _fmvPerPage;
+void FMVMenuScreen::loadFMVWidgets(uint page) {
+	uint start = page * _fmvPerPage;
+	uint end = start + _fmvPerPage;
 	end = end < StarkDiary->countFMV() ? end : StarkDiary->countFMV();
 
-	for (int i = start; i < end; ++i) {
+	for (uint i = start; i < end; ++i) {
 		_fmvWidgets.push_back(new FMVWidget(_gfx, i));
 	}
 }
 
-void FMVMenuScreen::changePage(int page) {
-	assert(page >= 0 && page <= _maxPage);
+void FMVMenuScreen::changePage(uint page) {
+	assert(page <= _maxPage);
 
 	freeFMVWidgets();
 	loadFMVWidgets(page);
@@ -179,7 +179,7 @@ void FMVMenuScreen::changePage(int page) {
 	_page = page;
 }
 
-FMVWidget::FMVWidget(Gfx::Driver *gfx, int fmvIndex) :
+FMVWidget::FMVWidget(Gfx::Driver *gfx, uint fmvIndex) :
 		_filename(StarkDiary->getFMVFilename(fmvIndex)),
 		_title(gfx) {
 	_title.setText(StarkDiary->getFMVTitle(fmvIndex));

--- a/engines/stark/ui/menu/fmvmenu.cpp
+++ b/engines/stark/ui/menu/fmvmenu.cpp
@@ -195,7 +195,7 @@ FMVWidget::FMVWidget(Gfx::Driver *gfx, int fmvIndex) :
 }
 
 void FMVWidget::onClick() {
-	StarkUserInterface->requestFMVPlayback(Common::String(_filename));
+	StarkUserInterface->requestFMVPlayback(_filename);
 }
 
 bool FMVWidget::isMouseInside(const Common::Point &mousePos) const {

--- a/engines/stark/ui/menu/fmvmenu.cpp
+++ b/engines/stark/ui/menu/fmvmenu.cpp
@@ -24,6 +24,7 @@
 
 #include "engines/stark/services/services.h"
 #include "engines/stark/services/userinterface.h"
+#include "engines/stark/services/diary.h"
 
 namespace Stark {
 
@@ -70,6 +71,10 @@ void FMVMenuScreen::open() {
 			"FormatRectangle",
 			nullptr,
 			nullptr));
+
+	for (int i = 0; i < StarkDiary->countFMV(); ++i) {
+		debug("%s %s", StarkDiary->getFMVFilename(i).c_str(), StarkDiary->getFMVTitle(i).c_str());
+	}
 }
 
 void FMVMenuScreen::backHandler() {

--- a/engines/stark/ui/menu/fmvmenu.cpp
+++ b/engines/stark/ui/menu/fmvmenu.cpp
@@ -156,7 +156,7 @@ FMVWidget::FMVWidget(Gfx::Driver *gfx, int fmvIndex) :
 }
 
 void FMVWidget::onClick() {
-	StarkUserInterface->requestFMVPlayback(_filename);
+	StarkUserInterface->requestFMVPlayback(Common::String(_filename));
 }
 
 bool FMVWidget::isMouseInside(const Common::Point &mousePos) const {

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -42,6 +42,7 @@ public:
 	// StaticLocationScreen API
 	void open() override;
 	void close() override;
+	void onScreenChanged() override;
 
 protected:
 	// Window API
@@ -50,11 +51,25 @@ protected:
 	void onRender() override;
 
 private:
+	static const int _fmvPerPage = 18;
+
+	enum WidgetIndex {
+		kWidgetPrevious = 3,
+		kWidgetNext = 4
+	};
+
 	Common::Array<FMVWidget *> _fmvWidgets;
 
+	// Count from zero
+	int _page, _maxPage;
+
 	void backHandler();
+	void prevPageHandler() { changePage(_page - 1); }
+	void nextPageHandler() { changePage(_page + 1); }
 
 	void freeFMVWidgets();
+	void loadFMVWidgets(int page);
+	void changePage(int page);
 };
 
 /**
@@ -62,7 +77,7 @@ private:
  */
 class FMVWidget {
 public:
-	FMVWidget(Gfx::Driver *gfx, int index);
+	FMVWidget(Gfx::Driver *gfx, int fmvIndex);
 	~FMVWidget() {}
 
 	void render() { _title.render(_position); }
@@ -76,6 +91,8 @@ public:
 	void onClick();
 
 	void setTextColor(uint32 color) { _title.setColor(color); }
+
+	void onScreenChanged() { _title.resetTexture(); }
 
 private:
 	const static int _fmvPerPage = 18;

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -20,37 +20,28 @@
  *
  */
 
-#ifndef STARK_UI_MENU_DIARY_INDEX_H
-#define STARK_UI_MENU_DIARY_INDEX_H
+#ifndef STARK_UI_MENU_FMV_MENU_H
+#define STARK_UI_MENU_FMV_MENU_H
 
 #include "engines/stark/ui/menu/locationscreen.h"
 
 namespace Stark {
 
 /**
- * The diary index is the in-game menu
+ * The video replay menu
  */
-class DiaryIndexScreen : public StaticLocationScreen {
+class FMVMenuScreen : public StaticLocationScreen {
 public:
-	DiaryIndexScreen(Gfx::Driver *gfx, Cursor *cursor);
-	virtual ~DiaryIndexScreen();
+	FMVMenuScreen(Gfx::Driver *gfx, Cursor *cursor);
+	virtual ~FMVMenuScreen();
 
 	// StaticLocationScreen API
 	void open() override;
 
 private:
-	void widgetTextColorHandler(StaticLocationWidget &widget, const Common::Point &mousePos);
 	void backHandler();
-	void settingsHandler();
-	void fmvHandler();
-	void loadHandler();
-	void saveHandler();
-	void quitHandler();
-
-	static const uint32 _textColorHovered = 0xFF961E1E;
-	static const uint32 _textColorDefault = 0xFF000000;
 };
 
 } // End of namespace Stark
 
- #endif // STARK_UI_MENU_DIARY_INDEX_H
+#endif // STARK_UI_MENU_FMV_MENU_H

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -100,7 +100,7 @@ private:
 	static const uint32 _textColorHovered = 0xFF961E1E;
 	static const uint32 _textColorDefault = 0xFF000000;
 
-	Common::String _filename;
+	const Common::String &_filename;
 	VisualText _title;
 
 	int _width;

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -38,7 +38,7 @@ class FMVMenuScreen : public StaticLocationScreen {
 public:
 	static Common::Point _formatRectPos;
 	static int _fontHeight;
-	static int _fmvPerPage;
+	static uint _fmvPerPage;
 
 	FMVMenuScreen(Gfx::Driver *gfx, Cursor *cursor);
 	virtual ~FMVMenuScreen();
@@ -63,15 +63,15 @@ private:
 	Common::Array<FMVWidget *> _fmvWidgets;
 
 	// Count from zero
-	int _page, _maxPage;
+	uint _page, _maxPage;
 
 	void backHandler();
 	void prevPageHandler() { changePage(_page - 1); }
 	void nextPageHandler() { changePage(_page + 1); }
 
 	void freeFMVWidgets();
-	void loadFMVWidgets(int page);
-	void changePage(int page);
+	void loadFMVWidgets(uint page);
+	void changePage(uint page);
 };
 
 /**
@@ -79,7 +79,7 @@ private:
  */
 class FMVWidget {
 public:
-	FMVWidget(Gfx::Driver *gfx, int fmvIndex);
+	FMVWidget(Gfx::Driver *gfx, uint fmvIndex);
 	~FMVWidget() {}
 
 	void render() { _title.render(_position); }

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -25,7 +25,11 @@
 
 #include "engines/stark/ui/menu/locationscreen.h"
 
+#include "engines/stark/visual/text.h"
+
 namespace Stark {
+
+class FMVWidget;
 
 /**
  * The video replay menu
@@ -37,9 +41,53 @@ public:
 
 	// StaticLocationScreen API
 	void open() override;
+	void close() override;
+
+protected:
+	// Window API
+	void onMouseMove(const Common::Point &pos) override;
+	void onClick(const Common::Point &pos) override;
+	void onRender() override;
 
 private:
+	Common::Array<FMVWidget *> _fmvWidgets;
+
 	void backHandler();
+
+	void freeFMVWidgets();
+};
+
+/**
+ * The widget for FMV entry, specifically built for FMVMenuScreen
+ */
+class FMVWidget {
+public:
+	FMVWidget(Gfx::Driver *gfx, int index);
+	~FMVWidget() {}
+
+	void render() { _title.render(_position); }
+
+	bool isMouseInside(const Common::Point &mousePos) const;
+
+	void onMouseMove(const Common::Point &mousePos) {
+		setTextColor(isMouseInside(mousePos) ? _textColorHovered : _textColorDefault);
+	}
+
+	void onClick();
+
+	void setTextColor(uint32 color) { _title.setColor(color); }
+
+private:
+	const static int _fmvPerPage = 18;
+	const static int _height = 16;
+	static const uint32 _textColorHovered = 0xFF961E1E;
+	static const uint32 _textColorDefault = 0xFF000000;
+
+	Common::String _filename;
+	VisualText _title;
+
+	int _width;
+	Common::Point _position;
 };
 
 } // End of namespace Stark

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -36,6 +36,10 @@ class FMVWidget;
  */
 class FMVMenuScreen : public StaticLocationScreen {
 public:
+	static Common::Point _formatRectPos;
+	static int _fontHeight;
+	static int _fmvPerPage;
+
 	FMVMenuScreen(Gfx::Driver *gfx, Cursor *cursor);
 	virtual ~FMVMenuScreen();
 
@@ -51,8 +55,6 @@ protected:
 	void onRender() override;
 
 private:
-	static const int _fmvPerPage = 18;
-
 	enum WidgetIndex {
 		kWidgetPrevious = 3,
 		kWidgetNext = 4
@@ -95,8 +97,6 @@ public:
 	void onScreenChanged() { _title.resetTexture(); }
 
 private:
-	const static int _fmvPerPage = 18;
-	const static int _height = 16;
 	static const uint32 _textColorHovered = 0xFF961E1E;
 	static const uint32 _textColorDefault = 0xFF000000;
 

--- a/engines/stark/ui/menu/saveloadmenu.cpp
+++ b/engines/stark/ui/menu/saveloadmenu.cpp
@@ -207,8 +207,8 @@ SaveDataWidget::SaveDataWidget(int slot, Gfx::Driver *gfx, SaveLoadMenuScreen *s
 	lineSurface.free();
 
 	// Set the position
-	_thumbPos.x = 41 + (_slot % _slotPerRow) * (_thumbWidth + 39);
-	_thumbPos.y = 61 + (_slot % _slotPerPage / _slotPerColumn) * (_thumbHeight + 38);
+	_thumbPos.x = 41 + (_slot % SaveLoadMenuScreen::_slotPerRow) * (_thumbWidth + 39);
+	_thumbPos.y = 61 + (_slot % SaveLoadMenuScreen::_slotPerPage / SaveLoadMenuScreen::_slotPerColumn) * (_thumbHeight + 38);
 
 	_textDescPos.x = _thumbPos.x;
 	_textDescPos.y = _thumbPos.y + _thumbHeight + 2;

--- a/engines/stark/ui/menu/saveloadmenu.h
+++ b/engines/stark/ui/menu/saveloadmenu.h
@@ -43,6 +43,10 @@ class SaveDataWidget;
  */
 class SaveLoadMenuScreen : public StaticLocationScreen {
 public:
+	static const int _slotPerRow = 3;
+	static const int _slotPerColumn = 3;
+	static const int _slotPerPage = 9;
+
 	SaveLoadMenuScreen(Gfx::Driver *gfx, Cursor *cursor, Screen::Name screenName);
 	virtual ~SaveLoadMenuScreen();
 
@@ -68,7 +72,6 @@ protected:
 
 private:
 	static const uint32 _textColorBlack = 0xFF000000;
-	static const int _slotPerPage = 9;
 
 	// Start from zero
 	static const int _maxPage = 10;
@@ -142,9 +145,6 @@ public:
 private:
 	static const uint32 _outlineColor = 0xFF961E1E;
 	static const uint32 _textColor = 0xFF3D485C;
-	static const int _slotPerRow = 3;
-	static const int _slotPerColumn = 3;
-	static const int _slotPerPage = 9;
 
 	int _slot;
 	SaveLoadMenuScreen *_screen;

--- a/engines/stark/ui/screen.h
+++ b/engines/stark/ui/screen.h
@@ -42,7 +42,8 @@ public:
 		kScreenDiaryIndex,
 		kScreenSettingsMenu,
 		kScreenSaveMenu,
-		kScreenLoadMenu
+		kScreenLoadMenu,
+		kScreenFMVMenu
 	};
 
 	explicit Screen(Name name) : _name(name) {};

--- a/engines/stark/ui/world/gamescreen.cpp
+++ b/engines/stark/ui/world/gamescreen.cpp
@@ -36,10 +36,6 @@
 #include "engines/stark/resources/level.h"
 #include "engines/stark/resources/location.h"
 
-#include "engines/engine.h"
-
-#include "audio/mixer.h"
-
 namespace Stark {
 
 GameScreen::GameScreen(Gfx::Driver *gfx, Cursor *cursor) :
@@ -146,7 +142,6 @@ void GameScreen::pauseGame(bool pause) {
 		StarkGlobal->getCurrent()->getLevel()->onEnginePause(pause);
 		StarkGlobal->getCurrent()->getLocation()->onEnginePause(pause);
 	}
-	g_engine->_mixer->pauseAll(pause);
 }
 
 } // End of namespace Stark

--- a/engines/stark/ui/world/gamescreen.cpp
+++ b/engines/stark/ui/world/gamescreen.cpp
@@ -24,6 +24,7 @@
 
 #include "engines/stark/services/services.h"
 #include "engines/stark/services/userinterface.h"
+#include "engines/stark/services/global.h"
 
 #include "engines/stark/ui/cursor.h"
 #include "engines/stark/ui/world/actionmenu.h"
@@ -32,7 +33,12 @@
 #include "engines/stark/ui/world/inventorywindow.h"
 #include "engines/stark/ui/world/topmenu.h"
 
+#include "engines/stark/resources/level.h"
+#include "engines/stark/resources/location.h"
+
 #include "engines/engine.h"
+
+#include "audio/mixer.h"
 
 namespace Stark {
 
@@ -64,15 +70,14 @@ GameScreen::~GameScreen() {
 }
 
 void GameScreen::open() {
-	if (g_engine->isPaused()) {
-		g_engine->pauseEngine(false);
-	}
+	pauseGame(false);
 	StarkUserInterface->freeGameScreenThumbnail();
 }
 
 void GameScreen::close() {
 	_cursor->setMouseHint("");
-	g_engine->pauseEngine(true);
+	pauseGame(true);
+	StarkUserInterface->saveGameScreenThumbnail();
 }
 
 void GameScreen::render() {
@@ -131,6 +136,17 @@ void GameScreen::notifyInventoryItemEnabled(uint16 itemIndex) {
 
 void GameScreen::notifyDiaryEntryEnabled() {
 	_topMenu->notifyDiaryEntryEnabled();
+}
+
+void GameScreen::pauseGame(bool pause) {
+	if (StarkGlobal->getLevel()) {
+		StarkGlobal->getLevel()->onEnginePause(pause);
+	}
+	if (StarkGlobal->getCurrent()) {
+		StarkGlobal->getCurrent()->getLevel()->onEnginePause(pause);
+		StarkGlobal->getCurrent()->getLocation()->onEnginePause(pause);
+	}
+	g_engine->_mixer->pauseAll(pause);
 }
 
 } // End of namespace Stark

--- a/engines/stark/ui/world/gamescreen.cpp
+++ b/engines/stark/ui/world/gamescreen.cpp
@@ -32,6 +32,8 @@
 #include "engines/stark/ui/world/inventorywindow.h"
 #include "engines/stark/ui/world/topmenu.h"
 
+#include "engines/engine.h"
+
 namespace Stark {
 
 GameScreen::GameScreen(Gfx::Driver *gfx, Cursor *cursor) :
@@ -62,12 +64,15 @@ GameScreen::~GameScreen() {
 }
 
 void GameScreen::open() {
+	if (g_engine->isPaused()) {
+		g_engine->pauseEngine(false);
+	}
 	StarkUserInterface->freeGameScreenThumbnail();
 }
 
 void GameScreen::close() {
 	_cursor->setMouseHint("");
-	StarkUserInterface->saveGameScreenThumbnail();
+	g_engine->pauseEngine(true);
 }
 
 void GameScreen::render() {

--- a/engines/stark/ui/world/gamescreen.h
+++ b/engines/stark/ui/world/gamescreen.h
@@ -84,6 +84,7 @@ private:
 
 	typedef void (Window::*WindowHandler)();
 	void dispatchEvent(WindowHandler handler);
+	void pauseGame(bool pause);
 };
 
 } // End of namespace Stark

--- a/engines/stark/visual/text.h
+++ b/engines/stark/visual/text.h
@@ -56,6 +56,9 @@ public:
 	void setTargetHeight(uint32 height);
 	void setFont(FontProvider::FontType type, int32 customFontIndex = -1);
 
+	uint getTargetWidth() { return _targetWidth; }
+	uint getTargetHeight() { return _targetHeight; }
+
 	void render(const Common::Point &position);
 	void resetTexture();
 


### PR DESCRIPTION
This PR is corresponding to the implementation of the video replay menu of TLJ, ~which is probably the easiest menu to implement~.

Based on the original game, the widget for FMV entries works slightly different from our written `StaticLocationWidget`. The cursor will not change when hovering on it. Since the widget does not have many fancy functionalities, I chose to build it out of scratch instead of extending the `StaticLocationWidget`.

I don't see the necessity to dynamically calculate some UI position parameters so I hard-coded them. If the dynamic calculation is really needed like there is a version with dramatically long video titles in a different language, it could be easily fixed.

It would be important now to actually [pause the game's sound when the menu is opened](https://github.com/residualvm/residualvm/pull/1429), otherwise, the game's sound will jam with the replayed video sound.