### PR TITLE
AMIGAOS4: Automate installation process on local builds

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -1,13 +1,31 @@
-# Special target to create an AmigaOS snapshot installation.
+# Special target to create an AmigaOS snapshot installation
 # AmigaOS shell doesn't like indented comments.
 amigaosdist: $(EXECUTABLE) $(PLUGINS)
 	mkdir -p $(AMIGAOSPATH)
-	mkdir -p $(AMIGAOSPATH)/themes
 	mkdir -p $(AMIGAOSPATH)/extras
-	$(STRIP) $(EXECUTABLE) -o $(AMIGAOSPATH)/$(EXECUTABLE)
-	cp ${srcdir}/icons/residualvm_drawer.info $(AMIGAOSPATH).info
-	cp ${srcdir}/icons/residualvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
-	cp $(DIST_FILES_THEMES) $(AMIGAOSPATH)/themes/
+#	cp ${srcdir}/dists/amiga/residualvm_drawer.info $(AMIGAOSPATH).info
+#	cp ${srcdir}/dists/amiga/residualvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
+# Copy mandatory installation files.
+# Prepare README.md for AmigaGuide conversion.
+	cat ${srcdir}/README.md | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
+# AmigaOS AREXX has a problem when ${srcdir} is '.'.
+# It will break with a "Program not found" error.
+#
+# Skip the following for now, since the script breaks installation.
+# (It was not designed to work with residualvm's readme).
+# If i ever get around adapting/enhancing it to work with residualvm's
+# readme i'll revisit this.
+#
+# Copy the script to cwd and, once it has finished, remove it.
+#	cp ${srcdir}/dists/amiga/RM2AG.rexx .
+#	rx RM2AG.rexx README.conv $(AMIGAOSPATH)
+#	rm README.conv
+#	rm RM2AG.rexx
+ifdef DIST_FILES_DOCS
+	mkdir -p $(AMIGAOSPATH)/doc
+	cp -r $(srcdir)/doc/ $(AMIGAOSPATH)
+	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc/
+endif
 ifdef DIST_FILES_ENGINEDATA
 	cp $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras/
 endif
@@ -17,18 +35,23 @@ endif
 ifdef DIST_FILES_VKEYBD
 	cp $(DIST_FILES_VKEYBD) $(AMIGAOSPATH)/extras/
 endif
-	cat ${srcdir}/README.md | sed -f ${srcdir}/dists/amiga/convertRM.sed > README.conv
-# AmigaOS's shell is not happy with indented comments, thus don't do it.
-# AREXX seems to have problems when ${srcdir} is '.'. It will break with a
-# "Program not found" error. Therefore we copy the script to the cwd and
-# remove it again, once it has finished.
-	cp ${srcdir}/dists/amiga/RM2AG.rexx .
-	rx RM2AG.rexx README.conv
-	cp README.guide $(AMIGAOSPATH)
-	rm RM2AG.rexx
-	rm README.conv
-	rm README.guide
-	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)
+ifdef DIST_FILES_THEMES
+	mkdir -p $(AMIGAOSPATH)/themes
+	cp $(DIST_FILES_THEMES) $(AMIGAOSPATH)/themes/
+endif
+# Strip and copy engine plugins.
+ifdef DYNAMIC_MODULES
+	mkdir -p $(AMIGAOSPATH)/plugins
+	$(foreach plugin, $(PLUGINS), $(STRIP) $(plugin) -o $(AMIGAOSPATH)/$(plugin);)
+# Extract and install compiled-in shared libraries.
+# Not every AmigaOS installation, especially vanilla ones,
+# come with every mandatory shared library.
+	mkdir -p $(AMIGAOSPATH)/sobjs
+	cp ${srcdir}/dists/amiga/Ext_Inst_so.rexx .
+	rx Ext_Inst_so.rexx $(EXECUTABLE) $(AMIGAOSPATH)
+	rm Ext_Inst_so.rexx
+endif
+	$(STRIP) $(EXECUTABLE) -o $(AMIGAOSPATH)/$(EXECUTABLE)
 
 # Special target to cross create an AmigaOS snapshot installation
 amigaoscross: $(EXECUTABLE)


### PR DESCRIPTION
There´s a catch unfortunately.

As one can, see there are two files automatically installed (icons for drawer and app), but i´m not allowed to upload those through the GitHub site.

So, i´d need help with that, please.
Could some dev please grab the attached files and place them into "dists/amiga/"?

Thanks a lot
[residualvm.zip](https://github.com/residualvm/residualvm/files/4688502/residualvm.zip)

