### PR TITLE
MACOS: Generate bundle without external dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,10 +78,9 @@ matrix:
             - glew
             - bzip2
             - zlib
-            - libiconv
             - freetype
       install:
-        - cp -v /usr/local/Cellar/{bzip2,libiconv,zlib}/*/lib/*.a /usr/local/lib
+        - cp -v /usr/local/Cellar/{bzip2,zlib}/*/lib/*.a /usr/local/lib
       script:
         - ./configure --enable-all-engines && make -j4
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
       install:
         - cp -v /usr/local/Cellar/{bzip2,zlib}/*/lib/*.a /usr/local/lib
       script:
-        - ./configure --enable-all-engines && make -j4
+        - ./configure --enable-all-engines && make -j4 bundle
       before_deploy:
         - make osxsnap
         - mkdir artifacts && cp -r ResidualVM-snapshot.dmg artifacts

--- a/ports.mk
+++ b/ports.mk
@@ -177,7 +177,10 @@ endif
 # Location of static libs for the iPhone
 ifneq ($(BACKEND), iphone)
 # Static libaries, used for the residualvm-static and iphone targets
-OSX_STATIC_LIBS := `$(SDLCONFIG) --static-libs`
+OSX_STATIC_LIBS := $(shell $(SDLCONFIG) --static-libs)
+ifdef USE_SDL2
+OSX_STATIC_LIBS := $(subst -lSDL2,$(STATICLIBPATH)/lib/libSDL2.a,$(OSX_STATIC_LIBS))
+endif
 ifdef USE_SDL_NET
 ifdef USE_SDL2
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libSDL2_net.a

--- a/ports.mk
+++ b/ports.mk
@@ -276,11 +276,6 @@ ifdef USE_GLEW
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libglew.a
 endif
 
-# ResidualVM specific:
-ifdef USE_ICONV
-OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libiconv.a
-endif
-
 # Special target to create a static linked binary for Mac OS X.
 # We use -force_cpusubtype_ALL to ensure the binary runs on every
 # PowerPC machine.

--- a/ports.mk
+++ b/ports.mk
@@ -95,8 +95,8 @@ ScummVMDockTilePlugin64.o:
 ScummVMDockTilePlugin64: ScummVMDockTilePlugin64.o
 	$(CXX) -mmacosx-version-min=10.6 -arch x86_64 -bundle -framework Foundation -framework AppKit -fobjc-link-runtime ScummVMDockTilePlugin64.o -o ScummVMDockTilePlugin64
 
-ResidualVMDockTilePlugin: ScummVMDockTilePlugin32 ScummVMDockTilePlugin64
-	lipo -create ScummVMDockTilePlugin32 ScummVMDockTilePlugin64 -output ResidualVMDockTilePlugin
+ResidualVMDockTilePlugin: ScummVMDockTilePlugin64
+	cp $^ $@
 
 residualvm.docktileplugin: ResidualVMDockTilePlugin
 	mkdir -p residualvm.docktileplugin/Contents

--- a/ports.mk
+++ b/ports.mk
@@ -313,7 +313,7 @@ osxsnap: bundle
 	mkdir ResidualVM-snapshot/doc
 	cp $(srcdir)/doc/QuickStart ./ResidualVM-snapshot/doc/QuickStart
 	$(XCODETOOLSPATH)/SetFile -t ttro -c ttxt ./ResidualVM-snapshot/doc/QuickStart
-	$(XCODETOOLSPATH)/CpMac -r $(bundle_name) ./ResidualVM-snapshot/
+	cp -r $(bundle_name) ./ResidualVM-snapshot/
 # ResidualVM missing background file:
 #	cp $(srcdir)/dists/macosx/DS_Store ./ResidualVM-snapshot/.DS_Store
 #	cp $(srcdir)/dists/macosx/background.jpg ./ResidualVM-snapshot/background.jpg


### PR DESCRIPTION
This PR adds the necessary build commands to bundle libSDL2.dylib with the app. It should allow dependency-less 64-bit OSX apps.