### PR TITLE
ANDROID: always start browser on external storage (SD card)

### DIFF
--- a/.travis/android-build
+++ b/.travis/android-build
@@ -24,5 +24,6 @@ echo ">>> Creating final APK"
 # Now copy the ARMv7 one into the ARM64 tree and build the final package from there
 [ ! -d build ] && ln -s build-arm64-v8a build
 export ANDROID_VERSIONCODE=$((40000 + ${TRAVIS_BUILD_NUMBER:-0}))
-install -C -D -m 644 build-armeabi-v7a/libresidualvm.so build/android/jni/armeabi-v7a/libresidualvm.so
+mkdir -p build/android/jni/armeabi-v7a
+install -C -m 644 build-armeabi-v7a/libresidualvm.so build/android/jni/armeabi-v7a/libresidualvm.so
 TERM=dumb make -C build androidrelease ABI=arm64-v8a

--- a/.travis/android-set-environment
+++ b/.travis/android-set-environment
@@ -1,5 +1,9 @@
 #!/bin/sh
-export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+if uname -s | grep -qi linux; then
+	export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+elif uname -s | grep -qi darwin; then
+	export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/darwin-x86_64
+fi
 export ANDROID_LEVEL=${ANDROID_LEVEL:-26}
 export ANDROID_TARGET_VERSION=${ANDROID_LEVEL}
 if [ "$CROSS_HOST" = "armv7a-linux-androideabi" ]; then
@@ -21,5 +25,5 @@ export STRIP=$TOOLCHAIN/bin/${CROSS_HOST}-strip
 export PATH=$TOOLCHAIN/bin:$ANDROID_NDK:$PATH
 export CXXFLAGS=-Wno-inconsistent-missing-override
 
-NPROC=$(nproc 2>/dev/null)
+NPROC=$(nproc 2>/dev/null || echo "")
 export MAKEFLAGS="-j${NPROC:-4}"

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -353,6 +353,7 @@ void OSystem_Android::initBackend() {
 	ConfMan.setInt("autosave_period", 0);
 	ConfMan.setBool("FM_high_quality", false);
 	ConfMan.setBool("FM_medium_quality", true);
+	ConfMan.set("browser_lastpath", ConfMan.get("path"));
 
 	if (ConfMan.hasKey("touchpad_mouse_mode"))
 		_touchpad_mode = ConfMan.getBool("touchpad_mouse_mode");

--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -29,10 +29,11 @@ ifdef USE_OPENGL_SHADERS
 endif
 
 $(PATH_BUILD):
-	$(MKDIR) -p $(PATH_BUILD_ASSETS)
+	$(INSTALL) -d $(PATH_BUILD_ASSETS)
 
 $(PATH_BUILD_JNI): libresidualvm.so
-	$(INSTALL) -C -D -m 644 libresidualvm.so $(PATH_BUILD_JNI)
+	$(INSTALL) -d $(dir $(PATH_BUILD_JNI))
+	$(INSTALL) -C -m 644 libresidualvm.so $(PATH_BUILD_JNI)
 
 $(PATH_BUILD_GRADLE): $(PATH_BUILD_ASSETS) $(PATH_DIST)/build.gradle
 	$(eval ABIS = $(notdir $(wildcard $(PATH_BUILD)/jni/*)))

--- a/configure
+++ b/configure
@@ -1805,7 +1805,7 @@ android)
 		echo "Please set ANDROID_NDK in your environment. export ANDROID_NDK=<path to Android NDK>"
 		exit 1
 	fi
-	ndk_version=$(sed -En -e 's/^Pkg.Revision\s*=\s*([0-9a-f]+).*/\1/p' "$ANDROID_NDK/source.properties")
+	ndk_version=$(sed -En -e 's/^Pkg.Revision *= *([0-9a-f]+).*/\1/p' "$ANDROID_NDK/source.properties")
 	if [ -z "$ndk_version" -o "$ndk_version" -lt 18 ]; then
 		echo "Need Android NDK r18 or later to compile! Found version '$ndk_version'"
 		exit 1


### PR DESCRIPTION
The first commit fixes some build issues I encountered while building Android on macOS.

The second commit fixes #1589. It also _always_ resets the lastpath.