### PR TITLE
ANDROID: Fix sigsegv and sigfpe on start. Enable basic touch control.

### DIFF
--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -100,8 +100,10 @@ void OSystem_Android::scaleMouse(Common::Point &p, int x, int y, bool touchpadMo
 }
 
 void OSystem_Android::updateEventScale(const GLESBaseTexture *tex) {
-	_eventScaleY = 100 * 480 / tex->height();
-	_eventScaleX = 100 * 640 / tex->width();
+    if (tex && (tex->height() != 0) && (tex->width() != 0)) {
+	    _eventScaleY = 100 * 480 / tex->height();
+	    _eventScaleX = 100 * 640 / tex->width();
+    }
 }
 
 void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
@@ -393,6 +395,8 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 			scaleMouse(e.mouse, arg3 - _touch_pt_scroll.x,
 						arg4 - _touch_pt_scroll.y, true);
 			e.mouse += _touch_pt_down;
+			scaleMouse(e.relMouse, arg3 - _touch_pt_scroll.x,
+						arg4 - _touch_pt_scroll.y, true);
 		} else {
 			scaleMouse(e.mouse, arg3, arg4);
 		}

--- a/backends/platform/android/graphics.cpp
+++ b/backends/platform/android/graphics.cpp
@@ -58,6 +58,7 @@ AndroidGraphicsManager::AndroidGraphicsManager() :
 	_force_redraw(false),
 	_game_texture(0),
 	_game_pbuf(),
+	_frame_buffer(0),
 	_cursorX(0),
 	_cursorY(0),
 	_overlay_texture(0),


### PR DESCRIPTION
Myst III on Android can be started and played till some point after these changes. Tested on x86 and armv7.