### PR TITLE
EMI: Check _musicTable is null before it is used to avoid segfault

### DIFF
--- a/engines/grim/emi/sound/emisound.cpp
+++ b/engines/grim/emi/sound/emisound.cpp
@@ -488,6 +488,11 @@ void EMISound::setMusicState(int stateId) {
 	if (stateId == _curMusicState)
 		return;
 
+	if (_musicTable == nullptr) {
+		Debug::debug(Debug::Sound, "No music table loaded");
+		return;
+	}
+
 	Common::String soundName = _musicTable[stateId]._filename;
 	int sync = _musicTable[stateId]._sync;
 	Audio::Timestamp musicPos;
@@ -528,10 +533,6 @@ void EMISound::setMusicState(int stateId) {
 
 	if (stateId == 0) {
 		_curMusicState = 0;
-		return;
-	}
-	if (_musicTable == nullptr) {
-		Debug::debug(Debug::Sound, "No music table loaded");
 		return;
 	}
 	if (_musicTable[stateId]._id != stateId) {


### PR DESCRIPTION
After having installed EMI data and started the game, if we are in the situation
where it is asked to rename resource file FullMonkeyMap.imt from both CDs
into FullMonkeyMap1.imt and FullMonkeyMap2.imt, the game tries to start but
leads to an immediate segmentation fault.

In EMISound::setMusicState, _musicTable is checked againt nullptr but ... after
it is used. This check is moved up.