### PR TITLE
EMI: Always enable movie subtitles for the demo

### DIFF
--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -171,6 +171,9 @@ void Lua_V2::StartMovie() {
 			showSubtitles = true;
 		}
 	}
+	if (g_grim->getGameFlags() & ADGF_DEMO) {
+		showSubtitles = true;
+	}
 
 	GrimEngine::EngineMode prevEngineMode = g_grim->getMode();
 	g_grim->setMode(GrimEngine::SmushMode);

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -619,9 +619,9 @@ void GrimEngine::updateDisplayScene() {
 		}
 		// Draw Primitives
 		_iris->draw();
-		if (_movieSubtitle) {
-			_movieSubtitle->draw();
-		}
+
+		g_movie->drawMovieSubtitle();
+
 	} else if (_mode == NormalMode || _mode == OverworldMode) {
 		updateNormalMode();
 	} else if (_mode == DrawMode) {
@@ -1354,6 +1354,11 @@ void GrimEngine::setMovieSubtitle(TextObject *to) {
 		delete _movieSubtitle;
 		_movieSubtitle = to;
 	}
+}
+
+void GrimEngine::drawMovieSubtitle() {
+	if (_movieSubtitle)
+		_movieSubtitle->draw();
 }
 
 void GrimEngine::setMovieSetup() {

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -161,6 +161,7 @@ public:
 	bool areActorsTalking() const;
 	void immediatelyRemoveActor(Actor *actor);
 
+	void drawMovieSubtitle();
 	void setMovieSubtitle(TextObject *to);
 	void setMovieSetup();
 

--- a/engines/grim/movie/movie.cpp
+++ b/engines/grim/movie/movie.cpp
@@ -123,6 +123,11 @@ Graphics::Surface *MoviePlayer::getDstSurface() {
 	return _externalSurface;
 }
 
+void MoviePlayer::drawMovieSubtitle() {
+	Common::StackLock lock(_frameMutex);
+	g_grim->drawMovieSubtitle();
+}
+
 void MoviePlayer::init() {
 	if (!_timerStarted) {
 		g_system->getTimerManager()->installTimerProc(&timerCallback, 10000, this, "movieLoop");

--- a/engines/grim/movie/movie.h
+++ b/engines/grim/movie/movie.h
@@ -79,6 +79,9 @@ public:
 	virtual void clearUpdateNeeded() { _updateNeeded = false; }
 	virtual int32 getMovieTime() { return (int32)_movieTime; }
 
+	/* Draw the subtitles, guarded by _drawMutex */
+	void drawMovieSubtitle();
+
 	/**
 	 * Saves the state of the video to a savegame
 	 * @param state         The state to save to


### PR DESCRIPTION
This fixes #1161.

In the course of implementing this, I stumbled upon a race condition in the subtitle drawing:

- the movie thread takes the frame mutex to update its internal structures and update `_movieSubtitle`.
- the drawing thread only takes the mutex (briefly) to grab any new movie frames, but does not synchronize to take the subtitle.

I fixed this by drawing the subtitles while holding the movie mutex. It works but I'm open to nicer suggestions. I tried to see if we could only take a _copy_ of the `TextObject::Ptr` while holding the mutex, but the movie player calls `delete` on the underlying pointer, and a `TextObject::Ptr` is not a proper smart pointer...