### PR TITLE
CONFIGURE: Add AmigaOS4 GLESv2 implementation

### DIFF
--- a/configure
+++ b/configure
@@ -4973,14 +4973,19 @@ EOF
 			fi
 		done
 	elif test "$_opengles2" = yes ; then
+		# 1) GLESv2    This is generally used by nearly all platforms for OpenGL ES 2
+		# 2) ogles2    This is used by AmigaOS4 (and proabably others)
 		_opengles2=no
-		if cc_check_no_clean $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS "-lGLESv2"
-			then
-			_opengl=yes
-			_opengles2=yes
-			_opengl_shaders=yes
-			append_var OPENGL_LIBS "-lGLESv2"
-		fi
+		for lib in "-lGLESv2" "-logles2"; do
+			if cc_check_no_clean $DEFINES $OPENGL_CFLAGS $OPENGL_LIBS $lib
+				then
+				_opengl=yes
+				_opengles2=yes
+				_opengl_shaders=yes
+				append_var OPENGL_LIBS "$lib"
+				break
+			fi
+		done
 	else
 		case $_host_os in
 		darwin*)


### PR DESCRIPTION
Discussion welcome.
Although i´m probably not able to add anything to the reason why the decision was taken by AmigaOS4 devs on using -logles2 over -lGLESv2.

Confirmed working on AmigaOS4 (with hopefully nothing broken on any other platform).