### PR TITLE
[STARK] Changed listInventory → listInventoryItems 

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Command               | Description
 `enableInventoryItem` | Enable a specific inventory item
 `enableScript`        | Enable or disable script
 `forceScript`         | Force the execution of a script
-`listInventory`       | List all inventory items in the game
+`listInventoryItems`  | List all inventory items in the game
 `listLocations`       | List all the locations in the game
 `listScripts`         | List all the scripts in current level
 `location`            | Display the current location

--- a/engines/stark/console.cpp
+++ b/engines/stark/console.cpp
@@ -59,7 +59,7 @@ Console::Console() :
 	registerCmd("forceScript",          WRAP_METHOD(Console, Cmd_ForceScript));
 	registerCmd("decompileScript",      WRAP_METHOD(Console, Cmd_DecompileScript));
 	registerCmd("testDecompiler",       WRAP_METHOD(Console, Cmd_TestDecompiler));
-	registerCmd("listInventory",        WRAP_METHOD(Console, Cmd_ListInventory));
+	registerCmd("listInventoryItems",   WRAP_METHOD(Console, Cmd_ListInventoryItems));
 	registerCmd("listLocations",        WRAP_METHOD(Console, Cmd_ListLocations));
 	registerCmd("location",             WRAP_METHOD(Console, Cmd_Location));
 	registerCmd("chapter",              WRAP_METHOD(Console, Cmd_Chapter));
@@ -495,7 +495,7 @@ bool Console::Cmd_EnableInventoryItem(int argc, const char **argv) {
 	}
 
 	if (argc != 2) {
-		debugPrintf("Enable a specific inventory item. Use listInventory to get an id\n");
+		debugPrintf("Enable a specific inventory item. Use listInventoryItems to get an id\n");
 		debugPrintf("Usage :\n");
 		debugPrintf("enableInventoryItem [id]\n");
 		return true;


### PR DESCRIPTION
Changed listInventory to listInventoryItems to fit other commands, that is.:
* changeLocation → listLocations
* decompileScript, enableScript, forceScript → listScripts
so
* enableInventoryItem → listInventory**Items**

Also updated README.md with the updated command name.