### PR TITLE
AMIGAOS4: SDL/OGL - Add backwards compatibility for AmigaOS4

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -278,8 +278,16 @@ bool OpenGLSdlGraphicsManager::createOrUpdateGLContext(uint effectiveWidth, uint
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
 #else
-		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+		// AmigaOS4's OpenGL implementation is close to 1.3. Until that changes we need
+		// to use 1.3 as version or residualvm will cease working at all on that platform.
+		// This will be revised and removed once AmigaOS4 supports 2.x or OpenGLES.
+		#ifdef __amigaos4__
+			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+		#else
+			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+		#endif
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
 #endif
 #endif


### PR DESCRIPTION
Since the internal switch to OpenGL 2.0, residualvm stopped working entirely on the AmigaOS4 platform.
Due to the fact that AmigaOS4 only supports OpenGL close to version 1.3, the program quits right after starting with an error message of not being able to create a proper screen.

This PR is to make residualvm work again on the AmigaOS4 platform (Grim Fandango is working great, EMI with a few glitches, TLJ not at all due to missing shaders).

Please revise and tell me what has to be changed to get accepted.
Maybe there is another (cleaner) way to do it, if so, please advise.