### PR TITLE
GRIM: Fix alloc-dealloc mismatch in grim engine

### DIFF
--- a/engines/grim/textsplit.cpp
+++ b/engines/grim/textsplit.cpp
@@ -235,8 +235,8 @@ static void parse(const char *line, const char *fmt, int field_count, va_list va
 				break;
 		}
 	}
-	free(str);
-	free(format);
+	delete[] str;
+	delete[] format;
 
 	if (count < field_count) {
 		error("Expected line of format '%s', got '%s'", fmt, line);


### PR DESCRIPTION
These changes fix issues with a minor impact because they are revealed at exit.
But that cleans the code and avoid pollution, what will ease the detection of other problems.

Problems were found thanks to compilation code instrumentation (using sanitizers).
