### PR TITLE
MYST3: Debug warn instead of error for unknown var

### DIFF
--- a/engines/myst3/console.cpp
+++ b/engines/myst3/console.cpp
@@ -165,6 +165,10 @@ bool Console::Cmd_Var(int argc, const char **argv) {
 	}
 
 	uint16 var = atoi(argv[1]);
+	if (var < 1 || var > 2047) {
+		debugPrintf("Variable out of range %d\n", var);
+		return true;
+	}	
 	uint32 value = _vm->_state->getVar(var);
 
 	if (argc == 3) {


### PR DESCRIPTION
When using the var command in the debug console warn
if the variable number is not in range rather than
error.