### PR TITLE
Fix mouse going out of bounds in fullscreen

### DIFF
--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -260,7 +260,7 @@ void ResVmSdlGraphicsManager::notifyVideoExpose() {
 	//updateScreen();
 }
 
-bool ResVmSdlGraphicsManager::notifyMousePosition(Common::Point mouse) {
+bool ResVmSdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 	transformMouseCoordinates(mouse);
 	// ResidualVM: not use that:
 	//setMousePos(mouse.x, mouse.y);

--- a/backends/graphics/sdl/resvm-sdl-graphics.h
+++ b/backends/graphics/sdl/resvm-sdl-graphics.h
@@ -66,7 +66,7 @@ public:
 	void activateManager() override;
 	void deactivateManager() override;
 	void notifyVideoExpose() override;
-	bool notifyMousePosition(Common::Point mouse) override;
+	bool notifyMousePosition(Common::Point &mouse) override;
 
 	// GraphicsManager API - Features
 	void setFeatureState(OSystem::Feature f, bool enable) override;

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -97,7 +97,7 @@ public:
 	 * @returns true if the mouse was in a valid position for the game and
 	 * should cause the event to be sent to the game.
 	 */
-	virtual bool notifyMousePosition(Common::Point mouse) = 0;
+	virtual bool notifyMousePosition(Common::Point &mouse) = 0;
 
 	/**
 	 * A (subset) of the graphic manager's state. This is used when switching


### PR DESCRIPTION
The coordinates were translated, but this was done on a copy
instead of overwriting the original object.

In ScummVM this is a reference.

Found the bug with grim-mouse fork.