### PR TITLE
GRIM: Fix memory issues

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -113,6 +113,8 @@ GfxOpenGL::GfxOpenGL() : _smushNumTex(0),
 GfxOpenGL::~GfxOpenGL() {
 	delete[] _storedDisplay;
 
+	releaseMovieFrame();
+
 	if (_emergFont && glIsList(_emergFont))
 		glDeleteLists(_emergFont, 128);
 

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -217,7 +217,6 @@ GrimEngine::~GrimEngine() {
 }
 
 void GrimEngine::clearPools() {
-	Set::getPool().deleteObjects();
 	Actor::getPool().deleteObjects();
 	PrimitiveObject::getPool().deleteObjects();
 	TextObject::getPool().deleteObjects();
@@ -225,6 +224,7 @@ void GrimEngine::clearPools() {
 	Font::getPool().deleteObjects();
 	ObjectState::getPool().deleteObjects();
 
+	Set::getPool().deleteObjects();
 	_currSet = nullptr;
 }
 

--- a/engines/grim/textsplit.cpp
+++ b/engines/grim/textsplit.cpp
@@ -235,8 +235,8 @@ static void parse(const char *line, const char *fmt, int field_count, va_list va
 				break;
 		}
 	}
-	free(str);
-	free(format);
+	delete[] str;
+	delete[] format;
 
 	if (count < field_count) {
 		error("Expected line of format '%s', got '%s'", fmt, line);


### PR DESCRIPTION
These changes fix issues with a minor impact because they are revealed at exit.
But that cleans the code and avoid pollution, what will ease the detection of other problems.

Problems were found thanks to compilation code instrumentation (using sanitizers).
