### PR TITLE
GFX: Do not consult color map for alpha for AlphaOff meshes

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -770,7 +770,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 			byte r = (byte)(model->_colorMap[index].r * lighting.x());
 			byte g = (byte)(model->_colorMap[index].g * lighting.y());
 			byte b = (byte)(model->_colorMap[index].b * lighting.z());
-			byte a = (int)(model->_colorMap[index].a * alpha * _currentActor->getLocalAlpha(index));
+			byte a = (int)(alpha * (model->_meshAlphaMode == Actor::AlphaReplace ? model->_colorMap[index].a * _currentActor->getLocalAlpha(index) : 255.f));
 			glColor4ub(r, g, b, a);
 		}
 


### PR DESCRIPTION
This PR is intended to solve #1263: it ignores zero-alpha values in the color map instead of propagating them to the framebuffer causing black silhouettes to appear. I cannot reproduce the issue locally but an API trace confirmed that all pixels written have the correct alpha value now.

EDIT: this only affects the regular OpenGL drawing, and only EMI.