### PR TITLE
SDL: Add the support of saving screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Arrow keys      | Movement
 `Alt` + `x`     | Quit (in-game)
 `Ctrl` + `c`    | Force quit (from command line)
 `Alt` + `Enter` | Switch between windowed mode and fullscreen
+`Alt` + `s`     | Save a screenshot
 
 ### 3.4. Joystick/gamepad support ###
 
@@ -212,6 +213,7 @@ Key           | Binding
 `Ctrl` + `F5` | ResidualVM menu
 `Ctrl` + `c`  | Force quit (from command line)
 `Ctrl` + `q`  | Quit (in-game)
+`Alt`  + `s`  | Save a screenshot
 
 
 ## 5. Running The Longest Journey
@@ -226,6 +228,7 @@ need:
   * The `static` directory.
   * The `fonts` directory (not critical, but recommended – see below).
   * `x.xarc` and all the `INI` files.
+  * `game.exe` (not critical, but recommended for a styled message dialog)
 
 The 2-CD and DVD versions have some of the data files packed in installer
 archives. The archives need to be unpacked before they can be used.
@@ -258,6 +261,7 @@ Key             | Binding
 `F5`            | April's Diary (initially disabled)
 `F6`            | Video replay
 `F7`            | Game settings
+`F8`            | Save a screenshot
 `F9`            | Toggle subtitles on and off
 `F10`           | Quit game and return to to main menu
 `A`             | Cycle back through inventory cursor items
@@ -277,6 +281,7 @@ Key             | Binding
 `Ctrl` + `q`    | Quit (in-game)
 `Alt` + `x`     | Quit
 `Alt` + `q`     | Quit
+`Alt` + `s`     | Save a screenshot
 
 
 ## 6. Configuration
@@ -297,7 +302,25 @@ Linux                | `~/.config/residualvm/residualvm.ini`
 macOS/OS X           | `~/Library/Preferences/ResidualVM Preferences`
 Others               | `residualvm.ini` in the current directory
 
-### 6.2. Interesting settings for GrimE games ###
+### 6.2. Location of saved screenshots ###
+
+By default, screenshots will be saved to:
+
+Operating System    | Location
+------------------- | -----------------------------------------------------------------
+Windows             | `\Users\username\My Pictures\ResidualVM Screenshots`
+macOS X             | On the Desktop
+Other unices        | In the XDG Pictures user directory, e.g. `~/Pictures/ResidualVM Screenshots`
+Any other OS        | In the current directory
+
+Alternatively, you can specify the directory where the screenshots will be saved in the configuration file. To do so, add a screenshotpath value under the [residualvm] section:
+
+```
+[residualvm]
+screenshotpath=/path/to/screenshots/
+```
+
+### 6.3. Interesting settings for GrimE games ###
 
 The following settings are currently available in the config file, however
 some of them might not work with your current build and some of them might

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -22,6 +22,8 @@
 
 #include "common/scummsys.h"
 
+// #define SDL_BACKEND
+
 #if defined(SDL_BACKEND)
 
 #include "backends/graphics/openglsdl/openglsdl-graphics.h"
@@ -657,8 +659,8 @@ void OpenGLSdlGraphicsManager::deinitializeRenderer() {
 
 bool OpenGLSdlGraphicsManager::saveScreenshot(const Common::String &file) const {
 	// Largely based on the implementation from ScummVM
-	uint width = getWidth();
-	uint height = getHeight();
+	uint width = _overlayScreen->getWidth();
+	uint height = _overlayScreen->getHeight();
 
 	uint linePaddingSize = width % 4;
 	uint lineSize = width * 3 + linePaddingSize;
@@ -670,7 +672,14 @@ bool OpenGLSdlGraphicsManager::saveScreenshot(const Common::String &file) const 
 
 	Common::Array<uint8> pixels;
 	pixels.resize(lineSize * height);
+
+	if (_frameBuffer) {
+		_frameBuffer->detach();
+	}
 	glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, &pixels.front());
+	if (_frameBuffer) {
+		_frameBuffer->attach();
+	}
 
 #ifdef USE_PNG
 	Graphics::PixelFormat format(3, 8, 8, 8, 0, 16, 8, 0, 0);

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -37,6 +37,9 @@
 #include "graphics/opengl/texture.h"
 #include "graphics/opengl/tiledsurface.h"
 
+#include "common/file.h"
+#include "image/png.h"
+
 OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window, const Capabilities &capabilities)
 	:
 	ResVmSdlGraphicsManager(sdlEventSource, window, capabilities),
@@ -651,5 +654,58 @@ void OpenGLSdlGraphicsManager::deinitializeRenderer() {
 	_glContext = nullptr;
 }
 #endif // SDL_VERSION_ATLEAST(2, 0, 0)
