### PR TITLE
ALL: Add error checking to PEResources::getResource

### DIFF
--- a/common/winexe_pe.cpp
+++ b/common/winexe_pe.cpp
@@ -212,8 +212,17 @@ SeekableReadStream *PEResources::getResource(const WinResourceID &type, const Wi
 		return nullptr;
 
 	const Resource &resource = _resources[type][id][langList[0]];
-	_exe->seek(resource.offset);
-	return _exe->readStream(resource.size);
+	if (!_exe->seek(resource.offset)) {
+		warning("Cannot seek to offset of resource");
+		return nullptr;
+	}
+	SeekableReadStream *stream = _exe->readStream(resource.size);
+	if (_exe->eos() || _exe->err()) {
+		warning("Error or premature end of stream while reading resource");
+		delete stream;
+		return nullptr;
+	}
+	return stream;
 }
 
 SeekableReadStream *PEResources::getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang) {


### PR DESCRIPTION
For some reason the `game.exe` that comes with the steam version of TLJ is truncated. It is only 95744 bytes and contains a resource table but not the resource data.

This currently results in random data from the binary to be passed into the BMP parser in `DialogBox::loadBackground()`, resulting in a warning `Only Windows v3 & v4 bitmaps are supported`. It could be worse, but it sets developers on the wrong trail toward trying to fix BMP parsing.

Avoid doing this by adding a check that both the seek and the read succeed, which if so, makes loading the resource simply fail.