### PR TITLE
EMI: Support merged FullMonkeyMap.int as well

### DIFF
--- a/engines/grim/emi/sound/emisound.h
+++ b/engines/grim/emi/sound/emisound.h
@@ -135,7 +135,7 @@ private:
 	void saveTrack(SoundTrack *track, SaveGame *savedState);
 	SoundTrack *restoreTrack(SaveGame *savedState);
 	MusicEntry *initMusicTableDemo(const Common::String &filename);
-	MusicEntry *initMusicTableRetail(MusicEntry *table, const Common::String &filename);
+	void initMusicTableRetail(MusicEntry *table, const Common::String filename);
 };
 
 extern EMISound *g_emiSound;


### PR DESCRIPTION
Fixes #1541. Maybe #1451 too?

I reworked the load logic to just load all three known files in succession and then check if the number of valid tracks > 100. Both CD and Steam versions have 125 tracks, so 100 seems like a safe margin.