+
+bool OpenGLSdlGraphicsManager::saveScreenshot(const Common::String &file) const {
+	// Largely based on the implementation from ScummVM
+	uint width = getWidth();
+	uint height = getHeight();
+
+	uint linePaddingSize = width % 4;
+	uint lineSize = width * 3 + linePaddingSize;
+
+	Common::DumpFile out;
+	if (!out.open(file)) {
+		return false;
+	}
+
+	Common::Array<uint8> pixels;
+	pixels.resize(lineSize * height);
+	glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, &pixels.front());
+
+#ifdef USE_PNG
+	Graphics::PixelFormat format(3, 8, 8, 8, 0, 16, 8, 0, 0);
+	Graphics::Surface data;
+	data.init(width, height, lineSize, &pixels.front(), format);
+	return Image::writePNG(out, data, true);
+#else
+	for (uint y = height; y-- > 0;) {
+		uint8 *line = &pixels.front() + y * lineSize;
+
+		for (uint x = width; x > 0; --x, line += 3) {
+			SWAP(line[0], line[2]);
+		}
+	}
+
+	out.writeByte('B');
+	out.writeByte('M');
+	out.writeUint32LE(height * lineSize + 54);
+	out.writeUint32LE(0);
+	out.writeUint32LE(54);
+	out.writeUint32LE(40);
+	out.writeUint32LE(width);
+	out.writeUint32LE(height);
+	out.writeUint16LE(1);
+	out.writeUint16LE(24);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.writeUint32LE(0);
+	out.write(&pixels.front(), pixels.size());
+
+	return true;
+#endif
+}
 
 #endif

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -129,6 +129,9 @@ protected:
 	OpenGL::FrameBuffer *createFramebuffer(uint width, uint height);
 
 	bool isVSyncEnabled() const;
+
+	// ResVmSdlGraphicsManager API
+	virtual bool saveScreenshot(const Common::String &file) const override;
 };
 
 #endif

--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -24,9 +24,11 @@
 
 #include "backends/platform/sdl/sdl-sys.h"
 #include "backends/events/sdl/sdl-events.h"
+#include "backends/platform/sdl/sdl.h"
 
 #include "common/config-manager.h"
 #include "common/textconsole.h"
+#include "common/file.h"
 
 static const OSystem::GraphicsMode s_supportedGraphicsModes[] = {
 		{0, 0, 0}
@@ -239,6 +241,9 @@ bool ResVmSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 	//ResidualVM specific:
 	switch ((int)event.type) {
 		case Common::EVENT_KEYDOWN:
+			if (event.kbd.hasFlags(Common::KBD_ALT) && event.kbd.keycode == Common::KEYCODE_s) {
+				saveScreenshot();
+			}
 			break;
 		case Common::EVENT_KEYUP:
 			break;
@@ -259,4 +264,42 @@ bool ResVmSdlGraphicsManager::notifyMousePosition(Common::Point mouse) {
 	// ResidualVM: not use that:
 	//setMousePos(mouse.x, mouse.y);
 	return true;
+}
+
+void ResVmSdlGraphicsManager::saveScreenshot() const {
+	OSystem_SDL *g_systemSdl = dynamic_cast<OSystem_SDL*>(g_system);
+
+	if (g_systemSdl) {
+		Common::String filename;
+		Common::String path = g_systemSdl->getScreenshotsPath();
+
+		// Find unused filename
+		int n = 0;
+		while (true) {
+#ifdef USE_PNG
+			filename = Common::String::format("residualvm%05d.png", n);
+#else
+			filename = Common::String::format("residualvm%05d.bmp", n);
+#endif
+			SDL_RWops *file = SDL_RWFromFile((path + filename).c_str(), "r");
+			if (!file) {
+				break;
+			}
+			SDL_RWclose(file);
+
+			++n;
+		}
+
+		if (saveScreenshot(path + filename)) {
+			if (path.empty())
+				debug("Saved screenshot '%s' in current directory", filename.c_str());
+			else
+				debug("Saved screenshot '%s' in directory '%s'", filename.c_str(), path.c_str());
+		} else {
+			if (path.empty())
+				warning("Could not save screenshot in current directory");
+			else
+				warning("Could not save screenshot in directory '%s'", path.c_str());
+		}
+	}
 }

--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -243,6 +243,7 @@ bool ResVmSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 		case Common::EVENT_KEYDOWN:
 			if (event.kbd.hasFlags(Common::KBD_ALT) && event.kbd.keycode == Common::KEYCODE_s) {
 				saveScreenshot();
+				return true;
 			}
 			break;
 		case Common::EVENT_KEYUP:

--- a/backends/graphics/sdl/resvm-sdl-graphics.h
+++ b/backends/graphics/sdl/resvm-sdl-graphics.h
@@ -126,6 +126,12 @@ public:
 	 */
 	bool isMouseLocked() const;
 
+	/**
+	 * Public method for saving a screenshot.
+	 * The method of capturing is based on the actual type of the graphics manager.
+	 */
+	void saveScreenshot() const;
+
 protected:
 	const Capabilities &_capabilities;
 
@@ -145,6 +151,11 @@ protected:
 
 	/** Obtain the user configured fullscreen resolution, or default to the desktop resolution */
 	Common::Rect getPreferredFullscreenResolution();
+
+	/** Save a screenshot to the specified file */
+	virtual bool saveScreenshot(const Common::String &file) const {
+		return false;
+	}
 };
 
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -31,6 +31,9 @@
 #include "graphics/pixelbuffer.h"
 #include "graphics/surface.h"
 
+#include "common/file.h"
+#include "image/png.h"
+
 SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window, const Capabilities &capabilities)
 	:
 	ResVmSdlGraphicsManager(sdlEventSource, window, capabilities),
