### PR TITLE
SDL: Fix SDL1 backward compatibility

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -477,8 +477,10 @@ bool SurfaceSdlGraphicsManager::saveScreenshot(const Common::String &file) const
 	bool success;
 	SDL_Surface *screen = nullptr;
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
+	// To keep it SDL1 backward compatible, this needs to be outside the SDL2 #if clause
 	int width, height;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_GetRendererOutputSize(_renderer, &width, &height);
 
 	screen = SDL_CreateRGBSurface(SDL_SWSURFACE,


### PR DESCRIPTION
Compiling ResidualVM with SDL1 gives me an error:

```
       C++      backends/graphics/surfacesdl/surfacesdl-graphics.o
backends/graphics/surfacesdl/surfacesdl-graphics.cpp: In member function 'virtual bool SurfaceSdlGraphicsManager::saveScreenshot(const Common::String&) const':
backends/graphics/surfacesdl/surfacesdl-graphics.cpp:512:13: error: 'width' was not declared in this scope
   data.init(width, height, screen->pitch, screen->pixels, format);
             ^~~~~
backends/graphics/surfacesdl/surfacesdl-graphics.cpp:512:20: error: 'height' was not declared in this scope
   data.init(width, height, screen->pitch, screen->pixels, format);
                    ^~~~~~
backends/graphics/surfacesdl/surfacesdl-graphics.cpp:512:20: note: suggested alternative: 'sig_t'
   data.init(width, height, screen->pitch, screen->pixels, format);
                    ^~~~~~
                    sig_t
gmake: *** [backends/graphics/surfacesdl/surfacesdl-graphics.o] Error 1
```

int width, height; will never be initialized on using SDL1.

Now, neither do i have the slightest idea if what i propose is the correct way to fix it,
(i get a warning with the fix in place, so i ´m sure it´s not correct)
```
    C++      backends/graphics/surfacesdl/surfacesdl-graphics.o
backends/graphics/surfacesdl/surfacesdl-graphics.cpp: In member function 'virtual bool SurfaceSdlGraphicsManager::saveScreenshot(const Common::String&) const':
backends/graphics/surfacesdl/surfacesdl-graphics.cpp:514:12: warning: 'width' may be used uninitialized in this function [-Wmaybe-uninitialized]
   data.init(width, height, screen->pitch, screen->pixels, format);
   ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
backends/graphics/surfacesdl/surfacesdl-graphics.cpp:514:12: warning: 'height' may be used uninitialized in this function [-Wmaybe-uninitialized]
```
nor do i know if backwards compatibility to SDL1 is still in consideration or even wanted,
but maybe someone can step in and correct my wrongs?

I do get a working SDL1 build out of this change again, at least.

Thank you