### PR TITLE
SDL: Move functionality from ResVmSdlGraphicsManager into the relevant subclasses

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -42,11 +42,14 @@ public:
 	virtual void setFeatureState(OSystem::Feature f, bool enable) = 0;
 	virtual bool getFeatureState(OSystem::Feature f) const = 0;
 
-	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const = 0;
-	virtual int getDefaultGraphicsMode() const = 0;
-	virtual bool setGraphicsMode(int mode) = 0;
-	virtual void resetGraphicsScale() = 0;
-	virtual int getGraphicsMode() const = 0;
+	virtual const OSystem::GraphicsMode *getSupportedGraphicsModes() const {
+		static const OSystem::GraphicsMode noGraphicsModes[] = {{"NONE", "Normal", 0}, {nullptr, nullptr, 0 }};
+		return noGraphicsModes;
+	};
+	virtual int getDefaultGraphicsMode() const { return 0; }
+	virtual bool setGraphicsMode(int mode) { return (mode == 0); }
+	virtual void resetGraphicsScale() {}
+	virtual int getGraphicsMode() const { return 0; }
 	virtual const OSystem::GraphicsMode *getSupportedShaders() const {
 		static const OSystem::GraphicsMode no_shader[2] = {{"NONE", "Normal (no shader)", 0}, {0, 0, 0}};
 		return no_shader;
@@ -71,15 +74,6 @@ public:
 
 	virtual void beginGFXTransaction() = 0;
 	virtual OSystem::TransactionError endGFXTransaction() = 0;
-
-	// ResidualVM specific method
-	virtual void setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d) = 0;
-	// ResidualVM specific method
-	virtual Graphics::PixelBuffer getScreenPixelBuffer() = 0;
-	// ResidualVM specific method
-	virtual void suggestSideTextures(Graphics::Surface *left, Graphics::Surface *right) = 0;
-	// ResidualVM specific method
-	virtual void saveScreenshot() {}
 
 	virtual int16 getHeight() const = 0;
 	virtual int16 getWidth() const = 0;
@@ -107,9 +101,6 @@ public:
 	virtual void warpMouse(int x, int y) = 0;
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) = 0;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) = 0;
-
-	// ResidualVM specific method
-	virtual bool lockMouse(bool lock) = 0;
 
 	virtual void displayMessageOnOSD(const char *msg) {}
 	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon) {}

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -50,12 +50,19 @@ OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(SdlEventSource *sdlEventSourc
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	_glContext(nullptr),
 #endif
+	_overlayVisible(false),
 	_overlayScreen(nullptr),
 	_overlayBackground(nullptr),
 	_gameRect(),
+	_fullscreen(false),
+	_lockAspectRatio(true),
 	_frameBuffer(nullptr),
-	_surfaceRenderer(nullptr) {
+	_surfaceRenderer(nullptr),
+	_engineRequestedWidth(0),
+	_engineRequestedHeight(0) {
 	ConfMan.registerDefault("antialiasing", 0);
+	ConfMan.registerDefault("aspect_ratio", true);
+	ConfMan.registerDefault("vsync", true);
 
 	_sideTextures[0] = _sideTextures[1] = nullptr;
 
@@ -86,8 +93,12 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	switch (f) {
 		case OSystem::kFeatureVSync:
 			return isVSyncEnabled();
+		case OSystem::kFeatureFullscreenMode:
+			return _fullscreen;
+		case OSystem::kFeatureAspectRatioCorrection:
+			return _lockAspectRatio;
 		default:
-			return ResVmSdlGraphicsManager::getFeatureState(f);
+			return false;
 	}
 }
 
@@ -99,8 +110,10 @@ void OpenGLSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) 
 				createOrUpdateScreen();
 			}
 			break;
+		case OSystem::kFeatureAspectRatioCorrection:
+			_lockAspectRatio = enable;
+			break;
 		default:
-			ResVmSdlGraphicsManager::setFeatureState(f, enable);
 			break;
 	}
 }

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -46,10 +46,11 @@
 
 OpenGLSdlGraphicsManager::OpenGLSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window, const Capabilities &capabilities)
 	:
-	ResVmSdlGraphicsManager(sdlEventSource, window, capabilities),
+	ResVmSdlGraphicsManager(sdlEventSource, window),
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	_glContext(nullptr),
 #endif
