### PR TITLE
GRIM: Fix resource leak calling releaseMovieFrame

### DIFF
--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -111,6 +111,7 @@ GfxOpenGL::GfxOpenGL() : _smushNumTex(0),
 }
 
 GfxOpenGL::~GfxOpenGL() {
+	releaseMovieFrame();
 	delete[] _storedDisplay;
 
 	if (_emergFont && glIsList(_emergFont))

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -239,6 +239,7 @@ GfxOpenGLS::GfxOpenGLS() {
 }
 
 GfxOpenGLS::~GfxOpenGLS() {
+	releaseMovieFrame();
 	for (unsigned int i = 0; i < _numSpecialtyTextures; i++) {
 		destroyTexture(&_specialtyTextures[i]);
 	}


### PR DESCRIPTION
In EMI and GRIM games, a resource leak was found with OpenGL and
OpenGL-shaders engines: releaseMovieFrame() was not called in the destructor
of these graphics drivers (and never called at all on exit).
This patch calls explicitely realeaseMovieFrame.

Note that is was already done correctly with TinyGL.