### PR TITLE
GRIM: Image format must match internalformat for sprites too (ES2)

### DIFF
--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1066,6 +1066,7 @@ void GfxOpenGLS::drawSprite(const Sprite *sprite) {
 	extraMatrix.transpose();
 	_spriteProgram->setUniform("extraMatrix", extraMatrix);
 	_spriteProgram->setUniform("textured", GL_TRUE);
+	_spriteProgram->setUniform("swapRandB", _selectedTexture->_colorFormat == BM_BGRA || _selectedTexture->_colorFormat == BM_BGR888);
 	_spriteProgram->setUniform("isBillboard", GL_TRUE);
 	_spriteProgram->setUniform("lightsEnabled", false);
 	if (g_grim->getGameType() == GType_GRIM) {


### PR DESCRIPTION
"swapRandB" variable must be set for sprites too, when ResidualVM is built with opengles2 + shaders support.

It fixes this kind of wrong colors rendered:

Here, flames color:
![bad1](https://user-images.githubusercontent.com/452720/52148973-b31eb100-266b-11e9-9ed2-e18d6ba27778.png)  ![good1](https://user-images.githubusercontent.com/452720/52148980-b87bfb80-266b-11e9-852d-d036d547d59f.png)

Other example, ship and blaze colors:
![bad2](https://user-images.githubusercontent.com/452720/52149009-cd588f00-266b-11e9-9bbb-c90ac30d496a.png)
![good2](https://user-images.githubusercontent.com/452720/52149013-cf225280-266b-11e9-9e53-1bbd09308b9d.png)



