### PR TITLE
STARK: Enabled and fixed action menu and cursor scaling

### DIFF
--- a/engines/stark/gfx/driver.cpp
+++ b/engines/stark/gfx/driver.cpp
@@ -69,7 +69,7 @@ void Driver::toggleFullscreen() const {
 void Driver::computeScreenViewport() {
 	int32 screenWidth = g_system->getWidth();
 	int32 screenHeight = g_system->getHeight();
-	
+
 	if (g_system->getFeatureState(OSystem::kFeatureAspectRatioCorrection)) {
 		// Aspect ratio correction
 		int32 viewportWidth = MIN<int32>(screenWidth, screenHeight * kOriginalWidth / kOriginalHeight);
@@ -89,16 +89,16 @@ Common::Rect Driver::gameViewport(bool unscaled) const {
 	uint32 width = 640;
 	uint32 height = 480;
 	uint32 left = 0;
-	
-	if(unscaled){
+
+	if(unscaled) {
 		width = _screenViewport.width();
 		height = _screenViewport.height();
 		left = _screenViewport.left;
 	}
-	
+
 	Common::Rect game = Common::Rect(width, height * kGameViewportHeight / kOriginalHeight);
 	game.translate(left, _screenViewport.top + height * kTopBorderHeight / kOriginalHeight);
-	
+
 	return game;
 }
 

--- a/engines/stark/gfx/driver.cpp
+++ b/engines/stark/gfx/driver.cpp
@@ -69,7 +69,7 @@ void Driver::toggleFullscreen() const {
 void Driver::computeScreenViewport() {
 	int32 screenWidth = g_system->getWidth();
 	int32 screenHeight = g_system->getHeight();
-
+	
 	if (g_system->getFeatureState(OSystem::kFeatureAspectRatioCorrection)) {
 		// Aspect ratio correction
 		int32 viewportWidth = MIN<int32>(screenWidth, screenHeight * kOriginalWidth / kOriginalHeight);
@@ -85,11 +85,25 @@ void Driver::computeScreenViewport() {
 	}
 }
 
-Common::Rect Driver::gameViewport() const {
-	Common::Rect game = Common::Rect(_screenViewport.width(), _screenViewport.height() * kGameViewportHeight / kOriginalHeight);
-	game.translate(_screenViewport.left, _screenViewport.top + _screenViewport.height() * kTopBorderHeight / kOriginalHeight);
-
+Common::Rect Driver::gameViewport(bool unscaled) const {
+	uint32 width = 640;
+	uint32 height = 480;
+	uint32 left = 0;
+	
+	if(unscaled){
+		width = _screenViewport.width();
+		height = _screenViewport.height();
+		left = _screenViewport.left;
+	}
+	
+	Common::Rect game = Common::Rect(width, height * kGameViewportHeight / kOriginalHeight);
+	game.translate(left, _screenViewport.top + height * kTopBorderHeight / kOriginalHeight);
+	
 	return game;
+}
+
+Common::Rect Driver::gameViewport() const {
+	return gameViewport(true);
 }
 
 Common::Point Driver::convertCoordinateCurrentToOriginal(const Common::Point &point) const {

--- a/engines/stark/gfx/driver.h
+++ b/engines/stark/gfx/driver.h
@@ -62,6 +62,7 @@ public:
 	/** Get the screen viewport in actual resolution */
 	Common::Rect getScreenViewport() { return _screenViewport; }
 
+	Common::Rect gameViewport(bool unscaled) const;
 	Common::Rect gameViewport() const;
 
 	virtual void clearScreen() = 0;

--- a/engines/stark/ui/cursor.cpp
+++ b/engines/stark/ui/cursor.cpp
@@ -122,10 +122,10 @@ void Cursor::render() {
 	}
 
 	if (_cursorImage) {
-		_gfx->setScreenViewport(false); // The cursor is drawn scaled
+		_gfx->setScreenViewport(true); // Unscaled viewport so that cursor is drawn on native pixel space, thus no 'skipping', perform scaling below instead
 
 		_cursorImage->setFadeLevel(_fadeLevel);
-		_cursorImage->render(_gfx->convertCoordinateCurrentToOriginal(_mousePos), true);
+		_cursorImage->render(_mousePos, true, false); // Draws image (scaled)
 	}
 }
 

--- a/engines/stark/ui/cursor.cpp
+++ b/engines/stark/ui/cursor.cpp
@@ -110,7 +110,7 @@ void Cursor::render() {
 
 		// TODO: Should probably query the image for the width of the cursor
 		// TODO: Add delay to the mouse hints like in the game
-		const int16 cursorDistance = _gfx->scaleHeightCurrentToOriginal(32);
+		const int16 cursorDistance = 32;
 		Common::Rect mouseRect = _mouseText->getRect();
 		Common::Point pos = _gfx->convertCoordinateCurrentToOriginal(_mousePos);
 		pos.x = CLIP<int16>(pos.x, 48, Gfx::Driver::kOriginalWidth - 48);
@@ -122,10 +122,10 @@ void Cursor::render() {
 	}
 
 	if (_cursorImage) {
-		_gfx->setScreenViewport(true); // The cursor is drawn unscaled
+		_gfx->setScreenViewport(false); // The cursor is drawn scaled
 
 		_cursorImage->setFadeLevel(_fadeLevel);
-		_cursorImage->render(_mousePos, true);
+		_cursorImage->render(_gfx->convertCoordinateCurrentToOriginal(_mousePos), true);
 	}
 }
 

--- a/engines/stark/ui/world/actionmenu.cpp
+++ b/engines/stark/ui/world/actionmenu.cpp
@@ -51,7 +51,7 @@ ActionMenu::ActionMenu(Gfx::Driver *gfx, Cursor *cursor) :
 		_item(nullptr),
 		_fromInventory(false) {
 
-	_unscaled = true;
+	_unscaled = false;
 
 	_background = StarkStaticProvider->getUIElement(StaticProvider::kActionMenuBg);
 
@@ -71,7 +71,7 @@ ActionMenu::~ActionMenu() {
 void ActionMenu::open(Resources::ItemVisual *item, const Common::Point &itemRelativePos) {
 	_visible = true;
 
-	Common::Point screenMousePos = _cursor->getMousePosition(true);
+	Common::Point screenMousePos = _cursor->getMousePosition(_unscaled);
 
 	_position = getPosition(screenMousePos);
 
@@ -106,7 +106,7 @@ void ActionMenu::close() {
 Common::Rect ActionMenu::getPosition(const Common::Point &mouse) const {
 	Common::Rect position = Common::Rect::center(mouse.x, mouse.y, 160, 111);
 
-	Common::Rect gameWindowRect = StarkGfx->gameViewport();
+	Common::Rect gameWindowRect = StarkGfx->gameViewport(_unscaled);
 
 	if (position.top < gameWindowRect.top)       position.translate(0, gameWindowRect.top - position.top);
 	if (position.left < gameWindowRect.left)     position.translate(gameWindowRect.left - position.left, 0);

--- a/engines/stark/visual/image.cpp
+++ b/engines/stark/visual/image.cpp
@@ -61,8 +61,17 @@ void VisualImageXMG::load(Common::ReadStream *stream) {
 }
 
 void VisualImageXMG::render(const Common::Point &position, bool useOffset) {
+	render(position, useOffset, true);
+}
+
+void VisualImageXMG::render(const Common::Point &position, bool useOffset, bool unscaled) {
 	Common::Point drawPos = useOffset ? position - _hotspot : position;
-	_surfaceRenderer->render(_texture, drawPos);
+
+	if (!unscaled) {
+		_surfaceRenderer->render(_texture, drawPos, _gfx->scaleWidthOriginalToCurrent(_texture->width()), _gfx->scaleHeightOriginalToCurrent(_texture->height()));
+	} else {
+		_surfaceRenderer->render(_texture, drawPos);
+	}
 }
 
 void VisualImageXMG::setFadeLevel(float fadeLevel) {

--- a/engines/stark/visual/image.h
+++ b/engines/stark/visual/image.h
@@ -52,6 +52,7 @@ public:
 
 	void load(Common::ReadStream *stream);
 	void render(const Common::Point &position, bool useOffset);
+	void render(const Common::Point &position, bool useOffset, bool unscaled);
 
 	/** Set an offset used when rendering */
 	void setHotSpot(const Common::Point &hotspot);


### PR DESCRIPTION
No reason not to scale them. As it currently is the proportions of these things are messed up when using high resolution, harming the user experience, which of course doesn't happen with the original game where there are only two possibilities: either no scaling at all and everything has the right proportions, or everything is scaled (by the monitor, GPU, or otherwise as the original game doesn't support scaling at all) with everything still having the right proportions. But there is no possibility in the original game where the situation is like it currently is with ResidualVM, where most things are scaled, but cursor and action menu aren't.