+	_capabilities(capabilities),
 	_overlayVisible(false),
 	_overlayScreen(nullptr),
 	_overlayBackground(nullptr),

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -48,6 +48,10 @@ public:
 	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 
 	// GraphicsManager API - Graphics mode
+#ifdef USE_RGB_COLOR
+	virtual Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
+#endif
+	virtual int getScreenChangeID() const override { return _screenChangeCount; }
 	virtual void setupScreen(uint gameWidth, uint gameHeight, bool fullscreen, bool accel3d) override;
 	virtual Graphics::PixelBuffer getScreenPixelBuffer() override;
 	virtual int16 getHeight() const override;
@@ -59,6 +63,7 @@ public:
 	// GraphicsManager API - Overlay
 	virtual void showOverlay() override;
 	virtual void hideOverlay() override;
+	virtual Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
 	virtual void clearOverlay() override;
 	virtual void grabOverlay(void *buf, int pitch) const override;
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
@@ -116,13 +121,24 @@ protected:
 	// ResVmSdlGraphicsManager API
 	bool saveScreenshot(const Common::String &file) const override;
 
+	uint _engineRequestedWidth, _engineRequestedHeight;
+
+	int _screenChangeCount;
 	int _antialiasing;
 	bool _vsync;
+	bool _fullscreen;
+	bool _lockAspectRatio;
+	bool _overlayVisible;
 
 	OpenGL::TiledSurface *_overlayScreen;
 	OpenGL::TiledSurface *_overlayBackground;
 	OpenGL::Texture *_sideTextures[2];
 	OpenGL::SurfaceRenderer *_surfaceRenderer;
+
+	Graphics::PixelFormat _overlayFormat;
+#ifdef USE_RGB_COLOR
+	Graphics::PixelFormat _screenFormat;
+#endif
 
 	void initializeOpenGLContext() const;
 	void drawOverlay();

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -39,6 +39,21 @@ namespace OpenGL {
  */
 class OpenGLSdlGraphicsManager : public ResVmSdlGraphicsManager {
 public:
+	/**
+	 * Capabilities of the current device
+	 */
+	struct Capabilities {
+		/**
+		 * Is the device capable of rendering to OpenGL framebuffers
+		 */
+		bool openGLFrameBuffer;
+
+		/** Supported levels of MSAA when using the OpenGL renderers */
+		Common::Array<uint> openGLAntiAliasLevels;
+
+		Capabilities() : openGLFrameBuffer(false) {}
+	};
+
 	OpenGLSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window, const Capabilities &capabilities);
 	virtual ~OpenGLSdlGraphicsManager();
 
@@ -89,6 +104,8 @@ protected:
 	SDL_GLContext _glContext;
 	void deinitializeRenderer();
 #endif
+
+	const Capabilities &_capabilities;
 
 	Math::Rect2d _gameRect;
 

--- a/backends/graphics/resvm-graphics.h
+++ b/backends/graphics/resvm-graphics.h
@@ -1,0 +1,72 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef BACKENDS_GRAPHICS_RESVM_ABSTRACT_H
+#define BACKENDS_GRAPHICS_RESVM_ABSTRACT_H
+
+#include "common/system.h"
+#include "common/noncopyable.h"
+#include "common/keyboard.h"
+
+#include "graphics/mode.h"
+#include "graphics/palette.h"
+
+#include "backends/graphics/graphics.h"
+
+/**
+ * Abstract class for graphics manager. Subclasses
+ * implement the real functionality.
+ */
+class ResVmGraphicsManager : public GraphicsManager {
+public:
+	// Methods not used by ResidualVM
+#ifdef USE_RGB_COLOR
+	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const {
+		Common::List<Graphics::PixelFormat> supportedFormats;
+		return supportedFormats;
+	}
+#endif
+	virtual void initSize(uint width, uint height, const Graphics::PixelFormat *format = NULL) {}
+	virtual void beginGFXTransaction() {}
+	virtual OSystem::TransactionError endGFXTransaction() { return OSystem::kTransactionSuccess; }
+	virtual void setPalette(const byte *colors, uint start, uint num) {}
+	virtual void grabPalette(byte *colors, uint start, uint num) const {}
+	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {}
+	virtual Graphics::Surface *lockScreen() { return nullptr; }
+	virtual void unlockScreen() {}
+	virtual void fillScreen(uint32 col) {}
+	virtual void setShakePos(int shakeOffset) {}
+	virtual void setFocusRectangle(const Common::Rect& rect) {}
+	virtual void clearFocusRectangle() {}
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) {}
+	virtual void setCursorPalette(const byte *colors, uint start, uint num) {}
+
+	// ResidualVM specific methods
+	virtual void setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d) = 0;
+	virtual Graphics::PixelBuffer getScreenPixelBuffer() = 0;
+	virtual void suggestSideTextures(Graphics::Surface *left, Graphics::Surface *right) = 0;
+	virtual void saveScreenshot() {}
+	virtual bool lockMouse(bool lock) = 0;
+
+};
+
+#endif

