### PR TITLE
Revert "SDL: Move detection of the desktop resolution into the SdlWindow class"

### DIFF
--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -68,20 +68,42 @@ void ResVmSdlGraphicsManager::deactivateManager() {
 }
 
 Common::Rect ResVmSdlGraphicsManager::getPreferredFullscreenResolution() {
-	// Default to the desktop resolution, unless the user has set a
-	// resolution in the configuration file
+	// Default to the desktop resolution ...
+	uint preferredWidth = _capabilities.desktopWidth;
+	uint preferredHeight = _capabilities.desktopHeight;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	// When using SDL2, we can query the desktop resolution for the screen our window sits in
+	int displayIndex = -1;
+
+	SDL_Window *sdlWindow = _window->getSDLWindow();
+	if (sdlWindow) {
+		displayIndex = SDL_GetWindowDisplayIndex(sdlWindow);
+	}
+
+	if (displayIndex >= 0) {
+		SDL_DisplayMode displayMode;
+		if (!SDL_GetDesktopDisplayMode(displayIndex, &displayMode)) {
+			preferredWidth = displayMode.w;
+			preferredHeight = displayMode.h;
+		}
+	}
+#endif
+
+	// ... unless the user has set a resolution in the configuration file
 	const Common::String &fsres = ConfMan.get("fullscreen_res");
 	if (fsres != "desktop") {
 		uint newW, newH;
 		int converted = sscanf(fsres.c_str(), "%ux%u", &newW, &newH);
 		if (converted == 2) {
-			return Common::Rect(newW, newH);
+			preferredWidth = newW;
+			preferredHeight = newH;
 		} else {
 			warning("Could not parse 'fullscreen_res' option: expected WWWxHHH, got %s", fsres.c_str());
 		}
 	}
 
-	return _window->getDesktopResolution();
+	return Common::Rect(preferredWidth, preferredHeight);
 }
 
 void ResVmSdlGraphicsManager::resetGraphicsScale() {

--- a/backends/graphics/sdl/resvm-sdl-graphics.h
+++ b/backends/graphics/sdl/resvm-sdl-graphics.h
@@ -44,6 +44,12 @@ public:
 	 */
 	struct Capabilities {
 		/**
+		 * Desktop resolution
+		 */
+		uint desktopWidth;
+		uint desktopHeight;
+
+		/**
 		 * Is the device capable of rendering to OpenGL framebuffers
 		 */
 		bool openGLFrameBuffer;
@@ -51,7 +57,9 @@ public:
 		/** Supported levels of MSAA when using the OpenGL renderers */
 		Common::Array<uint> openGLAntiAliasLevels;
 
-		Capabilities() : openGLFrameBuffer(false) {}
+		Capabilities() :
+				desktopWidth(0), desktopHeight(0),
+				openGLFrameBuffer(false) {}
 	};
 
 	ResVmSdlGraphicsManager(SdlEventSource *source, SdlWindow *window, const Capabilities &capabilities);

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -38,15 +38,6 @@ SdlWindow::SdlWindow()
 	_lastFlags(0), _lastX(SDL_WINDOWPOS_UNDEFINED), _lastY(SDL_WINDOWPOS_UNDEFINED)
 #endif
 	{
-
-#if !SDL_VERSION_ATLEAST(2, 0, 0)
-	// Query the desktop resolution. We simply hope nothing tried to change
-	// the resolution so far.
-	const SDL_VideoInfo *videoInfo = SDL_GetVideoInfo();
-	if (videoInfo && videoInfo->current_w > 0 && videoInfo->current_h > 0) {
-		_desktopRes = Common::Rect(videoInfo->current_w, videoInfo->current_h);
-	}
-#endif
 }
 
 SdlWindow::~SdlWindow() {
@@ -200,19 +191,6 @@ bool SdlWindow::getSDLWMInformation(SDL_SysWMinfo *info) const {
 	return SDL_GetWMInfo(info);
 #endif
 }
-
-Common::Rect SdlWindow::getDesktopResolution() {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	int displayIndex = _window ? SDL_GetWindowDisplayIndex(_window) : 0;
-	SDL_DisplayMode displayMode;
-	if (!SDL_GetDesktopDisplayMode(displayIndex, &displayMode)) {
-		_desktopRes = Common::Rect(displayMode.w, displayMode.h);
-	}
-#endif
-
-	return _desktopRes;
-}
-
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 SDL_Surface *copySDLSurface(SDL_Surface *src) {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -25,7 +25,6 @@
 
 #include "backends/platform/sdl/sdl-sys.h"
 
-#include "common/rect.h"
 #include "common/str.h"
 
 class SdlWindow {
@@ -77,11 +76,6 @@ public:
 	 */
 	bool getSDLWMInformation(SDL_SysWMinfo *info) const;
 
-	/*
-	 * Retrieve the current desktop resolution.
-	 */
-	Common::Rect getDesktopResolution();
-
 	bool mouseIsGrabbed() const {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		if (_window) {
@@ -93,8 +87,6 @@ public:
 
 private:
 	bool _inputGrabState;
-
-	Common::Rect _desktopRes;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 public:

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -194,6 +194,7 @@ void OSystem_SDL::initBackend() {
 	debug(1, "Using SDL Video Driver \"%s\"", sdlDriverName);
 
 // ResidualVM specific code start
+	detectDesktopResolution();
 #ifdef USE_OPENGL
 	detectFramebufferSupport();
 	detectAntiAliasingSupport();
@@ -255,6 +256,24 @@ void OSystem_SDL::initBackend() {
 }
 
 // ResidualVM specific code
+void OSystem_SDL::detectDesktopResolution() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_DisplayMode displayMode;
+	if (!SDL_GetDesktopDisplayMode(0, &displayMode)) {
+		_capabilities.desktopWidth = displayMode.w;
+		_capabilities.desktopHeight = displayMode.h;
+	}
+#else
+	// Query the desktop resolution. We simply hope nothing tried to change
+	// the resolution so far.
+	const SDL_VideoInfo *videoInfo = SDL_GetVideoInfo();
+	if (videoInfo && videoInfo->current_w > 0 && videoInfo->current_h > 0) {
+		_capabilities.desktopWidth = videoInfo->current_w;
+		_capabilities.desktopHeight = videoInfo->current_h;
+	}
+#endif
+}
+
 #ifdef USE_OPENGL
 void OSystem_SDL::detectFramebufferSupport() {
 	_capabilities.openGLFrameBuffer = false;

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -131,6 +131,7 @@ protected:
 
 	// ResidualVM specific code
 	// Graphics capabilities
+	void detectDesktopResolution();
 	void detectFramebufferSupport();
 	void detectAntiAliasingSupport();
 	ResVmSdlGraphicsManager::Capabilities _capabilities;


### PR DESCRIPTION
Reverts residualvm/residualvm#1622  no reason to change
