### PR TITLE
AMIGAOS4: Use GL_UNSIGNED_BYTE for uploading video frames

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1584,8 +1584,14 @@ void GfxOpenGL::prepareMovieFrame(Graphics::Surface *frame) {
 
 	// Aspyr Logo format
 	if (frame->format == Graphics::PixelFormat(4, 8, 8, 8, 0, 8, 16, 24, 0)) {
+#if !defined(__amigaos4__)
 		format = GL_BGRA;
 		dataType = GL_UNSIGNED_INT_8_8_8_8;
+#else
+		// AmigaOS' MiniGL does not understand GL_UNSIGNED_INT_8_8_8_8 yet.
+		format = GL_BGRA;
+		dataType = GL_UNSIGNED_BYTE;
+#endif
 	} else if (frame->format == Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 0)) {
 		format = GL_BGRA;
 		dataType = GL_UNSIGNED_INT_8_8_8_8_REV;


### PR DESCRIPTION
GL_UNSIGNED_INT_8_8_8_8 is not (yet) recognized as a format.

Fixes #1498 