--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -32,16 +32,8 @@
 
 ResVmSdlGraphicsManager::ResVmSdlGraphicsManager(SdlEventSource *source, SdlWindow *window, const Capabilities &capabilities) :
 		SdlGraphicsManager(source, window),
-		_fullscreen(false),
-		_lockAspectRatio(true),
-		_overlayVisible(false),
-		_screenChangeCount(0),
-		_capabilities(capabilities),
-		_engineRequestedWidth(0),
-		_engineRequestedHeight(0)  {
+		_capabilities(capabilities)  {
 	ConfMan.registerDefault("fullscreen_res", "desktop");
-	ConfMan.registerDefault("aspect_ratio", true);
-	ConfMan.registerDefault("vsync", true);
 }
 
 ResVmSdlGraphicsManager::~ResVmSdlGraphicsManager() {
@@ -78,27 +70,6 @@ Common::Rect ResVmSdlGraphicsManager::getPreferredFullscreenResolution() {
 	}
 
 	return _window->getDesktopResolution();
-}
-
-void ResVmSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
-	switch (f) {
-		case OSystem::kFeatureAspectRatioCorrection:
-			_lockAspectRatio = enable;
-			break;
-		default:
-			break;
-	}
-}
-
-bool ResVmSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
-	switch (f) {
-		case OSystem::kFeatureFullscreenMode:
-			return _fullscreen;
-		case OSystem::kFeatureAspectRatioCorrection:
-			return _lockAspectRatio;
-		default:
-			return false;
-	}
 }
 
 #pragma mark -

--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -30,9 +30,8 @@
 #include "common/textconsole.h"
 #include "common/file.h"
 
-ResVmSdlGraphicsManager::ResVmSdlGraphicsManager(SdlEventSource *source, SdlWindow *window, const Capabilities &capabilities) :
-		SdlGraphicsManager(source, window),
-		_capabilities(capabilities)  {
+ResVmSdlGraphicsManager::ResVmSdlGraphicsManager(SdlEventSource *source, SdlWindow *window) :
+		SdlGraphicsManager(source, window)  {
 	ConfMan.registerDefault("fullscreen_res", "desktop");
 }
 

--- a/backends/graphics/sdl/resvm-sdl-graphics.cpp
+++ b/backends/graphics/sdl/resvm-sdl-graphics.cpp
@@ -30,10 +30,6 @@
 #include "common/textconsole.h"
 #include "common/file.h"
 
-static const OSystem::GraphicsMode s_supportedGraphicsModes[] = {
-		{0, 0, 0}
-};
-
 ResVmSdlGraphicsManager::ResVmSdlGraphicsManager(SdlEventSource *source, SdlWindow *window, const Capabilities &capabilities) :
 		SdlGraphicsManager(source, window),
 		_fullscreen(false),
@@ -84,10 +80,6 @@ Common::Rect ResVmSdlGraphicsManager::getPreferredFullscreenResolution() {
 	return _window->getDesktopResolution();
 }
 
-void ResVmSdlGraphicsManager::resetGraphicsScale() {
-	setGraphicsMode(0);
-}
-
 void ResVmSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
 	switch (f) {
 		case OSystem::kFeatureAspectRatioCorrection:
@@ -107,84 +99,6 @@ bool ResVmSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 		default:
 			return false;
 	}
-}
-
-const OSystem::GraphicsMode *ResVmSdlGraphicsManager::getSupportedGraphicsModes() const {
-	return s_supportedGraphicsModes;
-}
-
-int ResVmSdlGraphicsManager::getDefaultGraphicsMode() const {
-	return 0;// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::beginGFXTransaction() {
-	// ResidualVM: not use it
-}
-
-OSystem::TransactionError ResVmSdlGraphicsManager::endGFXTransaction() {
-	// ResidualVM: not use it
-	return OSystem::kTransactionSuccess;
-}
-
-#ifdef USE_RGB_COLOR
-Common::List<Graphics::PixelFormat> ResVmSdlGraphicsManager::getSupportedFormats() const {
-	// ResidualVM: not use it
-	return _supportedFormats;
-}
-#endif
-
-bool ResVmSdlGraphicsManager::setGraphicsMode(int mode) {
-	// ResidualVM: not use it
-	return true;
-}
-
-int ResVmSdlGraphicsManager::getGraphicsMode() const {
-	// ResidualVM: not use it
-	return 0;
-}
-
-void ResVmSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::copyRectToScreen(const void *src, int pitch, int x, int y, int w, int h) {
-	// ResidualVM: not use it
-}
-
-Graphics::Surface *ResVmSdlGraphicsManager::lockScreen() {
-	return NULL; // ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::unlockScreen() {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::fillScreen(uint32 col) {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::setPalette(const byte *colors, uint start, uint num) {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::grabPalette(byte *colors, uint start, uint num) const {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::setCursorPalette(const byte *colors, uint start, uint num) {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::setShakePos(int shake_pos) {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::setFocusRectangle(const Common::Rect &rect) {
-	// ResidualVM: not use it
-}
-
-void ResVmSdlGraphicsManager::clearFocusRectangle() {
-	// ResidualVM: not use it
 }
 
 #pragma mark -
