### PR TITLE
TINYGL: Fix wrong access to the list of dirty rects

### DIFF
--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -115,7 +115,7 @@ void tglDisposeDrawCallLists(TinyGL::GLContext *c) {
 
 static inline void _appendDirtyRectangle(const Graphics::DrawCall &call, Common::List<DirtyRectangle> &rectangles, int r, int g, int b) {
 	Common::Rect dirty_region = call.getDirtyRegion();
-	if (rectangles.empty() || dirty_region != (*rectangles.end()).rectangle)
+	if (rectangles.empty() || dirty_region != rectangles.back().rectangle)
 		rectangles.push_back(DirtyRectangle(dirty_region, r, g, b));
 }
 


### PR DESCRIPTION
The function end() of a list does not return the last element but a fake element
after the last one, for the need of the iterator.
Trying to access to the data of the element returned by end() and that has no
such field, that caused a stack buffer overflow, reading uninitialized data.

Called function back() instead, to get the last element of the list.