### PR TITLE
MYST3: Don't repeat first sin value in Effect

### DIFF
--- a/engines/myst3/effects.cpp
+++ b/engines/myst3/effects.cpp
@@ -488,7 +488,7 @@ bool MagnetEffect::update() {
 
 		if (ampl != _lastAmpl) {
 			for (uint i = 0; i < 256; i++) {
-				_verticalDisplacement[i] = sin(i * 2 * M_PI / 255.0) * ampl;
+				_verticalDisplacement[i] = sin(i * 2 * M_PI / 256.0) * ampl;
 			}
 
 			_lastAmpl = ampl;
@@ -759,7 +759,7 @@ bool ShieldEffect::update() {
 
 	// Update the displacement offsets
 	for (uint i = 0; i < 256; i++) {
-		_displacement[i] = (sin(i * 2 * M_PI / 255.0) + 1.0) * _amplitude;
+		_displacement[i] = (sin(i * 2 * M_PI / 256.0) + 1.0) * _amplitude;
 	}
 
 	return true;


### PR DESCRIPTION
Two of the sin loops evaluate sin(2 pi 255/255) at the
end of the sine loop which is the same as the first index,
sin(2 pi * 0), so when update() is called twice back to back
the last value of the first call, sin(2 pi 255/255) and the
first value of the next value sin(2 pi * 0) will be the same
so in effect it will be repeating the same sine value twice.

This changes the loop so it indexes the sin with 256 pieces
so that the last value is sin(2 pi * 255/256).