@@ -218,20 +132,6 @@ bool ResVmSdlGraphicsManager::isMouseLocked() const {
 	return SDL_GrabMode() == SDL_GRAB_ON;
 #endif
 }
-
-void ResVmSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspot_x, int hotspot_y, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
-	// ResidualVM: not use it
-}
-
-#pragma mark -
-#pragma mark --- On Screen Display ---
-#pragma mark -
-
-#ifdef USE_OSD
-void OpenGLResVmSdlGraphicsManager::displayMessageOnOSD(const char *msg) {
-	// ResidualVM: not use it
-}
-#endif
 
 bool ResVmSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 	//ResidualVM specific:

--- a/backends/graphics/sdl/resvm-sdl-graphics.h
+++ b/backends/graphics/sdl/resvm-sdl-graphics.h
@@ -63,22 +63,9 @@ public:
 	void notifyVideoExpose() override;
 	bool notifyMousePosition(Common::Point &mouse) override;
 
-	// GraphicsManager API - Features
-	void setFeatureState(OSystem::Feature f, bool enable) override;
-	bool getFeatureState(OSystem::Feature f) const override;
-
-	// GraphicsManager API - Graphics mode
-#ifdef USE_RGB_COLOR
-	Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
-#endif
-	int getScreenChangeID() const override { return _screenChangeCount; }
-
 public:
 	// GraphicsManager API - Draw methods
 	void saveScreenshot() override;
-
-	// GraphicsManager API - Overlay
-	Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
 
 	// GraphicsManager API - Mouse
 	bool showMouse(bool visible) override;
@@ -95,19 +82,6 @@ public:
 
 protected:
 	const Capabilities &_capabilities;
-
-	bool _fullscreen;
-	bool _lockAspectRatio;
-	uint _engineRequestedWidth, _engineRequestedHeight;
-
-	int _screenChangeCount;
-
-	bool _overlayVisible;
-	Graphics::PixelFormat _overlayFormat;
-
-#ifdef USE_RGB_COLOR
-	Graphics::PixelFormat _screenFormat;
-#endif
 
 	/** Obtain the user configured fullscreen resolution, or default to the desktop resolution */
 	Common::Rect getPreferredFullscreenResolution();

--- a/backends/graphics/sdl/resvm-sdl-graphics.h
+++ b/backends/graphics/sdl/resvm-sdl-graphics.h
@@ -68,37 +68,14 @@ public:
 	bool getFeatureState(OSystem::Feature f) const override;
 
 	// GraphicsManager API - Graphics mode
-	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
-	int getDefaultGraphicsMode() const override;
-	bool setGraphicsMode(int mode) override;
-	int getGraphicsMode() const override;
-	void resetGraphicsScale() override;
 #ifdef USE_RGB_COLOR
 	Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
-	Common::List<Graphics::PixelFormat> getSupportedFormats() const override;
 #endif