@@ -467,5 +470,58 @@ SDL_Surface *SurfaceSdlGraphicsManager::SDL_SetVideoMode(int width, int height, 
 	}
 }
 #endif // SDL_VERSION_ATLEAST(2, 0, 0)
+
+bool SurfaceSdlGraphicsManager::saveScreenshot(const Common::String &file) const {
+	// Based on the implementation from ScummVM
+	bool success;
+	SDL_Surface *screen = nullptr;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	int width, height;
+	SDL_GetRendererOutputSize(_renderer, &width, &height);
+
+	screen = SDL_CreateRGBSurface(SDL_SWSURFACE,
+								  width,
+								  height,
+								  24,
+#ifdef SCUMM_LITTLE_ENDIAN
+								  0x0000FF, 0x00FF00, 0xFF0000,
+#else
+								  0xFF0000, 0x00FF00, 0x0000FF,
+#endif // SCUMM_LITTLE_ENDIAN
+								  0);
+
+	SDL_RenderReadPixels(_renderer, nullptr, SDL_PIXELFORMAT_RGB24, screen->pixels, screen->pitch);
+#else
+	screen = _screen;
+#endif // SDL_VERSION_ATLEAST(2, 0, 0)
+
+#ifdef USE_PNG
+	Common::DumpFile out;
+	if (!out.open(file)) {
+		success = false;
+	} else {
+		if (SDL_LockSurface(screen) < 0) {
+			warning("Could not lock the screen surface");
+			success = false;
+		}
+
+		Graphics::PixelFormat format(3, 8, 8, 8, 0, 16, 8, 0, 0);
+		Graphics::Surface data;
+		data.init(width, height, screen->pitch, screen->pixels, format);
+		success = Image::writePNG(out, data);
+
+		SDL_UnlockSurface(screen);
+	}
+#else
+	success = SDL_SaveBMP(screen, file.c_str()) == 0;
+#endif
+
+	if (screen && screen != _screen) {
+		SDL_FreeSurface(screen);
+	}
+
+	return success;
+}
 
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -91,6 +91,9 @@ protected:
 	void drawOverlay();
 	void drawSideTextures();
 	void closeOverlay();
+
+	// ResVmSdlGraphicsManager API
+	virtual bool saveScreenshot(const Common::String &file) const override;
 };
 
 #endif

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -91,6 +91,10 @@ public:
 	virtual void setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d) override;
 	// ResidualVM specific code
 	virtual void launcherInitSize(uint w, uint h) override;
+	// ResidualVM specific code
+	GraphicsManager *getGraphicsManager() {
+		return _graphicsManager;
+	}
 
 protected:
 	bool _inited;

--- a/engines/stark/services/userinterface.cpp
+++ b/engines/stark/services/userinterface.cpp
@@ -58,6 +58,9 @@
 
 #include "gui/message.h"
 
+#include "backends/platform/sdl/sdl.h"
+#include "backends/graphics/sdl/resvm-sdl-graphics.h"
+
 namespace Stark {
 
 UserInterface::UserInterface(Gfx::Driver *gfx) :
@@ -489,7 +492,13 @@ void UserInterface::handleKeyPress(const Common::KeyState &keyState) {
 	} else if (keyState.keycode == Common::KEYCODE_F7) {
 		toggleScreen(Screen::kScreenSettingsMenu);
 	} else if (keyState.keycode == Common::KEYCODE_F8) {
-		warning("TODO: Implement the screenshot saving to local game directory");
+		OSystem_SDL *g_systemSdl = dynamic_cast<OSystem_SDL*>(g_system);
+		if (g_systemSdl) {
+			ResVmSdlGraphicsManager *graphicsMan = dynamic_cast<ResVmSdlGraphicsManager*>(g_systemSdl->getGraphicsManager());
+			if (graphicsMan) {
+				graphicsMan->saveScreenshot();
+			}
+		}
 	} else if (keyState.keycode == Common::KEYCODE_F9) {
 		if (isInGameScreen()) {
 			_shouldToggleSubtitle = !_shouldToggleSubtitle;


### PR DESCRIPTION
These are works referring to what has been done in ScummVM. The hotkey is the same, `Alt + s`.

The key implementation of creating the screenshots is basically the same as ScummVM, I simply make it adjustable with the existed structure of ResidualVM.

I also connect the screenshot saving feature to the F8 key in *The Longest Journey*, which is used by the original game. Yet to achieve this I decide to modify the `sdl.h` file, which comes from ScummVM. I hope this is okay since I see some functions there marked "ResidualVM specific".

I also update the `README.md` to include this new feature. The configuration part is also based on ScummVM's.