### PR TITLE
MYST3: Fix default text language when "text_language" key doesn't exist in residualvm.ini

### DIFF
--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -285,7 +285,13 @@ void Myst3Engine::openArchives() {
 	}
 
 	if (getGameLocalizationType() == kLocMulti6) {
-		switch (ConfMan.getInt("text_language")) {
+		int defaultLanguage = _db->getGameLanguageCode();
+
+		if (ConfMan.hasKey("text_language")) {
+			defaultLanguage = ConfMan.getInt("text_language");
+		}
+
+		switch (defaultLanguage) {
 		case kDutch:
 			textLanguage = "DUTCH";
 			break;


### PR DESCRIPTION
Currently, "text_language" key is not set just after adding "Myst 3" in residualvm.

It causes text to be set to "english" by default. This commit fixes that.