-	void initSize(uint w, uint h, const Graphics::PixelFormat *format = nullptr) override;
 	int getScreenChangeID() const override { return _screenChangeCount; }
-	void beginGFXTransaction() override;
-	OSystem::TransactionError endGFXTransaction() override;
-
-protected:
-	// PaletteManager API
-	void setPalette(const byte *colors, uint start, uint num) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
 
 public:
 	// GraphicsManager API - Draw methods
-	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override;
-	Graphics::Surface *lockScreen() override;
-	void unlockScreen() override;
-	void fillScreen(uint32 col) override;
-	void setShakePos(int shakeOffset) override;
 	void saveScreenshot() override;
-
-	// GraphicsManager API - Focus Rectangle
-	void setFocusRectangle(const Common::Rect& rect) override;
-	void clearFocusRectangle() override;
 
 	// GraphicsManager API - Overlay
 	Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
@@ -106,12 +83,6 @@ public:
 	// GraphicsManager API - Mouse
 	bool showMouse(bool visible) override;
 	bool lockMouse(bool lock) override; // ResidualVM specific method
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr) override;
-	void setCursorPalette(const byte *colors, uint start, uint num) override;
-
-#ifdef USE_OSD
-	void displayMessageOnOSD(const char *msg) override;
-#endif
 
 	// Common::EventObserver API
 	bool notifyEvent(const Common::Event &event) override;
@@ -136,7 +107,6 @@ protected:
 
 #ifdef USE_RGB_COLOR
 	Graphics::PixelFormat _screenFormat;
-	Common::List<Graphics::PixelFormat> _supportedFormats;
 #endif
 
 	/** Obtain the user configured fullscreen resolution, or default to the desktop resolution */

--- a/backends/graphics/sdl/resvm-sdl-graphics.h
+++ b/backends/graphics/sdl/resvm-sdl-graphics.h
@@ -39,22 +39,7 @@ class SdlEventSource;
  */
 class ResVmSdlGraphicsManager : public SdlGraphicsManager, public Common::EventObserver {
 public:
-	/**
-	 * Capabilities of the current device
-	 */
-	struct Capabilities {
-		/**
-		 * Is the device capable of rendering to OpenGL framebuffers
-		 */
-		bool openGLFrameBuffer;
-
-		/** Supported levels of MSAA when using the OpenGL renderers */
-		Common::Array<uint> openGLAntiAliasLevels;
-
-		Capabilities() : openGLFrameBuffer(false) {}
-	};
-
-	ResVmSdlGraphicsManager(SdlEventSource *source, SdlWindow *window, const Capabilities &capabilities);
+	ResVmSdlGraphicsManager(SdlEventSource *source, SdlWindow *window);
 	~ResVmSdlGraphicsManager() override;
 
 	// SdlGraphicsManager API
@@ -81,8 +66,6 @@ public:
 	bool isMouseLocked() const;
 
 protected:
-	const Capabilities &_capabilities;
-
 	/** Obtain the user configured fullscreen resolution, or default to the desktop resolution */
 	Common::Rect getPreferredFullscreenResolution();
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -23,7 +23,7 @@
 #ifndef BACKENDS_GRAPHICS_SDL_SDLGRAPHICS_H
 #define BACKENDS_GRAPHICS_SDL_SDLGRAPHICS_H
 
-#include "backends/graphics/graphics.h"
+#include "backends/graphics/resvm-graphics.h"
 #include "backends/platform/sdl/sdl-window.h"
 
 #include "common/rect.h"
@@ -35,7 +35,7 @@ class SdlEventSource;
  *
  * It features a few extra a few extra features required by SdlEventSource.
  */
-class SdlGraphicsManager : virtual public GraphicsManager {
+class SdlGraphicsManager : virtual public ResVmGraphicsManager {
 public:
 	SdlGraphicsManager(SdlEventSource *source, SdlWindow *window);
 	virtual ~SdlGraphicsManager();

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -45,8 +45,16 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 	_subScreen(0),
 	_overlayscreen(0),
 	_overlayDirty(true),
-	_gameRect()
+	_overlayVisible(false),
+	_fullscreen(false),
+	_lockAspectRatio(true),
+	_screenChangeCount(0),
+	_gameRect(),
+	_engineRequestedWidth(0),
+	_engineRequestedHeight(0)
 	{
+		ConfMan.registerDefault("aspect_ratio", true);
+
 		_sideSurfaces[0] = _sideSurfaces[1] = nullptr;
 }
 
@@ -68,7 +76,19 @@ bool SurfaceSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		(f == OSystem::kFeatureFullscreenToggleKeepsContext) ||
 #endif
+		(f == OSystem::kFeatureAspectRatioCorrection) ||
 		(f == OSystem::kFeatureFullscreenMode);
+}
+
+bool SurfaceSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
+	switch (f) {
+		case OSystem::kFeatureFullscreenMode:
+			return _fullscreen;
+		case OSystem::kFeatureAspectRatioCorrection:
+			return _lockAspectRatio;
+		default:
+			return false;
+	}
 }
 
 void SurfaceSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
@@ -79,8 +99,10 @@ void SurfaceSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable)
 				createOrUpdateScreen();
 			}
 			break;
