### PR TITLE
ENGINES: ALL: Split detection features (Individual engines support) [DO NOT MERGE]

### DIFF
--- a/engines/grim/detection.h
+++ b/engines/grim/detection.h
@@ -1,0 +1,48 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef GRIM_DETECTION_H
+#define GRIM_DETECTION_H
+
+#include "engines/advancedDetector.h"
+#include "engines/obsolete.h"
+
+static const Engines::ObsoleteGameID obsoleteGameIDsTable[] = {
+	{"grimdemo", "grim", Common::kPlatformWindows},
+	{nullptr, nullptr, Common::kPlatformUnknown}
+};
+
+namespace Grim {
+
+enum GrimGameType {
+	GType_GRIM,
+	GType_MONKEY4
+};
+
+struct GrimGameDescription {
+	ADGameDescription desc;
+	GrimGameType gameType;
+};
+
+} // End of namespace Grim
+
+#endif // GRIM_DETECTION_H

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -33,6 +33,7 @@
 
 #include "engines/grim/textobject.h"
 #include "engines/grim/iris.h"
+#include "engines/grim/detection.h"
 
 namespace Grim {
 
@@ -47,13 +48,6 @@ class TextObject;
 class PrimitiveObject;
 class LuaBase;
 class GfxBase;
-
-enum GrimGameType {
-	GType_GRIM,
-	GType_MONKEY4
-};
-
-struct GrimGameDescription;
 
 struct ControlDescriptor {
 	const char *name;

--- a/engines/grim/metaengine.cpp
+++ b/engines/grim/metaengine.cpp
@@ -1,0 +1,124 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+
+#include "engines/grim/grim.h"
+#include "engines/grim/savegame.h"
+#include "engines/grim/emi/emi.h"
+
+#include "common/system.h"
+#include "common/savefile.h"
+#include "common/config-manager.h"
+
+namespace Grim {
+
+class GrimMetaEngine : public AdvancedMetaEngine {
+public:
+    const char *getName() const override {
+        return "Grim";
+    }
+
+    Common::Error createInstance(OSystem *syst, Engine **engine) const override {
+		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
+		return AdvancedMetaEngine::createInstance(syst, engine);
+	}
+
+	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+
+	bool hasFeature(MetaEngineFeature f) const override;
+
+	SaveStateList listSaves(const char *target) const override;
+
+};
+
+bool GrimMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	const GrimGameDescription *gd = (const GrimGameDescription *)desc;
+
+	if (gd) {
+		if (gd->gameType == GType_MONKEY4) {
+			*engine = new EMIEngine(syst, gd->desc.flags, gd->gameType, gd->desc.platform, gd->desc.language);
+		} else {
+			*engine = new GrimEngine(syst, gd->desc.flags, gd->gameType, gd->desc.platform, gd->desc.language);
+		}
+	}
+
+	return gd != nullptr;
+}
+
+bool GrimMetaEngine::hasFeature(MetaEngineFeature f) const {
+	return
+		(f == kSupportsListSaves) ||
+		(f == kSupportsLoadingDuringStartup);
+}
+
+bool GrimMetaEngine::hasFeature(MetaEngineFeature f) const {
+	return
+		(f == kSupportsListSaves) ||
+		(f == kSupportsLoadingDuringStartup);
+}
+
+SaveStateList GrimMetaEngine::listSaves(const char *target) const {
+	Common::String gameId = ConfMan.get("gameid", target);
+	Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
+	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
+	Common::StringArray filenames;
+	Common::String pattern = gameId == "monkey4" ? "efmi###.gsv" : "grim##.gsv";
+	
+	if (platform == Common::kPlatformPS2)
+		pattern = "efmi###.ps2";
+
+	filenames = saveFileMan->listSavefiles(pattern);
+
+	SaveStateList saveList;
+	char str[256];
+	int32 strSize;
+	for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {
+		// Obtain the last digits of the filename, since they correspond to the save slot
+		int slotNum = atoi(file->c_str() + 4);
+
+		if (slotNum >= 0) {
+			SaveGame *savedState = SaveGame::openForLoading(*file);
+			if (savedState && savedState->isCompatible()) {
+				if (platform == Common::kPlatformPS2)
+					savedState->beginSection('PS2S');
+				else
+					savedState->beginSection('SUBS');
+				strSize = savedState->readLESint32();
+				savedState->read(str, strSize);
+				savedState->endSection();
+				saveList.push_back(SaveStateDescriptor(slotNum, str));
+			}
+			delete savedState;
+		}
+	}
+
+	Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
+	return saveList;
+}
+
+} // End of namespace Grim
+
+#if PLUGIN_ENABLED_DYNAMIC(GRIM)
+	REGISTER_PLUGIN_DYNAMIC(GRIM, PLUGIN_TYPE_ENGINE, Grim::GrimMetaEngine);
+#else
+	REGISTER_PLUGIN_STATIC(GRIM, PLUGIN_TYPE_ENGINE, Grim::GrimMetaEngine);
+#endif

--- a/engines/icb/detection.cpp
+++ b/engines/icb/detection.cpp
@@ -21,10 +21,6 @@
  */
 
 #include "engines/advancedDetector.h"
-#include "engines/icb/icb.h"
-
-#include "common/savefile.h"
-#include "common/system.h"
 
 namespace ICB {
 
@@ -67,9 +63,9 @@ static const ADGameDescription gameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-class IcbMetaEngine : public AdvancedMetaEngine {
+class IcbMetaEngineStatic : public AdvancedMetaEngineStatic {
 public:
-	IcbMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(ADGameDescription), icbGames) {
+	IcbMetaEngineStatic() : AdvancedMetaEngineStatic(gameDescriptions, sizeof(ADGameDescription), icbGames) {
 		_guiOptions = GUIO_NOMIDI;
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
@@ -82,23 +78,8 @@ public:
 	}
 
 	virtual const char *getOriginalCopyright() const override { return "(C) 2000 Revolution Software Ltd"; }
-
-	virtual bool hasFeature(MetaEngineFeature f) const override { return false; }
-
-	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
-
-bool IcbMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	if (desc)
-		*engine = new IcbEngine(syst, desc);
-
-	return desc != nullptr;
-}
 
 } // End of namespace ICB
 
-#if PLUGIN_ENABLED_DYNAMIC(ICB)
-REGISTER_PLUGIN_DYNAMIC(ICB, PLUGIN_TYPE_ENGINE, ICB::IcbMetaEngine);
-#else
-REGISTER_PLUGIN_STATIC(ICB, PLUGIN_TYPE_ENGINE, ICB::IcbMetaEngine);
-#endif
+REGISTER_PLUGIN_STATIC(ICB_DETECTION, PLUGIN_TYPE_METAENGINE, ICB::IcbMetaEngineStatic);

--- a/engines/icb/metaengine.cpp
+++ b/engines/icb/metaengine.cpp
@@ -1,0 +1,52 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "engines/icb/icb.h"
+#include "common/savefile.h"
+#include "common/system.h"
+
+namespace ICB {
+
+class IcbMetaEngine : public AdvancedMetaEngine {
+public:
+    const char *getName() const override {
+		return "icb";
+	}
+    virtual bool hasFeature(MetaEngineFeature f) const override { return false; }
+
+	virtual bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+};
+
+bool IcbMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	if (desc)
+		*engine = new IcbEngine(syst, desc);
+
+	return desc != nullptr;
+}
+
+} // End of namespace ICB
+
+#if PLUGIN_ENABLED_DYNAMIC(ICB)
+	REGISTER_PLUGIN_DYNAMIC(ICB, PLUGIN_TYPE_ENGINE, ICB::IcbMetaEngine);
+#else
+	REGISTER_PLUGIN_STATIC(ICB, PLUGIN_TYPE_ENGINE, ICB::IcbMetaEngine);
+#endif

--- a/engines/myst3/database.h
+++ b/engines/myst3/database.h
@@ -24,6 +24,7 @@
 #define DATABASE_H_
 
 #include "engines/myst3/hotspot.h"
+#include "engines/myst3/detection.h"
 
 #include "common/scummsys.h"
 #include "common/str.h"
@@ -35,12 +36,6 @@
 #include "common/stream.h"
 
 namespace Myst3 {
-
-enum GameLocalizationType {
-	kLocMonolingual,
-	kLocMulti2,
-	kLocMulti6
-};
 
 enum MystLanguage {
 	kEnglish = 0,

--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -20,24 +20,13 @@
  *
  */
 
-#include "engines/advancedDetector.h"
-
-#include "engines/myst3/database.h"
-#include "engines/myst3/gfx.h"
-#include "engines/myst3/state.h"
-
-#include "common/config-manager.h"
-#include "common/savefile.h"
 #include "common/translation.h"
 
-#include "graphics/scaler.h"
+#include "engines/advancedDetector.h"
+#include "engines/myst3/detection.h"
+
 
 namespace Myst3 {
-
-struct Myst3GameDescription {
-	ADGameDescription desc;
-	uint32 localizationType;
-};
 
 static const PlainGameDescriptor myst3Games[] = {
 	{ "myst3", "Myst III Exile" },
@@ -200,9 +189,9 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class Myst3MetaEngine : public AdvancedMetaEngine {
+class Myst3MetaEngineStatic : public AdvancedMetaEngineStatic {
 public:
-	Myst3MetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(Myst3GameDescription), myst3Games, optionsList) {
+	Myst3MetaEngineStatic() : AdvancedMetaEngineStatic(gameDescriptions, sizeof(Myst3GameDescription), myst3Games, optionsList) {
 		_guiOptions = GUIO5(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOSPEECH, GUIO_NOSUBTITLES, GAMEOPTION_WIDESCREEN_MOD);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
@@ -219,126 +208,8 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "Myst III Exile (C) Presto Studios";
 	}
-
-	bool hasFeature(MetaEngineFeature f) const override {
-		return
-			(f == kSupportsListSaves) ||
-			(f == kSupportsDeleteSave) ||
-			(f == kSupportsLoadingDuringStartup) ||
-			(f == kSavesSupportMetaInfo) ||
-			(f == kSavesSupportThumbnail) ||
-			(f == kSavesSupportCreationDate) ||
-			(f == kSavesSupportPlayTime);
-	}
-
-	SaveStateList listSaves(const char *target) const override {
-		Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
-		Common::StringArray filenames = Saves::list(g_system->getSavefileManager(), platform);
-
-		SaveStateList saveList;
-		for (uint32 i = 0; i < filenames.size(); i++)
-			saveList.push_back(SaveStateDescriptor(i, filenames[i]));
-
-		return saveList;
-	}
-
-	SaveStateDescriptor getSaveDescription(const char *target, int slot) const {
-		SaveStateList saves = listSaves(target);
-
-		SaveStateDescriptor description;
-		for (uint32 i = 0; i < saves.size(); i++) {
-			if (saves[i].getSaveSlot() == slot) {
-				description = saves[i];
-			}
-		}
-
-		return description;
-	}
-
-	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {
-		SaveStateDescriptor saveInfos = getSaveDescription(target, slot);
-
-		if (saveInfos.getDescription().empty()) {
-			// Unused slot
-			return SaveStateDescriptor();
-		}
-
-		// Open save
-		Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(saveInfos.getDescription());
-		if (!saveFile) {
-			warning("Unable to open file %s for reading, slot %d", saveInfos.getDescription().encode().c_str(), slot);
-			return SaveStateDescriptor();
-		}
-
-		// Read state data
-		Common::Serializer s = Common::Serializer(saveFile, 0);
-		GameState::StateData data;
-		data.syncWithSaveGame(s);
-
-		// Read and resize the thumbnail
-		Graphics::Surface *saveThumb = GameState::readThumbnail(saveFile);
-		Graphics::Surface *guiThumb = GameState::resizeThumbnail(saveThumb, kThumbnailWidth, kThumbnailHeight1);
-		saveThumb->free();
-		delete saveThumb;
-
-		// Set metadata
-		saveInfos.setThumbnail(guiThumb);
-		saveInfos.setPlayTime(data.secondsPlayed * 1000);
-
-		if (data.saveYear != 0) {
-			saveInfos.setSaveDate(data.saveYear, data.saveMonth, data.saveDay);
-			saveInfos.setSaveTime(data.saveHour, data.saveMinute);
-		}
-
-		if (data.saveDescription != "") {
-			saveInfos.setDescription(data.saveDescription);
-		}
-
-		if (s.getVersion() >= 150) {
-			saveInfos.setAutosave(data.isAutosave);
-		}
-
-		delete saveFile;
-
-		return saveInfos;
-	}
-
-	void removeSaveState(const char *target, int slot) const override {
-		SaveStateDescriptor saveInfos = getSaveDescription(target, slot);
-		g_system->getSavefileManager()->removeSavefile(saveInfos.getDescription());
-	}
-
-	int getMaximumSaveSlot() const override {
-		return 999;
-	}
-
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
-
-bool Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Myst3GameDescription *gd = (const Myst3GameDescription *)desc;
-	if (gd) {
-		*engine = new Myst3Engine(syst, gd);
-	}
-	return gd != 0;
-}
-
-Common::Platform Myst3Engine::getPlatform() const {
-	return _gameDescription->desc.platform;
-}
-
-Common::Language Myst3Engine::getGameLanguage() const {
-	return _gameDescription->desc.language;
-}
-
-uint32 Myst3Engine::getGameLocalizationType() const {
-	return _gameDescription->localizationType;
-}
 
 } // End of namespace Myst3
 
-#if PLUGIN_ENABLED_DYNAMIC(MYST3)
-	REGISTER_PLUGIN_DYNAMIC(MYST3, PLUGIN_TYPE_ENGINE, Myst3::Myst3MetaEngine);
-#else
-	REGISTER_PLUGIN_STATIC(MYST3, PLUGIN_TYPE_ENGINE, Myst3::Myst3MetaEngine);
-#endif
+REGISTER_PLUGIN_STATIC(MYST3_DETECTION, PLUGIN_TYPE_METAENGINE, Myst3::Myst3MetaEngineStatic);

--- a/engines/myst3/detection.h
+++ b/engines/myst3/detection.h
@@ -1,0 +1,43 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef MYST3_DETECTION_H
+#define MYST3_DETECTION_H
+
+#include "engines/advancedDetector.h"
+
+namespace Myst3 {
+
+enum GameLocalizationType {
+	kLocMonolingual,
+	kLocMulti2,
+	kLocMulti6
+};
+
+struct Myst3GameDescription {
+	ADGameDescription desc;
+	uint32 localizationType;
+};
+
+} // End of namespace Myst3
+
+#endif // MYST3_DETECTION_H

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -1,0 +1,163 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "engines/advancedDetector.h"
+#include "engines/myst3/database.h"
+#include "engines/myst3/gfx.h"
+#include "engines/myst3/state.h"
+#include "engines/myst3/detection.h"
+
+#include "common/config-manager.h"
+#include "common/savefile.h"
+
+#include "graphics/scaler.h"
+
+namespace Myst3{
+
+class Myst3MetaEngine : public AdvancedMetaEngine {
+public:
+    const char *getName() const override {
+		return "myst3";
+	}
+
+    bool hasFeature(MetaEngineFeature f) const override {
+		return
+			(f == kSupportsListSaves) ||
+			(f == kSupportsDeleteSave) ||
+			(f == kSupportsLoadingDuringStartup) ||
+			(f == kSavesSupportMetaInfo) ||
+			(f == kSavesSupportThumbnail) ||
+			(f == kSavesSupportCreationDate) ||
+			(f == kSavesSupportPlayTime);
+	}
+
+	SaveStateList listSaves(const char *target) const override {
+		Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
+		Common::StringArray filenames = Saves::list(g_system->getSavefileManager(), platform);
+
+		SaveStateList saveList;
+		for (uint32 i = 0; i < filenames.size(); i++)
+			saveList.push_back(SaveStateDescriptor(i, filenames[i]));
+
+		return saveList;
+	}
+
+	SaveStateDescriptor getSaveDescription(const char *target, int slot) const {
+		SaveStateList saves = listSaves(target);
+
+		SaveStateDescriptor description;
+		for (uint32 i = 0; i < saves.size(); i++) {
+			if (saves[i].getSaveSlot() == slot) {
+				description = saves[i];
+			}
+		}
+
+		return description;
+	}
+
+	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {
+		SaveStateDescriptor saveInfos = getSaveDescription(target, slot);
+
+		if (saveInfos.getDescription().empty()) {
+			// Unused slot
+			return SaveStateDescriptor();
+		}
+
+		// Open save
+		Common::InSaveFile *saveFile = g_system->getSavefileManager()->openForLoading(saveInfos.getDescription());
+		if (!saveFile) {
+			warning("Unable to open file %s for reading, slot %d", saveInfos.getDescription().encode().c_str(), slot);
+			return SaveStateDescriptor();
+		}
+
+		// Read state data
+		Common::Serializer s = Common::Serializer(saveFile, 0);
+		GameState::StateData data;
+		data.syncWithSaveGame(s);
+
+		// Read and resize the thumbnail
+		Graphics::Surface *saveThumb = GameState::readThumbnail(saveFile);
+		Graphics::Surface *guiThumb = GameState::resizeThumbnail(saveThumb, kThumbnailWidth, kThumbnailHeight1);
+		saveThumb->free();
+		delete saveThumb;
+
+		// Set metadata
+		saveInfos.setThumbnail(guiThumb);
+		saveInfos.setPlayTime(data.secondsPlayed * 1000);
+
+		if (data.saveYear != 0) {
+			saveInfos.setSaveDate(data.saveYear, data.saveMonth, data.saveDay);
+			saveInfos.setSaveTime(data.saveHour, data.saveMinute);
+		}
+
+		if (data.saveDescription != "") {
+			saveInfos.setDescription(data.saveDescription);
+		}
+
+		if (s.getVersion() >= 150) {
+			saveInfos.setAutosave(data.isAutosave);
+		}
+
+		delete saveFile;
+
+		return saveInfos;
+	}
+
+	void removeSaveState(const char *target, int slot) const override {
+		SaveStateDescriptor saveInfos = getSaveDescription(target, slot);
+		g_system->getSavefileManager()->removeSavefile(saveInfos.getDescription());
+	}
+
+	int getMaximumSaveSlot() const override {
+		return 999;
+	}
+
+	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+};
+
+bool Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	const Myst3GameDescription *gd = (const Myst3GameDescription *)desc;
+	if (gd) {
+		*engine = new Myst3Engine(syst, gd);
+	}
+	return gd != 0;
+}
+
+Common::Platform Myst3Engine::getPlatform() const {
+	return _gameDescription->desc.platform;
+}
+
+Common::Language Myst3Engine::getGameLanguage() const {
+	return _gameDescription->desc.language;
+}
+
+uint32 Myst3Engine::getGameLocalizationType() const {
+	return _gameDescription->localizationType;
+}
+
+} // End of namespace Myst3
+
+#if PLUGIN_ENABLED_DYNAMIC(MYST3)
+	REGISTER_PLUGIN_DYNAMIC(MYST3, PLUGIN_TYPE_ENGINE, Myst3::Myst3MetaEngine);
+#else
+	REGISTER_PLUGIN_STATIC(MYST3, PLUGIN_TYPE_ENGINE, Myst3::Myst3MetaEngine);
+#endif

--- a/engines/stark/detection.cpp
+++ b/engines/stark/detection.cpp
@@ -21,12 +21,7 @@
  */
 
 #include "engines/advancedDetector.h"
-#include "engines/stark/savemetadata.h"
-#include "engines/stark/stark.h"
-#include "engines/stark/services/stateprovider.h"
 
-#include "common/savefile.h"
-#include "common/system.h"
 #include "common/translation.h"
 
 namespace Stark {
@@ -370,9 +365,9 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class StarkMetaEngine : public AdvancedMetaEngine {
+class StarkMetaEngineStatic : public AdvancedMetaEngineStatic {
 public:
-	StarkMetaEngine() : AdvancedMetaEngine(gameDescriptions, sizeof(ADGameDescription), starkGames, optionsList) {
+	StarkMetaEngineStatic() : AdvancedMetaEngineStatic(gameDescriptions, sizeof(ADGameDescription), starkGames, optionsList) {
 		_guiOptions = GUIO4(GUIO_NOMIDI, GAMEOPTION_ASSETS_MOD, GAMEOPTION_LINEAR_FILTERING, GAMEOPTION_FONT_ANTIALIASING);
 	}
 
@@ -387,97 +382,8 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "(C) Funcom";
 	}
-
-	bool hasFeature(MetaEngineFeature f) const override {
-		return
-			(f == kSupportsListSaves) ||
-			(f == kSupportsLoadingDuringStartup) ||
-			(f == kSupportsDeleteSave) ||
-			(f == kSavesSupportThumbnail) ||
-			(f == kSavesSupportMetaInfo) ||
-			(f == kSavesSupportPlayTime) ||
-			(f == kSavesSupportCreationDate);
-	}
-
-	int getMaximumSaveSlot() const override {
-		return 999;
-	}
-
-	SaveStateList listSaves(const char *target) const override {
-		Common::StringArray filenames = StarkEngine::listSaveNames(target);
-
-		SaveStateList saveList;
-		for (Common::StringArray::const_iterator filename = filenames.begin(); filename != filenames.end(); ++filename) {
-			int slot = StarkEngine::getSaveNameSlot(target, *filename);
-
-			// Read the description from the save
-			Common::String description;
-			Common::InSaveFile *save = g_system->getSavefileManager()->openForLoading(*filename);
-			if (save) {
-				StateReadStream stream(save);
-				description = stream.readString();
-			}
-
-			saveList.push_back(SaveStateDescriptor(slot, description));
-		}
-
-		Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
-		return saveList;
-	}
-
-	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {
-		Common::String filename = StarkEngine::formatSaveName(target, slot);
-		Common::InSaveFile *save = g_system->getSavefileManager()->openForLoading(filename);
-		if (!save) {
-			return SaveStateDescriptor();
-		}
-
-		SaveStateDescriptor descriptor;
-		descriptor.setSaveSlot(slot);
-
-		SaveMetadata metadata;
-		Common::ErrorCode readError = metadata.read(save, filename);
-		if (readError != Common::kNoError) {
-			delete save;
-			return descriptor;
-		}
-
-		descriptor.setDescription(metadata.description);
-
-		if (metadata.version >= 9) {
-			Graphics::Surface *thumb = metadata.readGameScreenThumbnail(save);
-			descriptor.setThumbnail(thumb);
-			descriptor.setPlayTime(metadata.totalPlayTime);
-			descriptor.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
-			descriptor.setSaveTime(metadata.saveHour, metadata.saveMinute);
-		}
-
-		if (metadata.version >= 13) {
-			descriptor.setAutosave(metadata.isAutoSave);
-		}
-
-		delete save;
-
-		return descriptor;
-	}
-
-	void removeSaveState(const char *target, int slot) const override {
-		Common::String filename = StarkEngine::formatSaveName(target, slot);
-		g_system->getSavefileManager()->removeSavefile(filename);
-	}
-
-	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		if (desc)
-			*engine = new StarkEngine(syst, desc);
-
-		return desc != nullptr;
-	}
 };
 
 } // End of namespace Stark
 
-#if PLUGIN_ENABLED_DYNAMIC(STARK)
-	REGISTER_PLUGIN_DYNAMIC(STARK, PLUGIN_TYPE_ENGINE, Stark::StarkMetaEngine);
-#else
-	REGISTER_PLUGIN_STATIC(STARK, PLUGIN_TYPE_ENGINE, Stark::StarkMetaEngine);
-#endif
+REGISTER_PLUGIN_STATIC(STARK_DETECTION, PLUGIN_TYPE_METAENGINE, Stark::StarkMetaEngineStatic);

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -1,0 +1,131 @@
+/* ResidualVM - A 3D game interpreter
+ *
+ * ResidualVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "engines/advancedDetector.h"
+#include "engines/stark/savemetadata.h"
+#include "engines/stark/stark.h"
+#include "engines/stark/services/stateprovider.h"
+
+#include "common/savefile.h"
+#include "common/system.h"
+
+namespace Stark {
+
+class StarkMetaEngine : public AdvancedMetaEngine {
+public:
+    const char *getName() const override {
+		return "stark";
+	}
+
+    bool hasFeature(MetaEngineFeature f) const override {
+		return
+			(f == kSupportsListSaves) ||
+			(f == kSupportsLoadingDuringStartup) ||
+			(f == kSupportsDeleteSave) ||
+			(f == kSavesSupportThumbnail) ||
+			(f == kSavesSupportMetaInfo) ||
+			(f == kSavesSupportPlayTime) ||
+			(f == kSavesSupportCreationDate);
+	}
+
+	int getMaximumSaveSlot() const override {
+		return 999;
+	}
+
+	SaveStateList listSaves(const char *target) const override {
+		Common::StringArray filenames = StarkEngine::listSaveNames(target);
+
+		SaveStateList saveList;
+		for (Common::StringArray::const_iterator filename = filenames.begin(); filename != filenames.end(); ++filename) {
+			int slot = StarkEngine::getSaveNameSlot(target, *filename);
+
+			// Read the description from the save
+			Common::String description;
+			Common::InSaveFile *save = g_system->getSavefileManager()->openForLoading(*filename);
+			if (save) {
+				StateReadStream stream(save);
+				description = stream.readString();
+			}
+
+			saveList.push_back(SaveStateDescriptor(slot, description));
+		}
+
+		Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
+		return saveList;
+	}
+
+	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {
+		Common::String filename = StarkEngine::formatSaveName(target, slot);
+		Common::InSaveFile *save = g_system->getSavefileManager()->openForLoading(filename);
+		if (!save) {
+			return SaveStateDescriptor();
+		}
+
+		SaveStateDescriptor descriptor;
+		descriptor.setSaveSlot(slot);
+
+		SaveMetadata metadata;
+		Common::ErrorCode readError = metadata.read(save, filename);
+		if (readError != Common::kNoError) {
+			delete save;
+			return descriptor;
+		}
+
+		descriptor.setDescription(metadata.description);
+
+		if (metadata.version >= 9) {
+			Graphics::Surface *thumb = metadata.readGameScreenThumbnail(save);
+			descriptor.setThumbnail(thumb);
+			descriptor.setPlayTime(metadata.totalPlayTime);
+			descriptor.setSaveDate(metadata.saveYear, metadata.saveMonth, metadata.saveDay);
+			descriptor.setSaveTime(metadata.saveHour, metadata.saveMinute);
+		}
+
+		if (metadata.version >= 13) {
+			descriptor.setAutosave(metadata.isAutoSave);
+		}
+
+		delete save;
+
+		return descriptor;
+	}
+
+	void removeSaveState(const char *target, int slot) const override {
+		Common::String filename = StarkEngine::formatSaveName(target, slot);
+		g_system->getSavefileManager()->removeSavefile(filename);
+	}
+
+	bool createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+		if (desc)
+			*engine = new StarkEngine(syst, desc);
+
+		return desc != nullptr;
+	}    
+};
+
+} // End of namespace Stark
+
+#if PLUGIN_ENABLED_DYNAMIC(STARK)
+	REGISTER_PLUGIN_DYNAMIC(STARK, PLUGIN_TYPE_ENGINE, Stark::StarkMetaEngine);
+#else
+	REGISTER_PLUGIN_STATIC(STARK, PLUGIN_TYPE_ENGINE, Stark::StarkMetaEngine);
+#endif


### PR DESCRIPTION
Please refer to https://github.com/scummvm/scummvm/pull/2403 to refer to the main changes.

This PR adds support for each of ResidualVM's engines to the new split of MetaEngines, and enables detection features to be linked statically.

PS: This is only meant to be merged once ScummVM's PR is merged and when ResidualVM chooses to sync with ScummVM.