+		case OSystem::kFeatureAspectRatioCorrection:
+			_lockAspectRatio = enable;
+			break;
 		default:
-			ResVmSdlGraphicsManager::setFeatureState(f, enable);
 			break;
 	}
 }

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -35,9 +35,9 @@
 #include "image/png.h"
 #endif
 
-SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window, const Capabilities &capabilities)
+SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
 	:
-	ResVmSdlGraphicsManager(sdlEventSource, window, capabilities),
+	ResVmSdlGraphicsManager(sdlEventSource, window),
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	_renderer(nullptr), _screenTexture(nullptr),
 #endif

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -32,7 +32,7 @@
  */
 class SurfaceSdlGraphicsManager : public ResVmSdlGraphicsManager {
 public:
-	SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window, const Capabilities &capabilities);
+	SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 	virtual ~SurfaceSdlGraphicsManager();
 
 	// GraphicsManager API - Features

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -37,9 +37,14 @@ public:
 
 	// GraphicsManager API - Features
 	virtual bool hasFeature(OSystem::Feature f) const override;
+	virtual bool getFeatureState(OSystem::Feature f) const override;
 	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 
 	// GraphicsManager API - Graphics mode
+#ifdef USE_RGB_COLOR
+	virtual Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
+#endif
+	virtual int getScreenChangeID() const override { return _screenChangeCount; }
 	virtual void setupScreen(uint gameWidth, uint gameHeight, bool fullscreen, bool accel3d) override;
 	virtual Graphics::PixelBuffer getScreenPixelBuffer() override;
 	virtual int16 getHeight() const override;
@@ -51,6 +56,7 @@ public:
 	// GraphicsManager API - Overlay
 	virtual void showOverlay() override;
 	virtual void hideOverlay() override;
+	virtual Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
 	virtual void clearOverlay() override;
 	virtual void grabOverlay(void *buf, int pitch) const override;
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
@@ -83,6 +89,18 @@ protected:
 
 	SDL_Surface *_overlayscreen;
 	bool _overlayDirty;
+	bool _overlayVisible;
+
+	Graphics::PixelFormat _overlayFormat;
+#ifdef USE_RGB_COLOR
+	Graphics::PixelFormat _screenFormat;
+#endif
+
+	uint _engineRequestedWidth, _engineRequestedHeight;
+
+	bool _fullscreen;
+	bool _lockAspectRatio;
+	int _screenChangeCount;
 
 	Math::Rect2d _gameRect;
 

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -23,6 +23,7 @@
 #include "backends/modular-backend.h"
 
 #include "backends/graphics/graphics.h"
+#include "backends/graphics/resvm-graphics.h" // ResidualVM specific
 #include "backends/mutex/mutex.h"
 #include "gui/EventRecorder.h"
 

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -26,6 +26,7 @@
 #include "backends/base-backend.h"
 
 class GraphicsManager;
+class ResVmGraphicsManager; // ResidualVM specific
 class MutexManager;
 
 /**
@@ -149,7 +150,7 @@ protected:
 	//@{
 
 	MutexManager *_mutexManager;
-	GraphicsManager *_graphicsManager;
+	ResVmGraphicsManager *_graphicsManager; // ResidualVM: was GraphicsManager
 	Audio::Mixer *_mixer;
 
 	//@}

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -216,7 +216,7 @@ void OSystem_SDL::initBackend() {
 
 	if (_graphicsManager == 0) {
 		if (_graphicsManager == 0) {
-			_graphicsManager = new SurfaceSdlGraphicsManager(_eventSource, _window, _capabilities);
+			_graphicsManager = new SurfaceSdlGraphicsManager(_eventSource, _window);
 		}
 	}
 
@@ -414,8 +414,8 @@ void OSystem_SDL::setWindowCaption(const char *caption) {
 }
 
 // ResidualVM specific code
-void OSystem_SDL::setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d) {
 #ifdef USE_OPENGL
+void OSystem_SDL::setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d) {
 	bool switchedManager = false;
 	if (accel3d && !dynamic_cast<OpenGLSdlGraphicsManager *>(_graphicsManager)) {
 		switchedManager = true;
@@ -431,14 +431,18 @@ void OSystem_SDL::setupScreen(uint screenW, uint screenH, bool fullscreen, bool 
 		if (accel3d) {
 			_graphicsManager = sdlGraphicsManager = new OpenGLSdlGraphicsManager(_eventSource, _window, _capabilities);
 		} else {
-			_graphicsManager = sdlGraphicsManager = new SurfaceSdlGraphicsManager(_eventSource, _window, _capabilities);
+			_graphicsManager = sdlGraphicsManager = new SurfaceSdlGraphicsManager(_eventSource, _window);
 		}
 		sdlGraphicsManager->activateManager();
 	}
-#endif
 
 	ModularBackend::setupScreen(screenW, screenH, fullscreen, accel3d);
 }
+
+Common::Array<uint> OSystem_SDL::getSupportedAntiAliasingLevels() const {
+	return _capabilities.openGLAntiAliasLevels;
+}
+#endif
 
 void OSystem_SDL::launcherInitSize(uint w, uint h) {
 	Common::String rendererConfig = ConfMan.get("renderer");
@@ -450,9 +454,6 @@ void OSystem_SDL::launcherInitSize(uint w, uint h) {
 	setupScreen(w, h, fullscreen, matchingRendererType != Graphics::kRendererTypeTinyGL);
 }
 
-Common::Array<uint> OSystem_SDL::getSupportedAntiAliasingLevels() const {
-	return _capabilities.openGLAntiAliasLevels;
-}
 // End of ResidualVM specific code
 
 void OSystem_SDL::quit() {

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -30,7 +30,9 @@
 #include "backends/events/sdl/sdl-events.h"
 #include "backends/log/log.h"
 #include "backends/platform/sdl/sdl-window.h"
-#include "backends/graphics/sdl/resvm-sdl-graphics.h"
+#ifdef USE_OPENGL
+#include "backends/graphics/openglsdl/openglsdl-graphics.h"
+#endif
 
 #include "common/array.h"
 
@@ -89,12 +91,14 @@ public:
 	//Screenshots
 	virtual Common::String getScreenshotsPath();
 
+#ifdef USE_OPENGL
 	// ResidualVM specific code
 	virtual void setupScreen(uint screenW, uint screenH, bool fullscreen, bool accel3d) override;
 	// ResidualVM specific code
-	virtual void launcherInitSize(uint w, uint h) override;
-	// ResidualVM specific code
 	Common::Array<uint> getSupportedAntiAliasingLevels() const;
+#endif
+	// ResidualVM specific code
+	virtual void launcherInitSize(uint w, uint h) override;
 
 protected:
 	bool _inited;
@@ -130,10 +134,12 @@ protected:
 	SdlWindow *_window;
 
 	// ResidualVM specific code
+#ifdef USE_OPENGL
 	// Graphics capabilities
 	void detectFramebufferSupport();
 	void detectAntiAliasingSupport();
-	ResVmSdlGraphicsManager::Capabilities _capabilities;
+	OpenGLSdlGraphicsManager::Capabilities _capabilities;
+#endif
 	// End of ResidualVM specific code
 
 	virtual Common::EventSource *getDefaultEventSource() { return _eventSource; }


### PR DESCRIPTION
This serves as a first step towards separating `OpenGLSdlGraphicsManager` into two separate graphics managers, one with the generic OpenGL code, and a subclass with the SDL-specific context creation code, similar to what ScummVM does. The new base OpenGL graphics manager can then be reused by the Android port as well, reducing the amount of maintainance required, and making it slightly easier to keep ScummVM and ResidualVM in sync.

The last commit depends on PR #1622 so that the Capabilities struct only contains OpenGL related features, meaning that it can be moved into `OpenGLSdlGraphicsManager`; once that is done, it makes it easier to move it into the base OpenGL graphics manager later.